### PR TITLE
[Feat] CategoryModalView UI

### DIFF
--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/CategoryModalView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/CategoryModalView.swift
@@ -7,9 +7,74 @@
 
 import SwiftUI
 
+enum Category: String, CaseIterable {
+    case education = "교육"
+    case health = "건강 및 피트니스"
+    case finance = "금융"
+    case lifestyle = "라이프스타일"
+    case weather = "날씨"
+    case photo = "사진 및 비디오"
+    case decoration = "데코레이션/꾸미기"
+    case utility = "유틸리티"
+    case sns = "소셜 네트워킹"
+    case entertainment = "엔터테인먼트"
+    case trip = "여행"
+    case business = "비즈니스"
+    
+    var category: String {
+        String(describing: self)
+    }
+}
+
 struct CategoryModalView: View {
+    private let gridLayout = [GridItem(.flexible()), GridItem(.flexible())]
+    @State var selectedCategories = [String]()
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack {
+            Text("카테고리")
+                .font(.headline)
+            
+            LazyVGrid(columns: gridLayout, spacing: 12) {
+                ForEach(Category.allCases, id: \.self) { item in
+                    Button(item.rawValue, action: {
+                        
+                        // TODO: 버튼색 변경 및 데이터 저장
+                        
+                        self.selectedCategories.append(item.category)
+                    }).buttonStyle(categoryButtonStyle())
+                }
+            }
+            .padding(.horizontal, 16)
+            
+            Button(action: {
+                
+                // TODO: 모달 닫기 및 데이터 전달
+                
+            }) {
+                Text("완료")
+                    .Body1()
+                    .frame(maxWidth: .infinity, minHeight: 52)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(selectedCategories.isEmpty)
+            .padding(.horizontal, 16)
+            
+        }
+    }
+    
+    struct categoryButtonStyle: ButtonStyle {
+        func makeBody(configuration: Configuration) -> some View {
+            configuration.label
+                .Body2()
+                .frame(maxWidth: .infinity, minHeight: 48)
+                .foregroundColor(.Gray3)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(Color.Gray3, lineWidth: 1)
+                )
+            
+        }
     }
 }
 

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/CategoryModalView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/CategoryModalView.swift
@@ -31,12 +31,18 @@ struct CategoryModalView: View {
             Text("카테고리")
                 .font(.headline)
             
+            Spacer()
+                .frame(height: UIScreen.main.bounds.size.height * 0.7 * 0.04)
+            
             LazyVGrid(columns: gridLayout, spacing: 12) {
                 ForEach(Category.allCases, id: \.self) { item in
                     CategoryButton(item: item, items: $selectedCategories)
                 }
             }
             .padding(.horizontal, 16)
+            
+            Spacer()
+                .frame(height: UIScreen.main.bounds.size.height * 0.7 * 0.04)
             
             Button(action: {
                 
@@ -70,7 +76,7 @@ struct CategoryModalView: View {
                     .Body2()
                     .tag(item)
                     .foregroundColor(items.contains(item) ? Color.Primary : Color.Gray3)
-                    .frame(maxWidth: .infinity, minHeight: 48)
+                    .frame(maxWidth: .infinity, minHeight: UIScreen.main.bounds.size.height * 0.7 * 0.08)
                     .overlay(
                         RoundedRectangle(cornerRadius: 12)
                             .stroke(items.contains(item) ? Color.Primary : Color.Gray3, lineWidth: 1)

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/CategoryModalView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/CategoryModalView.swift
@@ -47,6 +47,7 @@ struct CategoryModalView: View {
                     .Body1()
                     .frame(maxWidth: .infinity, minHeight: 52)
             })
+            .tint(.Primary)
             .buttonStyle(.borderedProminent)
             .disabled(selectedCategories.isEmpty)
             .padding(.horizontal, 16)

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/CategoryModalView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/CategoryModalView.swift
@@ -7,21 +7,6 @@
 
 import SwiftUI
 
-enum Category: String, CaseIterable {
-    case education = "교육"
-    case health = "건강 및 피트니스"
-    case finance = "금융"
-    case lifestyle = "라이프스타일"
-    case weather = "날씨"
-    case photo = "사진 및 비디오"
-    case decoration = "데코레이션/꾸미기"
-    case utility = "유틸리티"
-    case sns = "소셜 네트워킹"
-    case entertainment = "엔터테인먼트"
-    case trip = "여행"
-    case business = "비즈니스"
-}
-
 struct CategoryModalView: View {
     private let gridLayout = [GridItem(.flexible()), GridItem(.flexible())]
     @State var selectedCategories: [Category] = []

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/CategoryModalView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/CategoryModalView.swift
@@ -20,15 +20,11 @@ enum Category: String, CaseIterable {
     case entertainment = "엔터테인먼트"
     case trip = "여행"
     case business = "비즈니스"
-    
-    var category: String {
-        String(describing: self)
-    }
 }
 
 struct CategoryModalView: View {
     private let gridLayout = [GridItem(.flexible()), GridItem(.flexible())]
-    @State var selectedCategories = [String]()
+    @State var selectedCategories: [Category] = []
     
     var body: some View {
         VStack {
@@ -37,43 +33,48 @@ struct CategoryModalView: View {
             
             LazyVGrid(columns: gridLayout, spacing: 12) {
                 ForEach(Category.allCases, id: \.self) { item in
-                    Button(item.rawValue, action: {
-                        
-                        // TODO: 버튼색 변경 및 데이터 저장
-                        
-                        self.selectedCategories.append(item.category)
-                    }).buttonStyle(categoryButtonStyle())
+                    CategoryButton(item: item, items: $selectedCategories)
                 }
             }
             .padding(.horizontal, 16)
             
             Button(action: {
                 
-                // TODO: 모달 닫기 및 데이터 전달
+                // TODO: 모달 닫기
                 
-            }) {
+            }, label: {
                 Text("완료")
                     .Body1()
                     .frame(maxWidth: .infinity, minHeight: 52)
-            }
+            })
             .buttonStyle(.borderedProminent)
             .disabled(selectedCategories.isEmpty)
             .padding(.horizontal, 16)
-            
         }
     }
     
-    struct categoryButtonStyle: ButtonStyle {
-        func makeBody(configuration: Configuration) -> some View {
-            configuration.label
-                .Body2()
-                .frame(maxWidth: .infinity, minHeight: 48)
-                .foregroundColor(.Gray3)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12)
-                        .stroke(Color.Gray3, lineWidth: 1)
-                )
-            
+    struct CategoryButton: View {
+        let item: Category
+        @Binding var items: [Category]
+        
+        var body: some View {
+            Button(action: {
+                if items.contains(item) {
+                    items.removeAll { $0 == item }
+                } else {
+                    items.append(item)
+                }
+            }, label: {
+                Text(item.rawValue)
+                    .Body2()
+                    .tag(item)
+                    .foregroundColor(items.contains(item) ? Color.Primary : Color.Gray3)
+                    .frame(maxWidth: .infinity, minHeight: 48)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(items.contains(item) ? Color.Primary : Color.Gray3, lineWidth: 1)
+                    )
+            })
         }
     }
 }


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #28 

## 구현/변경 사항
- selectedCategories 배열에 선택된 버튼의 enum case들을 넣어 전달합니다. 
- 완료버튼은 .borderedProminent로 설정해서 높이가 하이파이와 약간 달라보이는데 이후에 다른뷰들과 통일하겠습니다.

## 스크린샷

|iPhone SE|iPhone 14|iPhone 14 Pro Max|
|:---:|:---:|:---:|
|![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-10-24 at 23 46 21](https://user-images.githubusercontent.com/76623853/197559734-da2a42a2-fd8d-4e80-9040-acaca85c9f00.png)|![Simulator Screen Shot - iPhone 14 - 2022-10-24 at 23 44 39](https://user-images.githubusercontent.com/76623853/197559763-287998a2-8c8e-4151-9342-2471ae749489.png)|![Simulator Screen Shot - iPhone 14 Pro Max - 2022-10-24 at 23 45 53](https://user-images.githubusercontent.com/76623853/197559677-bacc727f-99b8-47d4-9a1d-359e6f630b10.png)|
