### PR TITLE
[Feat] WriteShortcutTagView내 Tag 구현

### DIFF
--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTagView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTagView.swift
@@ -75,6 +75,12 @@ struct WriteShortcutTagView: View {
     }
     
     struct relatedAppList: View {
+        enum FocusField: Hashable {
+            case field
+        }
+        
+        @State var isTextFieldShowing = false
+        @FocusState private var focusedField: FocusField?
         @State var relatedApp = ""
         @State var relatedApps: [String] = ["지도", "인스타그램"]
         
@@ -85,21 +91,44 @@ struct WriteShortcutTagView: View {
                         relatedAppCell(item: item, items: $relatedApps)
                     }
                     
-                    TextField("앱 추가", text: $relatedApp)
-                        .modifier(ClearButton(text: $relatedApp))
-                        .onSubmit {
-                            if !relatedApp.isEmpty {
-                                relatedApps.append(relatedApp)
-                                relatedApp = ""
+                    if isTextFieldShowing {
+                        TextField("", text: $relatedApp)
+                            .modifier(ClearButton(text: $relatedApp))
+                            .focused($focusedField, equals: .field)
+                            .onAppear {
+                                self.focusedField = .field
                             }
+                            .onSubmit {
+                                if !relatedApp.isEmpty {
+                                    relatedApps.append(relatedApp)
+                                    relatedApp = ""
+                                }
+                                isTextFieldShowing = false
+                            }
+                            .Body2()
+                            .foregroundColor(.Gray4)
+                            .frame(height: 46)
+                            .padding(.horizontal)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 12)
+                                    .strokeBorder(Color.Gray4, lineWidth: 1))
+                    }
+                    
+                    Button(action: {
+                        isTextFieldShowing = true
+                    }, label: {
+                        HStack {
+                            Image(systemName: "plus")
+                            Text("앱 추가")
                         }
-                        .Body2()
-                        .foregroundColor(.Gray3)
-                        .frame(height: 46)
-                        .padding(.horizontal)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 12)
-                                .strokeBorder(Color.Gray3, lineWidth: 1))
+                    })
+                    .Body2()
+                    .foregroundColor(.Gray3)
+                    .frame(height: 46)
+                    .padding(.horizontal)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .strokeBorder(Color.Gray3, lineWidth: 1))
                 }
             }
             .padding(.leading, 16)
@@ -135,18 +164,13 @@ struct WriteShortcutTagView: View {
         
         public func body(content: Content) -> some View {
             HStack {
-                if text.isEmpty {
-                    Image(systemName: "plus")
-                }
                 content
-                if !text.isEmpty {
-                    Button(action: {
-                        self.text = ""
-                    }) {
-                        Image(systemName: "x.circle.fill")
-                            .Body2()
-                            .foregroundColor(.Gray4)
-                    }
+                Button(action: {
+                    self.text = ""
+                }) {
+                    Image(systemName: "x.circle.fill")
+                        .Body2()
+                        .foregroundColor(.Gray4)
                 }
             }
         }

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTagView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTagView.swift
@@ -9,7 +9,147 @@ import SwiftUI
 
 struct WriteShortcutTagView: View {
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack {
+            categoryList()
+            relatedAppList()
+        }
+    }
+    
+    struct categoryList: View {
+        
+        //TODO: 카테고리는 최대 3개 선택 가능
+        
+        @State var categories: [Category] = [Category.lifestyle, Category.education, Category.finance]
+        
+        var body: some View {
+            ScrollView(.horizontal) {
+                HStack(spacing: 8) {
+                    ForEach(categories, id:\.self) { item in
+                        categoryCell(item: item.rawValue, items: $categories)
+                    }
+                    Button(action: {
+                        
+                        //TODO: CategoryModalView 열기
+                        
+                    }, label: {
+                        HStack {
+                            Image(systemName: "plus")
+                            Text("카테고리 추가")
+                        }
+                    })
+                    .Body2()
+                    .foregroundColor(.Gray3)
+                    .frame(height: 46)
+                    .padding(.horizontal)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .strokeBorder(Color.Gray3, lineWidth: 1))
+                }
+            }
+            .padding(.leading, 16)
+        }
+    }
+    
+    struct categoryCell: View {
+        var item: String
+        @Binding var items: [Category]
+        
+        var body: some View {
+            HStack {
+                Text(item)
+                
+                Button(action: {
+                    items.removeAll { $0.rawValue == item }
+                }, label: {
+                    Image(systemName: "xmark")
+                })
+            }
+            .Body2()
+            .foregroundColor(.Primary)
+            .frame(height: 46)
+            .padding(.horizontal)
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .strokeBorder(Color.Primary, lineWidth: 1))
+        }
+    }
+    
+    struct relatedAppList: View {
+        @State var relatedApp = ""
+        @State var relatedApps: [String] = ["지도", "인스타그램"]
+        
+        var body: some View {
+            ScrollView(.horizontal) {
+                HStack(spacing: 8) {
+                    ForEach(relatedApps, id:\.self) { item in
+                        relatedAppCell(item: item, items: $relatedApps)
+                    }
+                    
+                    TextField("앱 추가", text: $relatedApp)
+                        .modifier(ClearButton(text: $relatedApp))
+                        .onSubmit {
+                            if !relatedApp.isEmpty {
+                                relatedApps.append(relatedApp)
+                                relatedApp = ""
+                            }
+                        }
+                        .Body2()
+                        .foregroundColor(.Gray3)
+                        .frame(height: 46)
+                        .padding(.horizontal)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 12)
+                                .strokeBorder(Color.Gray3, lineWidth: 1))
+                }
+            }
+            .padding(.leading, 16)
+        }
+    }
+    
+    struct relatedAppCell: View {
+        var item: String
+        @Binding var items: [String]
+        
+        var body: some View {
+            HStack {
+                Text(item)
+                
+                Button(action: {
+                    items.removeAll { $0 == item }
+                }, label: {
+                    Image(systemName: "xmark")
+                })
+            }
+            .Body2()
+            .foregroundColor(.Primary)
+            .frame(height: 46)
+            .padding(.horizontal)
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .strokeBorder(Color.Primary, lineWidth: 1))
+        }
+    }
+    
+    struct ClearButton: ViewModifier {
+        @Binding var text: String
+        
+        public func body(content: Content) -> some View {
+            HStack {
+                if text.isEmpty {
+                    Image(systemName: "plus")
+                }
+                content
+                if !text.isEmpty {
+                    Button(action: {
+                        self.text = ""
+                    }) {
+                        Image(systemName: "x.circle.fill")
+                            .Body2()
+                            .foregroundColor(.Gray4)
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTagView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTagView.swift
@@ -37,13 +37,7 @@ struct WriteShortcutTagView: View {
                             Text("카테고리 추가")
                         }
                     })
-                    .Body2()
-                    .foregroundColor(.Gray3)
-                    .frame(height: 46)
-                    .padding(.horizontal)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12)
-                            .strokeBorder(Color.Gray3, lineWidth: 1))
+                    .modifier(TagCell(color: .Gray3))
                 }
             }
             .padding(.leading, 16)
@@ -64,13 +58,7 @@ struct WriteShortcutTagView: View {
                     Image(systemName: "xmark")
                 })
             }
-            .Body2()
-            .foregroundColor(.Primary)
-            .frame(height: 46)
-            .padding(.horizontal)
-            .overlay(
-                RoundedRectangle(cornerRadius: 12)
-                    .strokeBorder(Color.Primary, lineWidth: 1))
+            .modifier(TagCell(color: .Primary))
         }
     }
     
@@ -105,13 +93,7 @@ struct WriteShortcutTagView: View {
                                 }
                                 isTextFieldShowing = false
                             }
-                            .Body2()
-                            .foregroundColor(.Gray4)
-                            .frame(height: 46)
-                            .padding(.horizontal)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 12)
-                                    .strokeBorder(Color.Gray4, lineWidth: 1))
+                            .modifier(TagCell(color: .Gray4))
                     }
                     
                     Button(action: {
@@ -122,13 +104,7 @@ struct WriteShortcutTagView: View {
                             Text("앱 추가")
                         }
                     })
-                    .Body2()
-                    .foregroundColor(.Gray3)
-                    .frame(height: 46)
-                    .padding(.horizontal)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12)
-                            .strokeBorder(Color.Gray3, lineWidth: 1))
+                    .modifier(TagCell(color: .Gray3))
                 }
             }
             .padding(.leading, 16)
@@ -149,13 +125,22 @@ struct WriteShortcutTagView: View {
                     Image(systemName: "xmark")
                 })
             }
-            .Body2()
-            .foregroundColor(.Primary)
-            .frame(height: 46)
-            .padding(.horizontal)
-            .overlay(
-                RoundedRectangle(cornerRadius: 12)
-                    .strokeBorder(Color.Primary, lineWidth: 1))
+            .modifier(TagCell(color: .Primary))
+        }
+    }
+    
+    struct TagCell: ViewModifier {
+        @State var color: Color
+        
+        public func body(content: Content) -> some View {
+            content
+                .Body2()
+                .foregroundColor(color)
+                .frame(height: 46)
+                .padding(.horizontal)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .strokeBorder(color, lineWidth: 1))
         }
     }
     


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #26 

## 구현/변경 사항
- 단축어 관련 태그를 가로 스크롤뷰로 구현합니다.
- 카테고리 추가 버튼을 누르면 CategoryModalView가 연결되어야 합니다.
- 앱 추가 버튼을 누르면 텍스트필드가 열리고 return시 태그로 추가됩니다.
- 데이터 구조가 정해지고 Category를 String 배열로 저장하면 코드가 줄어들 수 있습니다.

## 스크린샷 (iPhone 14)
https://user-images.githubusercontent.com/76623853/197698458-ee8003ba-8f49-4b0e-82b4-5129adfce6c7.mp4

