### PR TITLE
[Feat] 리스트 맨 마지막에 패딩 44 설정

### DIFF
--- a/HappyAnding/HappyAnding/Views/Components/ListShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ListShortcutView.swift
@@ -50,6 +50,12 @@ struct ListShortcutView: View {
                     }
                 }
             }
+            
+            Rectangle()
+                .fill(Color.Background)
+                .frame(height: 44)
+                .listRowInsets(EdgeInsets())
+                .listRowSeparator(.hidden)
         }
         .listRowBackground(Color.Background)
         .listStyle(.plain)


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #79

## 구현/변경 사항
- 패딩 값 구현

## 스크린샷
- 패딩이서어 iPhone Pro max만 스샷 찍었어요

<img src = "https://user-images.githubusercontent.com/68676844/198014897-0f0ae000-43c6-4809-893b-a740457e8e41.png" width = 250> 
