### PR TITLE
[Feat] #127 Design Minor Changes

### DIFF
--- a/HappyAnding/HappyAnding/Views/Components/MyShortcutCardListView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/MyShortcutCardListView.swift
@@ -66,7 +66,7 @@ struct MyShortcutCardListView: View {
                                 NavigationLink(destination: {
                                     ReadShortcutView(shortcut: shortcut)
                                 }, label: {
-                                    MyShortcutCardView(myShortcutIcon: shortcut.sfSymbol, myShortcutName: shortcut.title, mySHortcutColor: shortcut.color)
+                                    MyShortcutCardView(myShortcutIcon: shortcut.sfSymbol, myShortcutName: shortcut.title, myShortcutColor: shortcut.color)
                                 })
                             }
                         }

--- a/HappyAnding/HappyAnding/Views/Components/MyShortcutCardView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/MyShortcutCardView.swift
@@ -11,30 +11,24 @@ struct MyShortcutCardView: View {
     
     let myShortcutIcon: String
     let myShortcutName: String
-    let mySHortcutColor: String
+    let myShortcutColor: String
     
     var body: some View {
-        VStack(alignment: .trailing) {
+        VStack(alignment: .leading, spacing: 4) {
+            Image(systemName: myShortcutIcon)
+                .frame(width: 30.0, height: 30.0)
+                .font(.title2)
+                .foregroundColor(Color.Gray1)
+            Text(myShortcutName)
+                .Subtitle()
+                .multilineTextAlignment(.leading)
+                .foregroundColor(Color.Gray1)
+                .lineLimit(3)
             Spacer()
-            HStack {
-                Image(systemName: myShortcutIcon)
-                    .frame(alignment: .leading)
-                    .font(.title2)
-                    .foregroundColor(Color.Gray1)
-                    Spacer()
-            }.padding(.bottom, 3)
-            HStack {
-                Text(myShortcutName)
-                    .Subtitle()
-                    .frame(alignment: .leading)
-                    .foregroundColor(Color.Gray1)
-                    .lineLimit(3)
-                Spacer()
-            }
         }
-        .padding()
+        .padding(.all, 12)
         .frame(width: 107, height: 144, alignment: .leading)
-        .background(Color.fetchGradient(color: mySHortcutColor))
+        .background(Color.fetchGradient(color: myShortcutColor))
         .cornerRadius(12)
     }
 }
@@ -56,7 +50,7 @@ struct AddMyShortcutCardView: View {
 
 struct MyShortcutCardView_Previews: PreviewProvider {
     static var previews: some View {
-    //    MyShortcutCardView(myShortcutIcon: "book.fill", myShortcutName: "노는게 제일조아", mySHortcutColor: "Coral")
+        MyShortcutCardView(myShortcutIcon: "book.fill", myShortcutName: "택배     조회하기", myShortcutColor: "Coral")
         AddMyShortcutCardView()
     }
 }

--- a/HappyAnding/HappyAnding/Views/Components/ValidationCheckTextField.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ValidationCheckTextField.swift
@@ -48,7 +48,7 @@ struct ValidationCheckTextField: View {
                     Button(action: {
                         content.removeAll()
                     }) {
-                        Image(systemName: "x.circle.fill")
+                        Image(systemName: "xmark.circle.fill")
                             .Body2()
                             .foregroundColor(.Gray4)
                     }

--- a/HappyAnding/HappyAnding/Views/MyPageViews/MyPageView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/MyPageView.swift
@@ -39,7 +39,6 @@ struct MyPageView: View {
                             .foregroundColor(.White)
                             .background(Color.Gray3)
                             .clipShape(Circle())
-                        VStack(alignment: .leading, spacing: 4) {
                             HStack {
                                 Text(userName)
                                     .Title1()
@@ -51,10 +50,6 @@ struct MyPageView: View {
                                     .foregroundColor(.Gray4)
                                  */
                             }
-                            Text(userEmail)
-                                .Body2()
-                                .foregroundColor(.Gray3)
-                        }
                         Spacer()
                     }
                     .frame(maxWidth: .infinity)

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTagView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTagView.swift
@@ -221,7 +221,7 @@ struct WriteShortcutTagView: View {
                 Button(action: {
                     self.text = ""
                 }) {
-                    Image(systemName: "x.circle.fill")
+                    Image(systemName: "xmark.circle.fill")
                         .Body2()
                         .foregroundColor(.Gray4)
                 }


### PR DESCRIPTION
## 관련 이슈
- closes #127

## 구현/변경 사항
- ProfileView : 닉네임 하단의 아이디 삭제
- 내 단축어 cell : 왼쪽 상단 정렬로 변경
- 내 단축어 cell : 텍스트 align 왼쪽정렬로 변경
- Input 활성화시 : Xmark 변경 (x.circle.fill -> xmark.circle.fill)

## 스크린샷

|ProfileView|MyShortcutCell|Xmark-SF|
|:---:|:---:|:---:|
|<img width="339" alt="Screenshot 2022-11-02 at 23 46 14" src="https://user-images.githubusercontent.com/94854258/199520746-d1705caa-a9f4-4a7c-9240-29337336bc72.png">|<img width="315" alt="Screenshot 2022-11-02 at 23 46 00" src="https://user-images.githubusercontent.com/94854258/199520835-d80e50d1-523d-4d0b-afaf-45c5e61e683a.png">|<img width="197" alt="Screenshot 2022-11-02 at 23 46 36" src="https://user-images.githubusercontent.com/94854258/199520913-a51b8a8b-0924-4c53-a4c9-bfd19279efb4.png">|

## 새로운 사실
- 여러 줄의 텍스트를 왼쪽정렬시킬때는 .multilineTextAlignment(.leading) 을 해주면 잘 되더라고요!
