### PR TITLE
[Feat] 단축어 cell 패딩 값 수정

### DIFF
--- a/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
@@ -73,7 +73,7 @@ struct ShortcutCell: View {
             }
             .padding(.vertical, 20)
             .background( background )
-            .padding(.horizontal, 16)
+            .padding(.horizontal, 20)
         }
         .padding(.top, 12)
         .background(Color.Background)


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #54

## 구현/변경 사항
- shortcut cell 패딩 값 수정

## 스크린샷
|before|after|
|---|---|
|<img src =  "https://user-images.githubusercontent.com/68676844/199604005-2bf61557-06da-4e29-a460-d682084a5247.png" width = 250>|<img src = "https://user-images.githubusercontent.com/68676844/199603889-9aefe7ae-8265-48f7-90c3-ab5cc9611ae0.png" width = 250>|

## 그냥 할 말
- 저는 어떤 차이가 있는지 잘 모르겠어요.. ^^
- 그래도 눈에 자가 달린 로미와 로겐은, 알아차릴 수 있을 거라 믿습니다.