### PR TITLE
[Feat] 단축어 링크 유효성 검사

### DIFF
--- a/HappyAnding/HappyAnding/Views/Components/ValidationCheckTextField.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ValidationCheckTextField.swift
@@ -27,6 +27,8 @@ struct ValidationCheckTextField: View {
     let title: String
     let placeholder: String
     let lengthLimit: Int
+    let isDownloadLink: Bool
+    
     @Binding var content: String
     @Binding var isValid: Bool
     
@@ -68,7 +70,7 @@ struct ValidationCheckTextField: View {
             
             HStack {
                 if isExceeded {
-                    Text("글자수를 초과하였습니다")
+                    Text(isDownloadLink ? "유효하지 않은 링크입니다" : "글자수를 초과하였습니다")
                         .Body2()
                         .foregroundColor(.Error)
                         .padding(.leading)
@@ -154,9 +156,22 @@ extension ValidationCheckTextField {
             isExceeded = false
             self.strokeColor = Color.Gray2
         } else if content.count <= lengthLimit {
-            isValid = true
-            isExceeded = false
-            self.strokeColor = Color.Success
+            if isDownloadLink {
+                if content.hasPrefix("https://www.icloud.com/shortcuts") {
+                    isValid = true
+                    isExceeded = false
+                    self.strokeColor = Color.Success
+                } else {
+                    isValid = textType.isOptional
+                    isExceeded = true
+                    self.strokeColor = Color.Error
+                }
+            } else {
+                isValid = true
+                isExceeded = false
+                self.strokeColor = Color.Success
+            }
+            
         } else {
             isValid = textType.isOptional
             isExceeded = true
@@ -173,6 +188,7 @@ struct ValidationCheckTextField_Previews: PreviewProvider {
             title: "설명",
             placeholder: "단축어에 대한 설명을 작성해주세요\n\n예시)\n- 이럴때 사용하면 좋아요\n- 이 단축어는 이렇게 사용해요",
             lengthLimit: 20,
+            isDownloadLink: false,
             content: .constant(""),
             isValid: .constant(true)
         )

--- a/HappyAnding/HappyAnding/Views/Components/ValidationCheckTextField.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ValidationCheckTextField.swift
@@ -27,7 +27,7 @@ struct ValidationCheckTextField: View {
     let title: String
     let placeholder: String
     let lengthLimit: Int
-    let isDownloadLink: Bool
+    let isDownloadLinkTextField: Bool
     
     @Binding var content: String
     @Binding var isValid: Bool
@@ -70,7 +70,7 @@ struct ValidationCheckTextField: View {
             
             HStack {
                 if isExceeded {
-                    Text(isDownloadLink ? "유효하지 않은 링크입니다" : "글자수를 초과하였습니다")
+                    Text(isDownloadLinkTextField ? "유효하지 않은 링크입니다" : "글자수를 초과하였습니다")
                         .Body2()
                         .foregroundColor(.Error)
                         .padding(.leading)
@@ -156,7 +156,7 @@ extension ValidationCheckTextField {
             isExceeded = false
             self.strokeColor = Color.Gray2
         } else if content.count <= lengthLimit {
-            if isDownloadLink {
+            if isDownloadLinkTextField {
                 if content.hasPrefix("https://www.icloud.com/shortcuts/") {
                     isValid = true
                     isExceeded = false
@@ -188,7 +188,7 @@ struct ValidationCheckTextField_Previews: PreviewProvider {
             title: "설명",
             placeholder: "단축어에 대한 설명을 작성해주세요\n\n예시)\n- 이럴때 사용하면 좋아요\n- 이 단축어는 이렇게 사용해요",
             lengthLimit: 20,
-            isDownloadLink: false,
+            isDownloadLinkTextField: false,
             content: .constant(""),
             isValid: .constant(true)
         )

--- a/HappyAnding/HappyAnding/Views/Components/ValidationCheckTextField.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ValidationCheckTextField.swift
@@ -157,7 +157,7 @@ extension ValidationCheckTextField {
             self.strokeColor = Color.Gray2
         } else if content.count <= lengthLimit {
             if isDownloadLink {
-                if content.hasPrefix("https://www.icloud.com/shortcuts") {
+                if content.hasPrefix("https://www.icloud.com/shortcuts/") {
                     isValid = true
                     isExceeded = false
                     self.strokeColor = Color.Success

--- a/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationInfoView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationInfoView.swift
@@ -37,7 +37,7 @@ struct WriteCurationInfoView: View {
                                      title: "큐레이션 이름",
                                      placeholder: "큐레이션 이름을 작성해주세요",
                                      lengthLimit: 20,
-                                     isDownloadLink: false,
+                                     isDownloadLinkTextField: false,
                                      content: $curation.title,
                                      isValid: $isValidTitle)
                 .padding(.top, 12)
@@ -47,7 +47,7 @@ struct WriteCurationInfoView: View {
                                      title: "한 줄 설명",
                                      placeholder: "나의 큐레이션을 설명할 수 있는 간단한 내용을 작성해주세요",
                                      lengthLimit: 40,
-                                     isDownloadLink: false,
+                                     isDownloadLinkTextField: false,
                                      content: Binding(get: {curation.subtitle ?? ""},
                                                       set: {curation.subtitle = $0}),
                                      isValid: $isValidDescription)

--- a/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationInfoView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationInfoView.swift
@@ -37,6 +37,7 @@ struct WriteCurationInfoView: View {
                                      title: "큐레이션 이름",
                                      placeholder: "큐레이션 이름을 작성해주세요",
                                      lengthLimit: 20,
+                                     isDownloadLink: false,
                                      content: $curation.title,
                                      isValid: $isValidTitle)
                 .padding(.top, 12)
@@ -46,6 +47,7 @@ struct WriteCurationInfoView: View {
                                      title: "한 줄 설명",
                                      placeholder: "나의 큐레이션을 설명할 수 있는 간단한 내용을 작성해주세요",
                                      lengthLimit: 40,
+                                     isDownloadLink: false,
                                      content: Binding(get: {curation.subtitle ?? ""},
                                                       set: {curation.subtitle = $0}),
                                      isValid: $isValidDescription)

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTagView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTagView.swift
@@ -50,6 +50,7 @@ struct WriteShortcutTagView: View {
                                      title: "단축어 사용을 위한 요구사항",
                                      placeholder: "단축어를 사용하기 위해서 필수적으로 요구되는 내용이 있다면, 작성해주세요",
                                      lengthLimit: 100,
+                                     isDownloadLink: false,
                                      content: $shortcut.shortcutRequirements,
                                      isValid: $isRequirementValid
             )

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTagView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTagView.swift
@@ -50,7 +50,7 @@ struct WriteShortcutTagView: View {
                                      title: "단축어 사용을 위한 요구사항",
                                      placeholder: "단축어를 사용하기 위해서 필수적으로 요구되는 내용이 있다면, 작성해주세요",
                                      lengthLimit: 100,
-                                     isDownloadLink: false,
+                                     isDownloadLinkTextField: false,
                                      content: $shortcut.shortcutRequirements,
                                      isValid: $isRequirementValid
             )

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTitleView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTitleView.swift
@@ -85,7 +85,7 @@ struct WriteShortcutTitleView: View {
                                          title: "단축어 이름",
                                          placeholder: "단축어 이름을 입력하세요",
                                          lengthLimit: 20,
-                                         isDownloadLink: false,
+                                         isDownloadLinkTextField: false,
                                          content: $shortcut.title,
                                          isValid: $isNameValid
                 )
@@ -97,7 +97,7 @@ struct WriteShortcutTitleView: View {
                                          title: "단축어 링크",
                                          placeholder: "단축어 링크를 추가하세요",
                                          lengthLimit: 100,
-                                         isDownloadLink: true   ,
+                                         isDownloadLinkTextField: true   ,
                                          content: $shortcut.downloadLink[0],
                                          isValid: $isLinkValid
                 )

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTitleView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTitleView.swift
@@ -85,6 +85,7 @@ struct WriteShortcutTitleView: View {
                                          title: "단축어 이름",
                                          placeholder: "단축어 이름을 입력하세요",
                                          lengthLimit: 20,
+                                         isDownloadLink: false,
                                          content: $shortcut.title,
                                          isValid: $isNameValid
                 )
@@ -96,6 +97,7 @@ struct WriteShortcutTitleView: View {
                                          title: "단축어 링크",
                                          placeholder: "단축어 링크를 추가하세요",
                                          lengthLimit: 100,
+                                         isDownloadLink: true   ,
                                          content: $shortcut.downloadLink[0],
                                          isValid: $isLinkValid
                 )

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutdescriptionView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutdescriptionView.swift
@@ -27,6 +27,7 @@ struct WriteShortcutdescriptionView: View {
                                      title: "한줄 설명",
                                      placeholder: "간단하게 설명을 작성해주세요",
                                      lengthLimit: 20,
+                                     isDownloadLink: false,
                                      content: $shortcut.subtitle,
                                      isValid: $isOneLineValid
             )
@@ -36,6 +37,7 @@ struct WriteShortcutdescriptionView: View {
                                      title: "설명",
                                      placeholder: "단축어에 대한 설명을 작성해주세요\n\n예시)\n- 이럴때 사용하면 좋아요\n- 이 단축어는 이렇게 사용해요",
                                      lengthLimit: 500,
+                                     isDownloadLink: false,
                                      content: $shortcut.description,
                                      isValid: $isMultiLineValid
             )

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutdescriptionView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutdescriptionView.swift
@@ -27,7 +27,7 @@ struct WriteShortcutdescriptionView: View {
                                      title: "한줄 설명",
                                      placeholder: "간단하게 설명을 작성해주세요",
                                      lengthLimit: 20,
-                                     isDownloadLink: false,
+                                     isDownloadLinkTextField: false,
                                      content: $shortcut.subtitle,
                                      isValid: $isOneLineValid
             )
@@ -37,7 +37,7 @@ struct WriteShortcutdescriptionView: View {
                                      title: "설명",
                                      placeholder: "단축어에 대한 설명을 작성해주세요\n\n예시)\n- 이럴때 사용하면 좋아요\n- 이 단축어는 이렇게 사용해요",
                                      lengthLimit: 500,
-                                     isDownloadLink: false,
+                                     isDownloadLinkTextField: false,
                                      content: $shortcut.description,
                                      isValid: $isMultiLineValid
             )


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #113

## 구현/변경 사항
- 링크가 https://www.icloud.com/shortcuts/으로 시작하는지 확인하여 간단한 유효성 검사를 합니다 

## 스크린샷

https://user-images.githubusercontent.com/68676844/199614657-79ce9a65-0480-4a80-be80-50eb40063a5a.mp4

## To Reviewer
- 1차원적으로만 생각한 로직이어서, 검증 부탁드려요