### PR TITLE
회원가입 관련 이슈 해결

### DIFF
--- a/HappyAnding/HappyAnding/Model/FirebaseService.swift
+++ b/HappyAnding/HappyAnding/Model/FirebaseService.swift
@@ -730,7 +730,7 @@ class FirebaseService {
     
     // MARK: - 이미 회원가입한 User인지 확인하는 함수
     
-    func checkExistsUser(completionHandler: @escaping (Bool) -> ()) {
+    func checkMembership(completionHandler: @escaping (Bool) -> ()) {
         
         var result = true
         

--- a/HappyAnding/HappyAnding/Model/FirebaseService.swift
+++ b/HappyAnding/HappyAnding/Model/FirebaseService.swift
@@ -474,4 +474,27 @@ class FirebaseService {
             print("this is not a model.")
         }
     }
+    
+    
+    // MARK: - 이미 회원가입한 User인지 확인하는 함수
+    
+    func checkExistsUser(completionHandler: @escaping (Bool) -> ()) {
+        
+        var result = true
+        
+        db.collection("User")
+            .whereField("id", isEqualTo: currentUser())
+            .limit(to: 1)
+            .getDocuments() { (querySnapshot, error) in
+                if let error {
+                    print("Error getting documnets: \(error)")
+                } else {
+                    guard let documents = querySnapshot?.documents else { return }
+                    if documents.count == 0 {
+                        result = false
+                    }
+                    completionHandler(result)
+                }
+            }
+    }
 }

--- a/HappyAnding/HappyAnding/Views/SignInViews/AppleAuthCoordinator.swift
+++ b/HappyAnding/HappyAnding/Views/SignInViews/AppleAuthCoordinator.swift
@@ -117,9 +117,6 @@ extension AppleAuthCoordinator: ASAuthorizationControllerDelegate {
             // Sign in with Firebase.
             Auth.auth().signIn(with: credential) { (authResult, error) in
                 if let error {
-                    // Error. If error.code == .MissingOrInvalidNonce, make sure
-                    // you're sending the SHA256-hashed nonce as a hex string with
-                    // your request to Apple.
                     print(error.localizedDescription)
                     return
                 }
@@ -133,9 +130,6 @@ extension AppleAuthCoordinator: ASAuthorizationControllerDelegate {
                         self.userAuth.signIn()
                     }
                 }
-//                self.userAuth.signIn()
-                // User is signed in to Firebase with Apple.
-                // ...
             }
         }
     }

--- a/HappyAnding/HappyAnding/Views/SignInViews/AppleAuthCoordinator.swift
+++ b/HappyAnding/HappyAnding/Views/SignInViews/AppleAuthCoordinator.swift
@@ -121,7 +121,7 @@ extension AppleAuthCoordinator: ASAuthorizationControllerDelegate {
                     return
                 }
                 
-                self.firebase.checkExistsUser { result in
+                self.firebase.checkMembership { result in
                     if result {
                         withAnimation(.easeInOut) {
                             self.signInStatus = true

--- a/HappyAnding/HappyAnding/Views/SignInViews/AppleAuthCoordinator.swift
+++ b/HappyAnding/HappyAnding/Views/SignInViews/AppleAuthCoordinator.swift
@@ -15,9 +15,12 @@ import CryptoKit
 /// Apple 로그인을 처리하는 클래스
 class AppleAuthCoordinator: NSObject {
     
+    @AppStorage("signInStatus") var signInStatus = false
+    
     var userAuth = UserAuth.shared
     var currentNonce: String?
     let window: UIWindow?
+    let firebase = FirebaseService()
     
     init(window: UIWindow?) {
         self.window = window
@@ -120,7 +123,17 @@ extension AppleAuthCoordinator: ASAuthorizationControllerDelegate {
                     print(error.localizedDescription)
                     return
                 }
-                self.userAuth.signIn()
+                
+                self.firebase.checkExistsUser { result in
+                    if result {
+                        withAnimation(.easeInOut) {
+                            self.signInStatus = true
+                        }
+                    } else {
+                        self.userAuth.signIn()
+                    }
+                }
+//                self.userAuth.signIn()
                 // User is signed in to Firebase with Apple.
                 // ...
             }

--- a/HappyAnding/HappyAnding/Views/SignInViews/UserAuth.swift
+++ b/HappyAnding/HappyAnding/Views/SignInViews/UserAuth.swift
@@ -10,18 +10,10 @@ import Foundation
 class UserAuth: ObservableObject {
     
     @Published var isLoggedIn = false
-//    @Published var isUser = false
     
     static let shared = UserAuth()
     
     func signIn() {
         self.isLoggedIn = true
     }
-    
-    
-    // TODO: Firebase로 user가 닉네임이 존재하는지 확인?
-    
-//    func signUp() {
-//        self.isUser = true
-//    }
 }

--- a/HappyAnding/HappyAnding/Views/SignInViews/UserAuth.swift
+++ b/HappyAnding/HappyAnding/Views/SignInViews/UserAuth.swift
@@ -10,7 +10,7 @@ import Foundation
 class UserAuth: ObservableObject {
     
     @Published var isLoggedIn = false
-    @Published var isUser = false
+//    @Published var isUser = false
     
     static let shared = UserAuth()
     
@@ -21,7 +21,7 @@ class UserAuth: ObservableObject {
     
     // TODO: Firebase로 user가 닉네임이 존재하는지 확인?
     
-    func signUp() {
-        self.isUser = true
-    }
+//    func signUp() {
+//        self.isUser = true
+//    }
 }

--- a/HappyAnding/HappyAnding/Views/SignInViews/WriteNicknameView.swift
+++ b/HappyAnding/HappyAnding/Views/SignInViews/WriteNicknameView.swift
@@ -71,6 +71,9 @@ struct WriteNicknameView: View {
                     .frame(height: 20)
                     .padding(.leading, 16)
                     .padding(.vertical, 12)
+                    .onChange(of: nickname) {_ in
+                        isNicknameChecked = false
+                    }
                 
                 if !nickname.isEmpty {
                     textFieldSFSymbol

--- a/HappyAnding/HappyAnding/Views/SignInViews/WriteNicknameView.swift
+++ b/HappyAnding/HappyAnding/Views/SignInViews/WriteNicknameView.swift
@@ -143,7 +143,7 @@ struct WriteNicknameView: View {
     ///시작하기 버튼
     var startButton: some View {
         Button(action: {
-            userAuth.signUp()
+//            userAuth.signUp()
             
             withAnimation(.easeInOut) {
                 self.signInStatus = true

--- a/HappyAnding/HappyAnding/Views/SignInViews/WriteNicknameView.swift
+++ b/HappyAnding/HappyAnding/Views/SignInViews/WriteNicknameView.swift
@@ -143,7 +143,6 @@ struct WriteNicknameView: View {
     ///시작하기 버튼
     var startButton: some View {
         Button(action: {
-//            userAuth.signUp()
             
             withAnimation(.easeInOut) {
                 self.signInStatus = true


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #145
- closes #151

## 구현/변경 사항
- 회원가입 뷰 로그인하는 경우는 닉네임 설정 뷰 안 나오도록 구현
- 닉네임 중복확인 후 변경되면, 다시 중복확인 요구하도록 구현

## 스크린샷

1. 회원가입 -> 닉네임 중복확인 -> 앱종료 후 재접속(자동로그인)

https://user-images.githubusercontent.com/68676844/199710104-ae0168fd-1a6e-487b-b123-e2fe4fff2771.mov


2. 앱 삭제 후 다시 빌드 -> 로그인 -> 닉네임화면 없이 메인화면으로 접속

https://user-images.githubusercontent.com/68676844/199710144-7a53514a-d634-4309-993b-c4b5fd9957ff.mp4


3. 닉네임 중복확인기능 구현

https://user-images.githubusercontent.com/68676844/199711935-afb9647d-1e49-48b8-9c0a-fd05515362f9.mp4




## 추가 컨텍스트
- 엘리 PR 머지되면 머지할게요