### PR TITLE
[Feat] Design Minor Changes 2

### DIFF
--- a/HappyAnding/HappyAnding/Views/Components/MyShortcutCardListView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/MyShortcutCardListView.swift
@@ -75,6 +75,6 @@ struct MyShortcutCardListView: View {
                 .padding(.horizontal, 16)
             }
         }
-        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarTitleDisplayMode(.automatic)
     }
 }

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ExploreCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ExploreCurationView.swift
@@ -27,7 +27,8 @@ struct ExploreCurationView: View {
                 }
                 .padding(.bottom, 32)
             }
-            .navigationTitle(Text("단축어 큐레이션"))
+            .navigationBarTitle(Text("큐레이션 둘러보기"))
+            .navigationBarTitleDisplayMode(.large)
             .background(Color.Background)
         }
     }
@@ -40,7 +41,7 @@ struct adminCurationsFrameiew: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(alignment: .bottom) {
-                Text("숏컷집의 추천 큐레이션")
+                Text("숏컷집 추천 큐레이션")
                     .Title2()
                     .foregroundColor(.Gray5)
                     .onTapGesture { }

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ExploreCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ExploreCurationView.swift
@@ -29,6 +29,7 @@ struct ExploreCurationView: View {
             }
             .navigationBarTitle(Text("큐레이션 둘러보기"))
             .navigationBarTitleDisplayMode(.large)
+            .scrollIndicators(.hidden)
             .background(Color.Background)
         }
     }

--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView/ExploreShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView/ExploreShortcutView.swift
@@ -27,6 +27,7 @@ struct ExploreShortcutView: View {
             }
             .navigationBarTitle(Text("단축어 둘러보기"))
             .navigationBarTitleDisplayMode(.large)
+            .scrollIndicators(.hidden)
             .background(Color.Background)
         }
     }

--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView/ExploreShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView/ExploreShortcutView.swift
@@ -25,7 +25,8 @@ struct ExploreShortcutView: View {
                 LovedShortcutView(shortcuts: shortcutsZipViewModel.sortedShortcutsByDownload)
                     .padding(.bottom, 44)
             }
-            .navigationTitle(Text("단축어 둘러보기"))
+            .navigationBarTitle(Text("단축어 둘러보기"))
+            .navigationBarTitleDisplayMode(.large)
             .background(Color.Background)
         }
     }

--- a/HappyAnding/HappyAnding/Views/MyPageViews/MyPageView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/MyPageView.swift
@@ -62,7 +62,8 @@ struct MyPageView: View {
                     
                 }
             }
-            .navigationTitle("프로필")
+            .navigationBarTitle("프로필")
+            .navigationBarTitleDisplayMode(.large)
             .toolbar {
                 ToolbarItem {
                     //TODO: 스프린트 1에서 배제 추후 주석 삭제할 것

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/CategoryModalView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/CategoryModalView.swift
@@ -14,38 +14,42 @@ struct CategoryModalView: View {
     private let gridLayout = [GridItem(.flexible()), GridItem(.flexible())]
     
     var body: some View {
-        VStack {
-            Text("카테고리")
-                .font(.headline)
-            
-            Spacer()
-                .frame(height: UIScreen.main.bounds.size.height * 0.7 * 0.04)
-            
-            LazyVGrid(columns: gridLayout, spacing: 12) {
-                ForEach(Category.allCases, id: \.self) { item in
-                    CategoryButton(item: item, items: $selectedCategories)
+        ZStack {
+            Color.Background
+                .ignoresSafeArea()
+            VStack {
+                Text("카테고리")
+                    .font(.headline)
+                
+                Spacer()
+                    .frame(height: UIScreen.main.bounds.size.height * 0.7 * 0.04)
+                
+                LazyVGrid(columns: gridLayout, spacing: 12) {
+                    ForEach(Category.allCases, id: \.self) { item in
+                        CategoryButton(item: item, items: $selectedCategories)
+                    }
                 }
+                .padding(.horizontal, 16)
+                
+                Spacer()
+                    .frame(height: UIScreen.main.bounds.size.height * 0.7 * 0.04)
+                
+                Button(action: {
+                    isShowingCategoryModal = false
+                }, label: {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 12)
+                            .foregroundColor(!selectedCategories.isEmpty ? .Primary : .Gray1 )
+                            .frame(maxWidth: .infinity, maxHeight: 52)
+                        
+                        Text("완료")
+                            .foregroundColor(!selectedCategories.isEmpty ? .Background : .Gray3 )
+                            .Body1()
+                    }
+                })
+                .disabled(selectedCategories.isEmpty)
+                .padding(.horizontal, 16)
             }
-            .padding(.horizontal, 16)
-            
-            Spacer()
-                .frame(height: UIScreen.main.bounds.size.height * 0.7 * 0.04)
-            
-            Button(action: {
-                isShowingCategoryModal = false
-            }, label: {
-                ZStack {
-                    RoundedRectangle(cornerRadius: 12)
-                        .foregroundColor(!selectedCategories.isEmpty ? .Primary : .Gray1 )
-                        .frame(maxWidth: .infinity, maxHeight: 52)
-                    
-                    Text("완료")
-                        .foregroundColor(!selectedCategories.isEmpty ? .Background : .Gray3 )
-                        .Body1()
-                }
-            })
-            .disabled(selectedCategories.isEmpty)
-            .padding(.horizontal, 16)
         }
     }
     

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/IconModalView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/IconModalView.swift
@@ -125,6 +125,7 @@ struct IconModalView: View {
             .padding(.horizontal, 16)
             .padding(.bottom, 24)
         }
+        .background(Color.Background)
     }
     
     struct ColorCell: View {

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTagView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTagView.swift
@@ -80,6 +80,7 @@ struct WriteShortcutTagView: View {
         }
         .navigationTitle(isEdit ? "단축어 편집" :"단축어 등록")
         .ignoresSafeArea(.keyboard)
+        .background(Color.Background)
     }
     
     struct categoryList: View {

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTitleView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTitleView.swift
@@ -122,6 +122,7 @@ struct WriteShortcutTitleView: View {
                 .padding(.bottom, 24)
             }
             .ignoresSafeArea(.keyboard, edges: .bottom)
+            .background(Color.Background)
         }
     }
 }

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutdescriptionView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutdescriptionView.swift
@@ -63,6 +63,7 @@ struct WriteShortcutdescriptionView: View {
         }
         .navigationTitle(isEdit ? "단축어 편집" : "단축어 등록")
         .ignoresSafeArea(.keyboard)
+        .background(Color.Background)
     }
 }
 


### PR DESCRIPTION
## 관련 이슈
- closes #152 

## 구현/변경 사항
- 글쓰기 뷰들의 배경색상을 .background로 통일함
- 멀티라인 텍스트 에디터의 zstack으로 쌓인 textfiled 부분이 터치되지 않고, 색이 다르게 표시되던 문제를 해결함
- 단축어 탭과 프로필 탭의 타이틀이 .inline으로 보이던 문제를 해결함
- 프로필 탭에 맞춰 단축어와 큐레이션 탭의 scroll indicator를 보이지 않게 처리함

## 스크린샷

*색상 변화 인지를 위해 다크모드로 설정 후 스크린샷을 촬영함
|배경색상|텍스트 에디터|타이틀|
|:---:|:---:|:---:|
|<img width="329" alt="Screenshot 2022-11-04 at 3 25 53" src="https://user-images.githubusercontent.com/94854258/199805179-1455596c-e650-489d-8981-bdef6793f1fa.png">|<img width="318" alt="Screenshot 2022-11-04 at 3 25 38" src="https://user-images.githubusercontent.com/94854258/199805233-218bc7dc-9e22-43b8-b6a9-cb7bc22736f6.png">|<img width="328" alt="Screenshot 2022-11-04 at 3 26 03" src="https://user-images.githubusercontent.com/94854258/199805267-39d28db7-c190-49de-9e35-25ce7d4f6a87.png">|
