### PR TITLE
Feat] ReadShortcutView 디자인 수정사항

### DIFF
--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutContentView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutContentView.swift
@@ -37,9 +37,14 @@ struct ReadShortcutContentView: View {
                     .padding(.bottom, 20)
                 categoryView
                     .padding(.bottom, 20)
-                ReusableTextView(title: "단축어 사용에 필요한 앱", contents: nil, contentsArray: shortcut.requiredApp)
-                    .padding(.bottom, 20)
-                ReusableTextView(title: "단축어 사용을 위한 요구사항", contents: shortcut.shortcutRequirements, contentsArray: nil)
+                
+                if !shortcut.requiredApp.isEmpty {
+                    ReusableTextView(title: "단축어 사용에 필요한 앱", contents: nil, contentsArray: shortcut.requiredApp)
+                        .padding(.bottom, 20)
+                }
+                if !shortcut.shortcutRequirements.isEmpty {
+                    ReusableTextView(title: "단축어 사용을 위한 요구사항", contents: shortcut.shortcutRequirements, contentsArray: nil)
+                }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(20)

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutContentView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutContentView.swift
@@ -61,6 +61,7 @@ struct ReadShortcutContentView: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 20)
+        .scrollIndicators(.hidden)
     }
     
     var categoryView: some View {


### PR DESCRIPTION
## 관련 이슈
- closes #178 

## 구현/변경 사항
- ReadShortcutView의 컨텐츠 중 값이 없을 수 있는 관련 앱과 요구사항의 경우 값이 없을 때는 해더도 표시되지 않도록 UI 수정
- ReadShortcutView 안 ReadShortcutContentView의 scroll indicator를 보이지 않게 처리

## 머지 시점
- @JIWON1923 쏘이의 #177 PR 시점의 코드를 풀 받아 작업했습니다.
- 해당 브랜치 머지 이후 머지가 진행되어야 문제가 없을 듯 합니다.

## 스크린샷

|옵셔널 값들| 스크롤 인디케이터|
|:---:|:---:|
|<img width="326" alt="Screenshot 2022-11-04 at 7 28 04" src="https://user-images.githubusercontent.com/94854258/199846429-6e0190f4-36e2-44a8-ac1f-8ed14c027f51.png">|![Simulator Screen Shot - iPhone 14 - 2022-11-04 at 07 28 17](https://user-images.githubusercontent.com/94854258/199846459-ddb44f00-cfac-413b-835c-7ca5c799d813.png)|
