### PR TITLE
[Feat] Hide imcomplete functions (공유 및 신고버튼)

### DIFF
--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
@@ -47,11 +47,16 @@ struct ReadUserCurationView: View {
             if userCuration.author == firebase.currentUser() {
                 myCurationMenuSection
             } else {
-                otherCurationMenuSection
+                //다른 사람 큐레이션 볼 때 공유버튼 동작(트레일링 아이템) 제거.
+                // TODO: 2차 스프린트 이후 공유 기능 구현 및 해당 코드 복원
+//                otherCurationMenuSection
             }
         }, label: {
             Image(systemName: userCuration.author == firebase.currentUser() ? "ellipsis" : "square.and.arrow.up")
                 .foregroundColor(.Gray4)
+                //다른 사람 큐레이션 볼 때 공유버튼 (트레일링 아이템) opacity 0
+                // TODO: 2차 스프린트 이후 공유 기능 구현 및 해당 코드 제거
+                .opacity(userCuration.author == firebase.currentUser() ? 1 : 0)
         }))
         .fullScreenCover(isPresented: $isTappedEditButton) {
             NavigationView {
@@ -132,12 +137,12 @@ extension ReadUserCurationView {
             }
             
             // TODO: 함수 구현 필요
-            
-            Button(action: {
-                //Place something action here
-            }) {
-                Label("공유", systemImage: "square.and.arrow.up")
-            }
+            // TODO: 2차 스프린트 이후 공유 기능 구현 및 해당 코드 복원
+//            Button(action: {
+//                //Place something action here
+//            }) {
+//                Label("공유", systemImage: "square.and.arrow.up")
+//            }
             Button(role: .destructive, action: {
                 isTappedDeleteButton.toggle()
                 

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -124,11 +124,13 @@ extension ReadShortcutView {
             }) {
                 Label("공유", systemImage: "square.and.arrow.up")
             }
-            Button(action: {
-                //Place something action here
-            }) {
-                Label("신고", systemImage: "light.beacon.max.fill")
-            }
+            
+            //TODO: 2차 스프린트 이후 신고 기능 추가 시 사용할 코드
+//            Button(action: {
+//                //Place something action here
+//            }) {
+//                Label("신고", systemImage: "light.beacon.max.fill")
+//            }
         }
     }
     


### PR DESCRIPTION
## 관련 이슈
- closes #171 

## 구현/변경 사항
- 단축어 상세 뷰에서 "신고" 버튼 숨기기
 - UserCurationView에서 "공유" 버튼 숨기기
 - 2차 스프린트 이후 신고 및 공유 기능이 적용될 경우 주석만 삭제하면 버튼 형태를 그대로 사용할 수 있습니다.

## 스크린샷

|신고버튼 숨기기|공유버튼 숨기기-내 큐레이션|공유버튼 숨기기-유저 큐레이션|
|:---:|:---:|:---:|
|<img width="335" alt="Screenshot 2022-11-04 at 9 22 12" src="https://user-images.githubusercontent.com/94854258/199859259-885778f4-561f-445f-90ea-d354af55e967.png">|<img width="329" alt="Screenshot 2022-11-04 at 9 22 32" src="https://user-images.githubusercontent.com/94854258/199859279-9e542184-5980-4bb3-866b-aa55ee95c2ba.png">|<img width="335" alt="Screenshot 2022-11-04 at 9 22 47" src="https://user-images.githubusercontent.com/94854258/199859320-7b3ac65f-1b8a-4c9f-929d-d9c4e2668a77.png">|

