### PR TITLE
[Fix] 단축어 중복 아이템 제거

### DIFF
--- a/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
+++ b/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
@@ -817,7 +817,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = HappyAnding/HappyAnding.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"HappyAnding/Preview Content\"";
@@ -841,7 +841,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.happyanding.HappyAnding;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = ShortcutsZipProfile1.0.0;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = ShortcutsZipProfileForDev;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -858,7 +858,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = HappyAnding/HappyAnding.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"HappyAnding/Preview Content\"";
@@ -882,7 +882,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.happyanding.HappyAnding;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = ShortcutsZipProfile1.0.0;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = ShortcutsZipProfileForDev;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/HappyAnding/HappyAnding/Model/Curation.swift
+++ b/HappyAnding/HappyAnding/Model/Curation.swift
@@ -17,7 +17,6 @@ struct Curation: Identifiable, Equatable, Codable {
     var background: String
     var author: String
     var shortcuts: [ShortcutCellModel]
-//    var shortcuts: [Shortcuts]
     
     var dictionary: [String: Any] {
         let data = (try? JSONEncoder().encode(self)) ?? Data()

--- a/HappyAnding/HappyAnding/Model/Shortcuts.swift
+++ b/HappyAnding/HappyAnding/Model/Shortcuts.swift
@@ -9,7 +9,7 @@ import Foundation
 
 // TODO: Shortcuts -> Shortcut으로 이름 변경 필요
 
-struct Shortcuts: Identifiable, Codable, Equatable {
+struct Shortcuts: Identifiable, Codable, Equatable, Hashable {
     var id = UUID().uuidString
     var sfSymbol: String
     var color: String

--- a/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
+++ b/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
@@ -25,6 +25,8 @@ class ShortcutsZipViewModel: ObservableObject {
     @Published var sortedShortcutsByDownload: [Shortcuts] = []  // 다운로드 수에 의해 정렬된 숏컷
     @Published var sortedShortcutsByLike: [Shortcuts] = []  // 다운로드 수에 의해 정렬된 숏컷
     @Published var shortcutsInCategory: [[Shortcuts]] = [[Shortcuts]].init(repeating: [], count: Category.allCases.count) // Category에서 사용할 숏컷 배열
+    @Published var isFirstFetchInCategory = [Bool] (repeating: true, count: Category.allCases.count) //카테고리를 리스트 첫 fetch여부
+    @Published var isLastFetchInCategory = [Bool] (repeating: false, count: Category.allCases.count) //카테고리를 리스트 마지막 fetch여부
     
     @Published var curationsMadeByUser: [Curation] = []         // 유저가 만든 큐레이션배열
     @Published var userCurations: [Curation] = []
@@ -211,6 +213,7 @@ class ShortcutsZipViewModel: ObservableObject {
             let index = category.index
             
             if let next = self.lastCategoryDocumentSnapshot[index] {
+                print("**\(next.data().map(String.init(describing:)) )")
                 query  = db.collection("Shortcut")
                     .whereField("category", arrayContains: category.rawValue)
                     .order(by: orderBy, descending: true)
@@ -245,7 +248,7 @@ class ShortcutsZipViewModel: ObservableObject {
             }
         }
     
-    // MARK: 현재 user가 만들었던 shortcuts을 받아오는 함수 (나의 단축어)
+    // MARK: 현재 user가 만들었던 shortcuts을 10개씩 받아오는 함수 (나의 단축어)
     
     func fetchShortcutByAuthor(author: String, completionHandler: @escaping ([Shortcuts])->()) {
         

--- a/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
+++ b/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
@@ -203,13 +203,14 @@ class ShortcutsZipViewModel: ObservableObject {
         category: Category,
         orderBy: String,
         completionHandler: @escaping ([Shortcuts])->()) {
+            print(category.rawValue)
             
             var shortcuts: [Shortcuts] = []
             
             var query: Query!
-            let index = checkShortcutIndex(orderBy: orderBy)
+            let index = category.index
             
-            if let next = self.lastShortcutDocumentSnapshot[index] {
+            if let next = self.lastCategoryDocumentSnapshot[index] {
                 query  = db.collection("Shortcut")
                     .whereField("category", arrayContains: category.rawValue)
                     .order(by: orderBy, descending: true)

--- a/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
+++ b/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
@@ -35,6 +35,7 @@ class ShortcutsZipViewModel: ObservableObject {
     
     var lastShortcutDocumentSnapshot = [QueryDocumentSnapshot?] (repeating: nil, count: 3)
     var lastCurationDocumentSnapshot = [QueryDocumentSnapshot?] (repeating: nil, count: 3)
+    var lastCategoryDocumentSnapshot = [QueryDocumentSnapshot?] (repeating: nil, count: 12)
     
     let numberOfPageLimit = 10
     let numberOfLike = 5
@@ -107,7 +108,6 @@ class ShortcutsZipViewModel: ObservableObject {
         return index
     }
     
-
     
 //MARK: - 데이터를 받아오는 함수들
     
@@ -200,7 +200,7 @@ class ShortcutsZipViewModel: ObservableObject {
     //MARK: 선택한 카테고리에 해당하는 단축어를 정렬하여 10개씩 가져오는 함수 (카테고리 단축어)
     
     func fetchCategoryShortcutLimit(
-        category: String,
+        category: Category,
         orderBy: String,
         completionHandler: @escaping ([Shortcuts])->()) {
             
@@ -211,13 +211,13 @@ class ShortcutsZipViewModel: ObservableObject {
             
             if let next = self.lastShortcutDocumentSnapshot[index] {
                 query  = db.collection("Shortcut")
-                    .whereField("category", arrayContains: category)
+                    .whereField("category", arrayContains: category.rawValue)
                     .order(by: orderBy, descending: true)
                     .limit(to: numberOfPageLimit)
                     .start(afterDocument: next)
             } else {
                 query = db.collection("Shortcut")
-                    .whereField("category", arrayContains: category)
+                    .whereField("category", arrayContains: category.rawValue)
                     .order(by: orderBy, descending: true)
                     .limit(to: numberOfPageLimit)
             }
@@ -238,7 +238,7 @@ class ShortcutsZipViewModel: ObservableObject {
                             print("error: \(error)")
                         }
                     }
-                    self.lastShortcutDocumentSnapshot[index] = documents.last
+                    self.lastCategoryDocumentSnapshot[category.index] = documents.last
                     completionHandler(shortcuts)
                 }
             }

--- a/HappyAnding/HappyAnding/Views/Components/ListShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ListShortcutView.swift
@@ -15,7 +15,7 @@ struct ListShortcutView: View {
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
     
     @State var shortcuts:[Shortcuts]?
-    @State var shortcutsArray: [Shortcuts] = []
+//    @State var shortcutsArray: [Shortcuts] = []
     @State private var isLastItem = false
     @State var description: String = ""
     

--- a/HappyAnding/HappyAnding/Views/Components/ListShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ListShortcutView.swift
@@ -66,7 +66,7 @@ struct ListShortcutView: View {
         .onAppear() {
             if let categoryName {
                 description = categoryName.fetchDescription()
-                shortcutsZipViewModel.fetchCategoryShortcutLimit(category: categoryName.rawValue, orderBy: "date") { shortcuts in
+                shortcutsZipViewModel.fetchCategoryShortcutLimit(category: categoryName, orderBy: "date") { shortcuts in
                     self.shortcuts = shortcuts
                 }
             } else if let sectionType {

--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView/LovedShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView/LovedShortcutView.swift
@@ -36,7 +36,7 @@ struct LovedShortcutView: View {
             if let shortcuts {
                 ForEach(Array(shortcuts.enumerated()), id:\.offset) { index, shortcut in
                     if index < 3 {
-                        NavigationLink(destination: ReadShortcutView(shortcut: shortcut, shortcutID: shortcut.id), label: {
+                        NavigationLink(destination: ReadShortcutView(shortcutID: shortcut.id), label: {
                             ShortcutCell(shortcut: shortcut)
                         })
                     }

--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ShortcutsListView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ShortcutsListView.swift
@@ -44,7 +44,7 @@ struct ShortcutsListView: View {
                                 case .myShortcut, .myLovingShortcut, .myDownloadShortcut: print("my goodgoodgood")
                                 default: // 카테고리일 경우
                                     if let categoryName {
-                                        shortcutsZipViewModel.fetchCategoryShortcutLimit(category: categoryName.rawValue, orderBy: "numberOfDownload") { newShortcuts in
+                                        shortcutsZipViewModel.fetchCategoryShortcutLimit(category: categoryName, orderBy: "numberOfDownload") { newShortcuts in
                                             shortcuts.append(contentsOf: newShortcuts)
                                         }
                                     }
@@ -61,7 +61,7 @@ struct ShortcutsListView: View {
             .onAppear {
                 if self.shortcuts.count == 0 {
                     if let categoryName {
-                        self.shortcutsZipViewModel.fetchCategoryShortcutLimit(category: categoryName.rawValue, orderBy: "numberOfDownload") { newShortcuts in
+                        self.shortcutsZipViewModel.fetchCategoryShortcutLimit(category: categoryName, orderBy: "numberOfDownload") { newShortcuts in
                             self.shortcuts.append(contentsOf: newShortcuts)
                         }
                     }

--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ShortcutsListView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ShortcutsListView.swift
@@ -23,13 +23,14 @@ struct ShortcutsListView: View {
             
             LazyVStack {
                 ForEach(Array(shortcuts.enumerated()), id: \.offset) { index, shortcut in
-                    NavigationLink(destination: ReadShortcutView(shortcut: shortcut, shortcutID: shortcut.id)) {
+                    NavigationLink(destination: ReadShortcutView(shortcutID: shortcut.id)) {
                         ShortcutCell(shortcut: shortcut,
                                      rankNumber: sectionType == .download ? index + 1 : -1)
                         .listRowInsets(EdgeInsets())
                         .listRowSeparator(.hidden)
                         .onAppear {
                             print(shortcuts.count)
+                            print("** \(sectionType)")
                             if shortcuts.last == shortcut && shortcuts.count % 10 == 0 {
                                 // TODO: sectionType에 따라서 요청함수 다르거 해줘야 함
                                 switch self.sectionType {
@@ -41,10 +42,22 @@ struct ShortcutsListView: View {
                                     shortcutsZipViewModel.fetchShortcutLimit(orderBy: "numberOfLike") { newShortcuts in
                                         shortcuts.append(contentsOf: newShortcuts)
                                     }
-                                case .myShortcut, .myLovingShortcut, .myDownloadShortcut: print("my goodgoodgood")
+                                case .myShortcut, .myLovingShortcut, .myDownloadShortcut:
+                                    print("my goodgoodgood")
                                 default: // 카테고리일 경우
-                                    if let categoryName {
-                                        shortcutsZipViewModel.fetchCategoryShortcutLimit(category: categoryName, orderBy: "numberOfDownload") { newShortcuts in
+                                    print("** section nil")
+                                    if let categoryName = self.categoryName {
+                                        print("** category \(categoryName)")
+                                        shortcutsZipViewModel.fetchCategoryShortcutLimit(category: categoryName, orderBy: "date") { newShortcuts in
+                                            shortcuts.append(contentsOf: newShortcuts)
+                                        }
+                                    }
+                                }
+                                if self.sectionType == nil {
+                                    print("** section nil")
+                                    if let categoryName = self.categoryName {
+                                        print("** category \(categoryName)")
+                                        shortcutsZipViewModel.fetchCategoryShortcutLimit(category: categoryName, orderBy: "date") { newShortcuts in
                                             shortcuts.append(contentsOf: newShortcuts)
                                         }
                                     }

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTagView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTagView.swift
@@ -124,11 +124,12 @@ struct WriteShortcutTagView: View {
                 } else {
                     //새로운 단축어 생성 및 저장
                     // 뷰모델에 추가
-                    print("**\(shortcut.category)")
                     shortcutsZipViewModel.shortcutsMadeByUser.insert(shortcut, at: 0)
                     shortcutsZipViewModel.sortedShortcutsByDownload.append(shortcut)
                     shortcut.category.forEach { category in
-                        shortcutsZipViewModel.shortcutsInCategory[Category(rawValue: category)!.index].append(shortcut)
+                        if !shortcutsZipViewModel.isFirstFetchInCategory[Category(rawValue: category)!.index] {
+                            shortcutsZipViewModel.shortcutsInCategory[Category(rawValue: category)!.index].insert(shortcut, at: 0)
+                        }
                     }
                     
                     // 서버에 추가

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTagView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTagView.swift
@@ -17,6 +17,7 @@ struct WriteShortcutTagView: View {
     @State var isShowingCategoryModal = false
     @State var isRequirementValid = false
     
+    @State var existingCategory: [String] = []
     let isEdit: Bool
     
     var body: some View {
@@ -65,13 +66,31 @@ struct WriteShortcutTagView: View {
             Spacer()
             
             Button(action: {
-                //새로운 단축어 생성 및 저장
-                // 뷰모델에 추가
-                shortcutsZipViewModel.shortcutsMadeByUser.insert(shortcut, at: 0)
                 shortcut.author = shortcutsZipViewModel.currentUser()
-                // 서버에 추가
-                shortcutsZipViewModel.setData(model: shortcut)
+                
                 if isEdit {
+                    //뷰모델에서 변경
+                    if let index = shortcutsZipViewModel.shortcutsUserLiked.firstIndex(where: { $0.id == shortcut.id}) {
+                        shortcutsZipViewModel.shortcutsUserLiked[index] = shortcut
+                    }
+                    if let index = shortcutsZipViewModel.shortcutsUserDownloaded.firstIndex(where: { $0.id == shortcut.id}) {
+                        shortcutsZipViewModel.shortcutsUserDownloaded[index] = shortcut
+                    }
+                    if let index = shortcutsZipViewModel.shortcutsMadeByUser.firstIndex(where: { $0.id == shortcut.id}) {
+                        shortcutsZipViewModel.shortcutsMadeByUser[index] = shortcut
+                    }
+                    if let index = shortcutsZipViewModel.sortedShortcutsByDownload.firstIndex(where: { $0.id == shortcut.id}) {
+                        shortcutsZipViewModel.sortedShortcutsByDownload[index] = shortcut
+                    }
+                    if let index = shortcutsZipViewModel.sortedShortcutsByLike.firstIndex(where: { $0.id == shortcut.id}) {
+                        shortcutsZipViewModel.sortedShortcutsByLike[index] = shortcut
+                    }
+                    //뷰모델의 카테고리별 단축어 목록에서 정보 수정
+                    shortcut.category
+//                    shortcutsZipViewModel.shortcutsInCategory
+                    
+                    //서버 데이터 변경
+                    shortcutsZipViewModel.setData(model: shortcut)
                     shortcutsZipViewModel.updateShortcutInCuration(
                         shortcutCell: ShortcutCellModel(
                             id: shortcut.id,
@@ -83,6 +102,13 @@ struct WriteShortcutTagView: View {
                         ),
                         curationIDs: shortcut.curationIDs
                     )
+                    
+                } else {
+                    //새로운 단축어 생성 및 저장
+                    // 뷰모델에 추가
+                    shortcutsZipViewModel.shortcutsMadeByUser.insert(shortcut, at: 0)
+                    // 서버에 추가
+                    shortcutsZipViewModel.setData(model: shortcut)
                 }
                 
                 isWriting.toggle()
@@ -100,6 +126,9 @@ struct WriteShortcutTagView: View {
             .disabled(shortcut.category.isEmpty || !isRequirementValid)
             .padding(.horizontal, 16)
             .padding(.bottom, 24)
+        }
+        .onAppear() {
+            existingCategory = shortcut.category
         }
         .navigationTitle(isEdit ? "단축어 편집" :"단축어 등록")
         .ignoresSafeArea(.keyboard)

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTagView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTagView.swift
@@ -18,6 +18,8 @@ struct WriteShortcutTagView: View {
     @State var isRequirementValid = false
     
     @State var existingCategory: [String] = []
+    @State var newCategory: [String] = []
+    
     let isEdit: Bool
     
     var body: some View {
@@ -67,8 +69,11 @@ struct WriteShortcutTagView: View {
             
             Button(action: {
                 shortcut.author = shortcutsZipViewModel.currentUser()
-                
+                print(shortcut.category)
                 if isEdit {
+                    
+                    newCategory = shortcut.category
+                    
                     //뷰모델에서 변경
                     if let index = shortcutsZipViewModel.shortcutsUserLiked.firstIndex(where: { $0.id == shortcut.id}) {
                         shortcutsZipViewModel.shortcutsUserLiked[index] = shortcut
@@ -86,8 +91,21 @@ struct WriteShortcutTagView: View {
                         shortcutsZipViewModel.sortedShortcutsByLike[index] = shortcut
                     }
                     //뷰모델의 카테고리별 단축어 목록에서 정보 수정
-                    shortcut.category
-//                    shortcutsZipViewModel.shortcutsInCategory
+                    existingCategory.forEach { category in
+                        if !shortcut.category.contains(category) {
+                            newCategory.removeAll(where: { $0 == category })
+                            //해당하는 카테고리의 인덱스를 받아와서 해당 배열에서 단축어 제거
+                            shortcutsZipViewModel.shortcutsInCategory[Category(rawValue: category)!.index].removeAll(where: { $0.id == shortcut.id })
+                        } else {
+                            newCategory.removeAll(where: { $0 == category })
+                            if let index = shortcutsZipViewModel.shortcutsInCategory[Category(rawValue: category)!.index].firstIndex(where: { $0.id == shortcut.id}) {
+                                shortcutsZipViewModel.shortcutsInCategory[Category(rawValue: category)!.index][index] = shortcut
+                            }
+                        }
+                    }
+                    newCategory.forEach { category in
+                        shortcutsZipViewModel.shortcutsInCategory[Category(rawValue: category)!.index].insert(shortcut, at: 0)
+                    }
                     
                     //서버 데이터 변경
                     shortcutsZipViewModel.setData(model: shortcut)
@@ -106,7 +124,13 @@ struct WriteShortcutTagView: View {
                 } else {
                     //새로운 단축어 생성 및 저장
                     // 뷰모델에 추가
+                    print("**\(shortcut.category)")
                     shortcutsZipViewModel.shortcutsMadeByUser.insert(shortcut, at: 0)
+                    shortcutsZipViewModel.sortedShortcutsByDownload.append(shortcut)
+                    shortcut.category.forEach { category in
+                        shortcutsZipViewModel.shortcutsInCategory[Category(rawValue: category)!.index].append(shortcut)
+                    }
+                    
                     // 서버에 추가
                     shortcutsZipViewModel.setData(model: shortcut)
                 }


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #234 

## 구현/변경 사항
- 단축어 수정 시 중복해서 생기는 아이템 제거
- 단축어 카테고리 리스트 pagination 구현

## 남은 이슈
- 내가 좋아요한 / 다운로드한 단축어 pagination
- 내가 작성한 단축어 / 큐레이션 pagination
- pagination으로 맨 마지막 셀 도달 시 UI는 더이상 그리지 않지만 여전히 함수는 호출하여 서버 사용량 발생
- 유저가 앱을 사용하는 동안에는 유저가 작성하는 단축어가 아니면 단축어 리스트에 변경이 일어나지 않음