### PR TITLE
[Feat] 뷰모델 함수 로직 변경

### DIFF
--- a/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
+++ b/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
@@ -10,7 +10,8 @@
 		3D41EE08290A4C18008BE986 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3D41EE07290A4C18008BE986 /* Launch Screen.storyboard */; };
 		4D61A767291E1EE8000EF531 /* NavigationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D61A766291E1EE8000EF531 /* NavigationViewModel.swift */; };
 		4D778A34290A53BA00C15AC4 /* Application+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D778A33290A53BA00C15AC4 /* Application+Extension.swift */; };
-		4DAD635A292AB2BC00ABF8C1 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4DAD6359292AB2BC00ABF8C1 /* GoogleService-Info.plist */; };
+		4DAD635C292AB5A800ABF8C1 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4DAD635B292AB5A800ABF8C1 /* GoogleService-Info.plist */; };
+		4DAD635E292AB61700ABF8C1 /* UpdateShortcutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DAD635D292AB61700ABF8C1 /* UpdateShortcutView.swift */; };
 		872A7D8F2918393B004A05B8 /* PrivacyPolicyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872A7D8E2918393B004A05B8 /* PrivacyPolicyView.swift */; };
 		8764C0D7291F85DF00E1593B /* NavigationStackModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8764C0D6291F85DF00E1593B /* NavigationStackModel.swift */; };
 		8788374A2920D549009B3F54 /* Binding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878837492920D549009B3F54 /* Binding.swift */; };
@@ -110,7 +111,8 @@
 		3D41EE07290A4C18008BE986 /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
 		4D61A766291E1EE8000EF531 /* NavigationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationViewModel.swift; sourceTree = "<group>"; };
 		4D778A33290A53BA00C15AC4 /* Application+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Application+Extension.swift"; sourceTree = "<group>"; };
-		4DAD6359292AB2BC00ABF8C1 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
+		4DAD635B292AB5A800ABF8C1 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
+		4DAD635D292AB61700ABF8C1 /* UpdateShortcutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateShortcutView.swift; sourceTree = "<group>"; };
 		872A7D8E2918393B004A05B8 /* PrivacyPolicyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyPolicyView.swift; sourceTree = "<group>"; };
 		8764C0D6291F85DF00E1593B /* NavigationStackModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationStackModel.swift; sourceTree = "<group>"; };
 		878837492920D549009B3F54 /* Binding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Binding.swift; sourceTree = "<group>"; };
@@ -336,6 +338,7 @@
 			children = (
 				A04ACB3029068688004A85A6 /* ReadShortcutView */,
 				87E99CAE28FFF26A009B691F /* EditShortcutView.swift */,
+				4DAD635D292AB61700ABF8C1 /* UpdateShortcutView.swift */,
 			);
 			path = ShortcutDetailViews;
 			sourceTree = "<group>";
@@ -643,6 +646,7 @@
 				A3B2636A2909DFD200829DE1 /* CurationListView.swift in Sources */,
 				87E99CC128FFF2B5009B691F /* CategoryModalView.swift in Sources */,
 				87E606B829114FB200C3DA13 /* UserAuth.swift in Sources */,
+				4DAD635E292AB61700ABF8C1 /* UpdateShortcutView.swift in Sources */,
 				87E99C9F28FFF21B009B691F /* SettingView.swift in Sources */,
 				A04ACB32290686AA004A85A6 /* ReadShortcutHeaderView.swift in Sources */,
 				87E99CA928FFF24F009B691F /* ExploreShortcutView.swift in Sources */,

--- a/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
+++ b/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
@@ -70,6 +70,8 @@
 		A04ACB32290686AA004A85A6 /* ReadShortcutHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04ACB31290686AA004A85A6 /* ReadShortcutHeaderView.swift */; };
 		A04ACB34290686C7004A85A6 /* ReadShortcutContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04ACB33290686C7004A85A6 /* ReadShortcutContentView.swift */; };
 		A09CBA7E2922B36C00D31F5F /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09CBA7D2922B36C00D31F5F /* String+Extension.swift */; };
+		A0DD085729276608008177BB /* URL+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0DD085629276608008177BB /* URL+Extension.swift */; };
+		A0DD0875292B53A6008177BB /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = A0DD0874292B53A6008177BB /* GoogleService-Info.plist */; };
 		A0F822AC2910B8F100AF4448 /* ShortcutsZipViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F822AB2910B8F100AF4448 /* ShortcutsZipViewModel.swift */; };
 		A0F822B729164D2300AF4448 /* ShortcutsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F822B629164D2300AF4448 /* ShortcutsListView.swift */; };
 		A33F74AE2908D8C800B8D0D0 /* CheckBoxShortcutCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A33F74AD2908D8C800B8D0D0 /* CheckBoxShortcutCell.swift */; };
@@ -181,6 +183,8 @@
 		A04ACB31290686AA004A85A6 /* ReadShortcutHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadShortcutHeaderView.swift; sourceTree = "<group>"; };
 		A04ACB33290686C7004A85A6 /* ReadShortcutContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadShortcutContentView.swift; sourceTree = "<group>"; };
 		A09CBA7D2922B36C00D31F5F /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
+		A0DD085629276608008177BB /* URL+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Extension.swift"; sourceTree = "<group>"; };
+		A0DD0874292B53A6008177BB /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		A0F822AB2910B8F100AF4448 /* ShortcutsZipViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsZipViewModel.swift; sourceTree = "<group>"; };
 		A0F822B629164D2300AF4448 /* ShortcutsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsListView.swift; sourceTree = "<group>"; };
 		A33F74AD2908D8C800B8D0D0 /* CheckBoxShortcutCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckBoxShortcutCell.swift; sourceTree = "<group>"; };
@@ -244,11 +248,7 @@
 		87E99C6128F94EA6009B691F = {
 			isa = PBXGroup;
 			children = (
-				4DAD6363292B522B00ABF8C1 /* GoogleService-Info.plist */,
-				F9724BC6292A578400860F8A /* GoogleService-Info.plist */,
-				8706202B29265EF3004B47E1 /* GoogleService-Info.plist */,
-				8795A12B292973A0004B765F /* GoogleService-Info.plist */,
-				F9A3FA8B292BA48100F5791D /* GoogleService-Info.plist */,
+				A0DD0874292B53A6008177BB /* GoogleService-Info.plist */,
 				87E99C6C28F94EA6009B691F /* HappyAnding */,
 				87E99C7D28F94EA8009B691F /* HappyAndingTests */,
 				87E99C8728F94EA8009B691F /* HappyAndingUITests */,
@@ -400,6 +400,7 @@
 				8792478C2918CE450040D5C3 /* UINavigationContoller+Extension.swift */,
 				A09CBA7D2922B36C00D31F5F /* String+Extension.swift */,
 				878837492920D549009B3F54 /* Binding.swift */,
+				A0DD085629276608008177BB /* URL+Extension.swift */,
 				8795A16D292AB841004B765F /* View+Extension.swift */,
 				8795A16F292AB945004B765F /* UIScreen+Extension.swift */,
 			);
@@ -607,10 +608,9 @@
 			files = (
 				87E99C7528F94EA8009B691F /* Preview Assets.xcassets in Resources */,
 				A3FF018A2918F8EF00384211 /* apache.txt in Resources */,
-				F9A3FA8C292BA48100F5791D /* GoogleService-Info.plist in Resources */,
+				A0DD0875292B53A6008177BB /* GoogleService-Info.plist in Resources */,
 				87E99C7228F94EA8009B691F /* Assets.xcassets in Resources */,
 				3D41EE08290A4C18008BE986 /* Launch Screen.storyboard in Resources */,
-				4DAD6364292B522B00ABF8C1 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -644,6 +644,7 @@
 				87E99CAF28FFF26A009B691F /* EditShortcutView.swift in Sources */,
 				A0F822AC2910B8F100AF4448 /* ShortcutsZipViewModel.swift in Sources */,
 				87E99CC429014572009B691F /* Color+Extension.swift in Sources */,
+				A0DD085729276608008177BB /* URL+Extension.swift in Sources */,
 				87E99CD929042536009B691F /* SectionType.swift in Sources */,
 				872A7D8F2918393B004A05B8 /* PrivacyPolicyView.swift in Sources */,
 				8792479B291BDF820040D5C3 /* SearchView.swift in Sources */,

--- a/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
+++ b/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		3D41EE08290A4C18008BE986 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3D41EE07290A4C18008BE986 /* Launch Screen.storyboard */; };
-		3D6C61CF292A8CF2005F8483 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3D6C61CE292A8CF2005F8483 /* GoogleService-Info.plist */; };
 		4D61A767291E1EE8000EF531 /* NavigationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D61A766291E1EE8000EF531 /* NavigationViewModel.swift */; };
 		4D778A34290A53BA00C15AC4 /* Application+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D778A33290A53BA00C15AC4 /* Application+Extension.swift */; };
 		4DAD635A292AB2BC00ABF8C1 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4DAD6359292AB2BC00ABF8C1 /* GoogleService-Info.plist */; };
@@ -109,7 +108,6 @@
 /* Begin PBXFileReference section */
 		3D41EE06290A458B008BE986 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		3D41EE07290A4C18008BE986 /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
-		3D6C61CE292A8CF2005F8483 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		4D61A766291E1EE8000EF531 /* NavigationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationViewModel.swift; sourceTree = "<group>"; };
 		4D778A33290A53BA00C15AC4 /* Application+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Application+Extension.swift"; sourceTree = "<group>"; };
 		4DAD6359292AB2BC00ABF8C1 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -234,7 +232,7 @@
 		87E99C6128F94EA6009B691F = {
 			isa = PBXGroup;
 			children = (
-				3D6C61CE292A8CF2005F8483 /* GoogleService-Info.plist */,
+				4DAD6363292B522B00ABF8C1 /* GoogleService-Info.plist */,
 				87E99C6C28F94EA6009B691F /* HappyAnding */,
 				87E99C7D28F94EA8009B691F /* HappyAndingTests */,
 				87E99C8728F94EA8009B691F /* HappyAndingUITests */,
@@ -590,7 +588,7 @@
 				A3FF018A2918F8EF00384211 /* apache.txt in Resources */,
 				87E99C7228F94EA8009B691F /* Assets.xcassets in Resources */,
 				3D41EE08290A4C18008BE986 /* Launch Screen.storyboard in Resources */,
-				3D6C61CF292A8CF2005F8483 /* GoogleService-Info.plist in Resources */,
+				4DAD6364292B522B00ABF8C1 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
+++ b/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
@@ -17,6 +17,10 @@
 		8788374A2920D549009B3F54 /* Binding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878837492920D549009B3F54 /* Binding.swift */; };
 		8792478D2918CE450040D5C3 /* UINavigationContoller+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8792478C2918CE450040D5C3 /* UINavigationContoller+Extension.swift */; };
 		8792479B291BDF820040D5C3 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8792479A291BDF820040D5C3 /* SearchView.swift */; };
+		8795A16E292AB841004B765F /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8795A16D292AB841004B765F /* View+Extension.swift */; };
+		8795A170292AB945004B765F /* UIScreen+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8795A16F292AB945004B765F /* UIScreen+Extension.swift */; };
+		8795A172292ABFDE004B765F /* ReadShortcutVersionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8795A171292ABFDE004B765F /* ReadShortcutVersionView.swift */; };
+		8795A174292ACA50004B765F /* ReadShortcutCommentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8795A173292ACA50004B765F /* ReadShortcutCommentView.swift */; };
 		87E606B0291062F900C3DA13 /* AppleAuthCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E606AF291062F900C3DA13 /* AppleAuthCoordinator.swift */; };
 		87E606B22910649B00C3DA13 /* SignInWithAppleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E606B12910649B00C3DA13 /* SignInWithAppleView.swift */; };
 		87E606B629114F7D00C3DA13 /* WriteNicknameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E606B529114F7D00C3DA13 /* WriteNicknameView.swift */; };
@@ -84,6 +88,7 @@
 		F94B43632907B19A00987819 /* FirebaseFirestoreCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = F94B43622907B19A00987819 /* FirebaseFirestoreCombine-Community */; };
 		F9724BBF292755E400860F8A /* Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9724BBE292755E400860F8A /* Comment.swift */; };
 		F99569182901DC4D0060AAEF /* Font+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F99569172901DC4D0060AAEF /* Font+Extension.swift */; };
+		F9A3FA8C292BA48100F5791D /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = F9A3FA8B292BA48100F5791D /* GoogleService-Info.plist */; };
 		F9CAEF832914855900224B0A /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9CAEF822914855900224B0A /* Date+Extension.swift */; };
 		F9CAEF8429148CDD00224B0A /* ReadAdminCurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E99CA428FFF238009B691F /* ReadAdminCurationView.swift */; };
 		F9F4D36A2906E0B000DC8546 /* Navigationbar+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F4D3692906E0B000DC8546 /* Navigationbar+Extension.swift */; };
@@ -118,6 +123,10 @@
 		878837492920D549009B3F54 /* Binding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Binding.swift; sourceTree = "<group>"; };
 		8792478C2918CE450040D5C3 /* UINavigationContoller+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationContoller+Extension.swift"; sourceTree = "<group>"; };
 		8792479A291BDF820040D5C3 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
+		8795A16D292AB841004B765F /* View+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
+		8795A16F292AB945004B765F /* UIScreen+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScreen+Extension.swift"; sourceTree = "<group>"; };
+		8795A171292ABFDE004B765F /* ReadShortcutVersionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadShortcutVersionView.swift; sourceTree = "<group>"; };
+		8795A173292ACA50004B765F /* ReadShortcutCommentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadShortcutCommentView.swift; sourceTree = "<group>"; };
 		87E606AD2910623C00C3DA13 /* HappyAnding.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = HappyAnding.entitlements; sourceTree = "<group>"; };
 		87E606AF291062F900C3DA13 /* AppleAuthCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleAuthCoordinator.swift; sourceTree = "<group>"; };
 		87E606B12910649B00C3DA13 /* SignInWithAppleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInWithAppleView.swift; sourceTree = "<group>"; };
@@ -186,6 +195,7 @@
 		F94B432D2907088400987819 /* UserCurationListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserCurationListView.swift; sourceTree = "<group>"; };
 		F9724BBE292755E400860F8A /* Comment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comment.swift; sourceTree = "<group>"; };
 		F99569172901DC4D0060AAEF /* Font+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+Extension.swift"; sourceTree = "<group>"; };
+		F9A3FA8B292BA48100F5791D /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../plist69/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		F9CAEF822914855900224B0A /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
 		F9F4D3692906E0B000DC8546 /* Navigationbar+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Navigationbar+Extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -235,6 +245,10 @@
 			isa = PBXGroup;
 			children = (
 				4DAD6363292B522B00ABF8C1 /* GoogleService-Info.plist */,
+				F9724BC6292A578400860F8A /* GoogleService-Info.plist */,
+				8706202B29265EF3004B47E1 /* GoogleService-Info.plist */,
+				8795A12B292973A0004B765F /* GoogleService-Info.plist */,
+				F9A3FA8B292BA48100F5791D /* GoogleService-Info.plist */,
 				87E99C6C28F94EA6009B691F /* HappyAnding */,
 				87E99C7D28F94EA8009B691F /* HappyAndingTests */,
 				87E99C8728F94EA8009B691F /* HappyAndingUITests */,
@@ -386,6 +400,8 @@
 				8792478C2918CE450040D5C3 /* UINavigationContoller+Extension.swift */,
 				A09CBA7D2922B36C00D31F5F /* String+Extension.swift */,
 				878837492920D549009B3F54 /* Binding.swift */,
+				8795A16D292AB841004B765F /* View+Extension.swift */,
+				8795A16F292AB945004B765F /* UIScreen+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -450,6 +466,8 @@
 				87E99CAC28FFF261009B691F /* ReadShortcutView.swift */,
 				A04ACB31290686AA004A85A6 /* ReadShortcutHeaderView.swift */,
 				A04ACB33290686C7004A85A6 /* ReadShortcutContentView.swift */,
+				8795A171292ABFDE004B765F /* ReadShortcutVersionView.swift */,
+				8795A173292ACA50004B765F /* ReadShortcutCommentView.swift */,
 			);
 			path = ReadShortcutView;
 			sourceTree = "<group>";
@@ -589,6 +607,7 @@
 			files = (
 				87E99C7528F94EA8009B691F /* Preview Assets.xcassets in Resources */,
 				A3FF018A2918F8EF00384211 /* apache.txt in Resources */,
+				F9A3FA8C292BA48100F5791D /* GoogleService-Info.plist in Resources */,
 				87E99C7228F94EA8009B691F /* Assets.xcassets in Resources */,
 				3D41EE08290A4C18008BE986 /* Launch Screen.storyboard in Resources */,
 				4DAD6364292B522B00ABF8C1 /* GoogleService-Info.plist in Resources */,
@@ -635,9 +654,11 @@
 				87E99CBF28FFF2AB009B691F /* WriteShortcutTagView.swift in Sources */,
 				A3766B232904330300708F83 /* ReadUserCurationView.swift in Sources */,
 				87E606B0291062F900C3DA13 /* AppleAuthCoordinator.swift in Sources */,
+				8795A170292AB945004B765F /* UIScreen+Extension.swift in Sources */,
 				A04ACB0A29041CD8004A85A6 /* DownloadRankView.swift in Sources */,
 				87E99CD1290145DE009B691F /* PaletteView.swift in Sources */,
 				87E99CDB29042CCA009B691F /* Category.swift in Sources */,
+				8795A16E292AB841004B765F /* View+Extension.swift in Sources */,
 				A04ACB062903D0B2004A85A6 /* MyShortcutCardView.swift in Sources */,
 				87E99CA728FFF23E009B691F /* ListCurationView.swift in Sources */,
 				F9CAEF832914855900224B0A /* Date+Extension.swift in Sources */,
@@ -657,6 +678,7 @@
 				87E99CCF290145D5009B691F /* PaletteCell.swift in Sources */,
 				87E99CC7290145AD009B691F /* ShortcutCell.swift in Sources */,
 				87E99CAB28FFF256009B691F /* ExploreCategoryView.swift in Sources */,
+				8795A172292ABFDE004B765F /* ReadShortcutVersionView.swift in Sources */,
 				87E99CBB28FFF298009B691F /* IconModalView.swift in Sources */,
 				87E99C7028F94EA6009B691F /* ShortcutTabView.swift in Sources */,
 				F99569182901DC4D0060AAEF /* Font+Extension.swift in Sources */,
@@ -676,6 +698,7 @@
 				87E99C6E28F94EA6009B691F /* HappyAndingApp.swift in Sources */,
 				87E99CD32901465F009B691F /* ValidationCheckTextField.swift in Sources */,
 				A3FF01882918581E00384211 /* LicenseView.swift in Sources */,
+				8795A174292ACA50004B765F /* ReadShortcutCommentView.swift in Sources */,
 				A04ACB0C29041CEE004A85A6 /* LovedShortcutView.swift in Sources */,
 				A09CBA7E2922B36C00D31F5F /* String+Extension.swift in Sources */,
 				87E99CB528FFF282009B691F /* WriteCurationInfoView.swift in Sources */,

--- a/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
+++ b/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		3D6C61CF292A8CF2005F8483 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3D6C61CE292A8CF2005F8483 /* GoogleService-Info.plist */; };
 		4D61A767291E1EE8000EF531 /* NavigationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D61A766291E1EE8000EF531 /* NavigationViewModel.swift */; };
 		4D778A34290A53BA00C15AC4 /* Application+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D778A33290A53BA00C15AC4 /* Application+Extension.swift */; };
+		4DAD635A292AB2BC00ABF8C1 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4DAD6359292AB2BC00ABF8C1 /* GoogleService-Info.plist */; };
 		872A7D8F2918393B004A05B8 /* PrivacyPolicyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872A7D8E2918393B004A05B8 /* PrivacyPolicyView.swift */; };
 		8764C0D7291F85DF00E1593B /* NavigationStackModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8764C0D6291F85DF00E1593B /* NavigationStackModel.swift */; };
 		8788374A2920D549009B3F54 /* Binding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878837492920D549009B3F54 /* Binding.swift */; };
@@ -111,6 +112,7 @@
 		3D6C61CE292A8CF2005F8483 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		4D61A766291E1EE8000EF531 /* NavigationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationViewModel.swift; sourceTree = "<group>"; };
 		4D778A33290A53BA00C15AC4 /* Application+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Application+Extension.swift"; sourceTree = "<group>"; };
+		4DAD6359292AB2BC00ABF8C1 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		872A7D8E2918393B004A05B8 /* PrivacyPolicyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyPolicyView.swift; sourceTree = "<group>"; };
 		8764C0D6291F85DF00E1593B /* NavigationStackModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationStackModel.swift; sourceTree = "<group>"; };
 		878837492920D549009B3F54 /* Binding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Binding.swift; sourceTree = "<group>"; };

--- a/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
+++ b/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		F9A3FA8C292BA48100F5791D /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = F9A3FA8B292BA48100F5791D /* GoogleService-Info.plist */; };
 		F9CAEF832914855900224B0A /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9CAEF822914855900224B0A /* Date+Extension.swift */; };
 		F9CAEF8429148CDD00224B0A /* ReadAdminCurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E99CA428FFF238009B691F /* ReadAdminCurationView.swift */; };
+		F9DEBAA7292AF70C004547BD /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = F9DEBAA6292AF70C004547BD /* GoogleService-Info.plist */; };
 		F9F4D36A2906E0B000DC8546 /* Navigationbar+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F4D3692906E0B000DC8546 /* Navigationbar+Extension.swift */; };
 /* End PBXBuildFile section */
 
@@ -201,6 +202,7 @@
 		F99569172901DC4D0060AAEF /* Font+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+Extension.swift"; sourceTree = "<group>"; };
 		F9A3FA8B292BA48100F5791D /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../plist69/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		F9CAEF822914855900224B0A /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
+		F9DEBAA6292AF70C004547BD /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../plist69/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		F9F4D3692906E0B000DC8546 /* Navigationbar+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Navigationbar+Extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -249,6 +251,7 @@
 			isa = PBXGroup;
 			children = (
 				A0DD0874292B53A6008177BB /* GoogleService-Info.plist */,
+				F9DEBAA6292AF70C004547BD /* GoogleService-Info.plist */,
 				87E99C6C28F94EA6009B691F /* HappyAnding */,
 				87E99C7D28F94EA8009B691F /* HappyAndingTests */,
 				87E99C8728F94EA8009B691F /* HappyAndingUITests */,
@@ -609,6 +612,7 @@
 				87E99C7528F94EA8009B691F /* Preview Assets.xcassets in Resources */,
 				A3FF018A2918F8EF00384211 /* apache.txt in Resources */,
 				A0DD0875292B53A6008177BB /* GoogleService-Info.plist in Resources */,
+				F9DEBAA7292AF70C004547BD /* GoogleService-Info.plist in Resources */,
 				87E99C7228F94EA8009B691F /* Assets.xcassets in Resources */,
 				3D41EE08290A4C18008BE986 /* Launch Screen.storyboard in Resources */,
 			);

--- a/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
+++ b/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
@@ -10,7 +10,6 @@
 		3D41EE08290A4C18008BE986 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3D41EE07290A4C18008BE986 /* Launch Screen.storyboard */; };
 		4D61A767291E1EE8000EF531 /* NavigationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D61A766291E1EE8000EF531 /* NavigationViewModel.swift */; };
 		4D778A34290A53BA00C15AC4 /* Application+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D778A33290A53BA00C15AC4 /* Application+Extension.swift */; };
-		4DAD635C292AB5A800ABF8C1 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4DAD635B292AB5A800ABF8C1 /* GoogleService-Info.plist */; };
 		4DAD635E292AB61700ABF8C1 /* UpdateShortcutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DAD635D292AB61700ABF8C1 /* UpdateShortcutView.swift */; };
 		872A7D8F2918393B004A05B8 /* PrivacyPolicyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872A7D8E2918393B004A05B8 /* PrivacyPolicyView.swift */; };
 		8764C0D7291F85DF00E1593B /* NavigationStackModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8764C0D6291F85DF00E1593B /* NavigationStackModel.swift */; };
@@ -90,10 +89,8 @@
 		F94B43632907B19A00987819 /* FirebaseFirestoreCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = F94B43622907B19A00987819 /* FirebaseFirestoreCombine-Community */; };
 		F9724BBF292755E400860F8A /* Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9724BBE292755E400860F8A /* Comment.swift */; };
 		F99569182901DC4D0060AAEF /* Font+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F99569172901DC4D0060AAEF /* Font+Extension.swift */; };
-		F9A3FA8C292BA48100F5791D /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = F9A3FA8B292BA48100F5791D /* GoogleService-Info.plist */; };
 		F9CAEF832914855900224B0A /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9CAEF822914855900224B0A /* Date+Extension.swift */; };
 		F9CAEF8429148CDD00224B0A /* ReadAdminCurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E99CA428FFF238009B691F /* ReadAdminCurationView.swift */; };
-		F9DEBAA7292AF70C004547BD /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = F9DEBAA6292AF70C004547BD /* GoogleService-Info.plist */; };
 		F9F4D36A2906E0B000DC8546 /* Navigationbar+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F4D3692906E0B000DC8546 /* Navigationbar+Extension.swift */; };
 /* End PBXBuildFile section */
 
@@ -119,7 +116,6 @@
 		3D41EE07290A4C18008BE986 /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
 		4D61A766291E1EE8000EF531 /* NavigationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationViewModel.swift; sourceTree = "<group>"; };
 		4D778A33290A53BA00C15AC4 /* Application+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Application+Extension.swift"; sourceTree = "<group>"; };
-		4DAD635B292AB5A800ABF8C1 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		4DAD635D292AB61700ABF8C1 /* UpdateShortcutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateShortcutView.swift; sourceTree = "<group>"; };
 		872A7D8E2918393B004A05B8 /* PrivacyPolicyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyPolicyView.swift; sourceTree = "<group>"; };
 		8764C0D6291F85DF00E1593B /* NavigationStackModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationStackModel.swift; sourceTree = "<group>"; };
@@ -200,9 +196,7 @@
 		F94B432D2907088400987819 /* UserCurationListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserCurationListView.swift; sourceTree = "<group>"; };
 		F9724BBE292755E400860F8A /* Comment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comment.swift; sourceTree = "<group>"; };
 		F99569172901DC4D0060AAEF /* Font+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+Extension.swift"; sourceTree = "<group>"; };
-		F9A3FA8B292BA48100F5791D /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../plist69/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		F9CAEF822914855900224B0A /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
-		F9DEBAA6292AF70C004547BD /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../plist69/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		F9F4D3692906E0B000DC8546 /* Navigationbar+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Navigationbar+Extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -251,7 +245,6 @@
 			isa = PBXGroup;
 			children = (
 				A0DD0874292B53A6008177BB /* GoogleService-Info.plist */,
-				F9DEBAA6292AF70C004547BD /* GoogleService-Info.plist */,
 				87E99C6C28F94EA6009B691F /* HappyAnding */,
 				87E99C7D28F94EA8009B691F /* HappyAndingTests */,
 				87E99C8728F94EA8009B691F /* HappyAndingUITests */,
@@ -612,7 +605,6 @@
 				87E99C7528F94EA8009B691F /* Preview Assets.xcassets in Resources */,
 				A3FF018A2918F8EF00384211 /* apache.txt in Resources */,
 				A0DD0875292B53A6008177BB /* GoogleService-Info.plist in Resources */,
-				F9DEBAA7292AF70C004547BD /* GoogleService-Info.plist in Resources */,
 				87E99C7228F94EA8009B691F /* Assets.xcassets in Resources */,
 				3D41EE08290A4C18008BE986 /* Launch Screen.storyboard in Resources */,
 			);

--- a/HappyAnding/HappyAnding/Extensions/Date+Extension.swift
+++ b/HappyAnding/HappyAnding/Extensions/Date+Extension.swift
@@ -18,3 +18,15 @@ extension Date {
         return formatter.string(from: current)
     }
 }
+
+extension String {
+    func getVersionUpdateDateFormat() -> String {
+        var date = self.substring(from: 0, to: 7)
+        let index1 = date.index(date.startIndex, offsetBy: 4)
+        let index2 = date.index(date.startIndex, offsetBy: 6)
+        date.insert(".", at: index2)
+        date.insert(".", at: index1)
+        
+        return date
+    }
+}

--- a/HappyAnding/HappyAnding/Extensions/String+Extension.swift
+++ b/HappyAnding/HappyAnding/Extensions/String+Extension.swift
@@ -37,5 +37,17 @@ extension String {
         }
         return true
     }
+    
+    // substring to string
+    func substring(from: Int, to: Int) -> String {
+        guard from < count, to >= 0, to - from >= 0 else {
+            return ""
+        }
+        
+        let startIndex = index(self.startIndex, offsetBy: from)
+        let endIndex = index(self.startIndex, offsetBy: to + 1)
+        
+        return String(self[startIndex ..< endIndex])
+    }
 }
 

--- a/HappyAnding/HappyAnding/Extensions/UIScreen+Extension.swift
+++ b/HappyAnding/HappyAnding/Extensions/UIScreen+Extension.swift
@@ -1,0 +1,14 @@
+//
+//  UIScreen.swift
+//  HappyAnding
+//
+//  Created by 이지원 on 2022/11/21.
+//
+
+import SwiftUI
+
+extension UIScreen {
+   static let screenWidth = UIScreen.main.bounds.size.width
+   static let screenHeight = UIScreen.main.bounds.size.height
+   static let screenSize = UIScreen.main.bounds.size
+}

--- a/HappyAnding/HappyAnding/Extensions/URL+Extension.swift
+++ b/HappyAnding/HappyAnding/Extensions/URL+Extension.swift
@@ -1,0 +1,34 @@
+//
+//  URL+Extension.swift
+//  HappyAnding
+//
+//  Created by KiWoong Hong on 2022/11/18.
+//
+
+import SwiftUI
+
+extension URL {
+    
+    // info 에서 추가한 딥링크가 들어왔는지 여부
+    var isDeeplink: Bool {
+        return scheme == "shortcutsZip"
+    }
+    
+    // url 들어오는 것으로 어떤 타입의 탭을 보여줘야 하는지 가져오기
+    // TabIdentifier 필요
+    var tabIdentifier: Tab? {
+        guard isDeeplink else { return nil }
+        
+        // shortcutsZip://host
+        switch host {
+        case "collect": return .collect
+        case "exploreShortcut": return .exploreShortcut
+        case "myPage": return .myPage
+        default: return nil
+        }
+    }
+    
+    // pageIdentifier 필요할 듯?
+  //  var detailPage:
+}
+

--- a/HappyAnding/HappyAnding/Extensions/URL+Extension.swift
+++ b/HappyAnding/HappyAnding/Extensions/URL+Extension.swift
@@ -16,7 +16,7 @@ extension URL {
     
     // url 들어오는 것으로 어떤 타입의 탭을 보여줘야 하는지 가져오기
     // TabIdentifier 필요
-    var tabIdentifier: Tab? {
+  /*  var tabIdentifier: Tab? {
         guard isDeeplink else { return nil }
         
         // shortcutsZip://host
@@ -27,7 +27,7 @@ extension URL {
         default: return nil
         }
     }
-    
+    */
     // pageIdentifier 필요할 듯?
   //  var detailPage:
 }

--- a/HappyAnding/HappyAnding/Extensions/View+Extension.swift
+++ b/HappyAnding/HappyAnding/Extensions/View+Extension.swift
@@ -1,0 +1,42 @@
+//
+//  View+Extension.swift
+//  HappyAnding
+//
+//  Created by 이지원 on 2022/11/21.
+//
+
+import SwiftUI
+
+extension View {
+    func readSize(onChange: @escaping (CGSize) -> Void) -> some View {
+        background(
+            GeometryReader { geometryProxy in
+                Color.clear
+                    .preference(key: SizePreferenceKey.self, value: geometryProxy.size)
+            }
+        )
+        .onPreferenceChange(SizePreferenceKey.self, perform: onChange)
+    }
+    
+    func swipeBack(perform action: @escaping () -> Void) -> some View {
+        gesture(
+            DragGesture()
+                .onEnded({ value in
+                    if value.translation.width > 50 {
+                        action()
+                    }
+                })
+        )
+    }
+    
+    func swipeForward(perform action: @escaping () -> Void) -> some View {
+        gesture(
+            DragGesture()
+                .onEnded({ value in
+                    if value.translation.width < 0 {
+                        action()
+                    }
+                })
+            )
+    }
+}

--- a/HappyAnding/HappyAnding/Info.plist
+++ b/HappyAnding/HappyAnding/Info.plist
@@ -2,10 +2,26 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.happyanding.HappyAnding</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>shortcutsZip</string>
+			</array>
+		</dict>
+		<dict/>
+	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>URL Schemes</key>
+	<string>shortcutsZip</string>
 </dict>
 </plist>

--- a/HappyAnding/HappyAnding/ViewModel/NavigationViewModel.swift
+++ b/HappyAnding/HappyAnding/ViewModel/NavigationViewModel.swift
@@ -8,10 +8,10 @@
 import SwiftUI
 
 class ShortcutNavigation: ObservableObject {
-    @Published var shortcutPath: NavigationPath
+    @Published var navigationPath: NavigationPath
     
     init() {
-        self.shortcutPath = NavigationPath()
+        self.navigationPath = NavigationPath()
     }
 }
 

--- a/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
+++ b/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
@@ -169,6 +169,7 @@ class ShortcutsZipViewModel: ObservableObject {
         shortcut.category.forEach { category in
             self.shortcutsInCategory[Category(rawValue: category)!.index].removeAll(where: { $0.id == shortcut.id })
         }
+        deleteShortcutInCuration(curationsIDs: shortcut.curationIDs, shortcutID: shortcut.id)
     }
     
     //MARK: Shortcut의 세부 정보를 가져오는 함수

--- a/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
+++ b/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
@@ -256,6 +256,34 @@ class ShortcutsZipViewModel: ObservableObject {
         return Array(shortcutCells)
     }
     
+    //MARK: 단축어 버전 업데이트하는 함수
+    
+    func updateShortcutVersion(shortcut: Shortcuts, updateDescription: String, updateLink: String) {
+        var data = shortcut
+        //서버 - 단축어 업데이트
+        data.downloadLink.insert(updateLink, at: 0)
+        data.updateDescription.insert(updateDescription, at: 0)
+        data.date.insert(Date().getDate(), at: 0)
+        
+        //카테고리별 단축어
+        shortcut.category.forEach { category in
+            if let index = shortcutsInCategory[Category(rawValue: category)!.index].firstIndex(where: { $0.id == shortcut.id}) {
+                shortcutsInCategory[Category(rawValue: category)!.index][index] = shortcut
+            }
+        }
+        setData(model: data)
+        
+        //서버 - 큐레이션 업데이트
+        let shortcutCell = ShortcutCellModel(
+            id: data.id,
+            sfSymbol: data.sfSymbol,
+            color: data.color,
+            title: data.title,
+            subtitle: data.subtitle,
+            downloadLink: data.downloadLink[0]
+        )
+        updateShortcutInCuration(shortcutCell: shortcutCell, curationIDs: data.curationIDs)
+    }
     
     //MARK: - 큐레이션
     

--- a/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
+++ b/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import FirebaseCore
 import FirebaseFirestore
+import FirebaseFirestoreSwift
 import FirebaseAuth
 
 /*
@@ -23,7 +24,7 @@ class ShortcutsZipViewModel: ObservableObject {
     @Published var shortcutsUserDownloaded: [Shortcuts] = []    // 유저가 다운로드한 숏컷들
     @Published var shortcutsMadeByUser: [Shortcuts] = []        // 유저가 만든 숏컷배열
     @Published var sortedShortcutsByDownload: [Shortcuts] = []  // 다운로드 수에 의해 정렬된 숏컷
-    @Published var sortedShortcutsByLike: [Shortcuts] = []  // 다운로드 수에 의해 정렬된 숏컷
+    @Published var sortedShortcutsByLike: [Shortcuts] = []      // 다운로드 수에 의해 정렬된 숏컷
     @Published var shortcutsInCategory: [[Shortcuts]] = [[Shortcuts]].init(repeating: [], count: Category.allCases.count) // Category에서 사용할 숏컷 배열
     @Published var isFirstFetchInCategory = [Bool] (repeating: true, count: Category.allCases.count) //카테고리를 리스트 첫 fetch여부
     @Published var isLastFetchInCategory = [Bool] (repeating: false, count: Category.allCases.count) //카테고리를 리스트 마지막 fetch여부
@@ -32,112 +33,52 @@ class ShortcutsZipViewModel: ObservableObject {
     @Published var userCurations: [Curation] = []
     @Published var adminCurations: [Curation] = []
     
-    @Published var keywords: Keyword = Keyword(keyword: [String]())
-    
     static let share = ShortcutsZipViewModel()
     private let db = Firestore.firestore()
     
-    var lastShortcutDocumentSnapshot = [QueryDocumentSnapshot?] (repeating: nil, count: 3)
-    var lastCurationDocumentSnapshot = [QueryDocumentSnapshot?] (repeating: nil, count: 3)
-    var lastCategoryDocumentSnapshot = [QueryDocumentSnapshot?] (repeating: nil, count: 12)
-    var lastSearchShortcutDocumentSnapshot: QueryDocumentSnapshot?
-    
     let numberOfPageLimit = 10
-    let numberOfLike = 5
+    let minimumOfLike = 5
     
+    var allShortcuts: [Shortcuts] = []
+
     init() {
-        
-        fetchShortcutLimit(orderBy: "numberOfDownload") { shortcuts in
-            self.sortedShortcutsByDownload = shortcuts
-        }
-        fetchShortcutLimitByLiked { shortcuts in
-            self.sortedShortcutsByLike = shortcuts
-        }
-        fetchCurationLimit(isAdmin: true) { curations in
-            self.adminCurations = curations
-        }
-        fetchCurationLimit(isAdmin: false) { curations in
-            self.userCurations = curations
-        }
-        initUserInfo()
-        fetchKeyword { keywords in
-            self.keywords = keywords
-        }
-    }
-    
-    func initUserInfo() {
-        fetchShortcutByAuthor(author: currentUser()) { shortcuts in
-            self.shortcutsMadeByUser = shortcuts
-        }
-        fetchCurationByAuthor(author: currentUser()) { curations in
-            self.curationsMadeByUser = curations
-        }
+        print("**init")
         fetchUser(userID: self.currentUser()) { user in
             self.userInfo = user
-            user.downloadedShortcuts.forEach { downloadedShortcut in
-                self.fetchShortcutDetail(id: downloadedShortcut.id) { shortcut in
-                    self.shortcutsUserDownloaded.append(shortcut)
-                }
-            }
-            self.fetchShortcutByIds(shortcutIds: user.likedShortcuts) { likedShortcuts in
-                self.shortcutsUserLiked = likedShortcuts
-            }
+            self.initUserShortcut(user: user)
+        }
+        fetchShortcutAll { shortcuts in
+            self.allShortcuts = shortcuts
+            self.initShortcut()
+        }
+        fetchCuration(isAdmin: true) { curations in
+            self.adminCurations = curations
+        }
+        fetchCuration(isAdmin: false) { curations in
+            self.userCurations = curations
+            self.curationsMadeByUser = self.fetchCurationByAuthor(author: self.currentUser())
         }
     }
     
-    //MARK: 키워드 받아오는 함수
-    func fetchKeyword(completionHandler: @escaping (Keyword)->()) {
-        var _: [String] = []
-        db.collection("Keyword").getDocuments { querySnapshot, error in
-            if let error {
-                print("Error getting documents: \(error)")
-            } else {
-                guard let documents = querySnapshot?.documents else { return }
-                let decoder = JSONDecoder()
-                for document in documents {
-                    do {
-                        let data = document.data()
-                        let jsonData = try JSONSerialization.data(withJSONObject: data)
-                        let keyword = try decoder.decode(Keyword.self, from: jsonData)
-                        completionHandler(keyword)
-                    } catch let error {
-                        print("error: \(error)")
-                    }
-                }
+    func initUserShortcut(user: User) {
+        shortcutsMadeByUser = allShortcuts.filter { $0.author == user.id }
+        user.downloadedShortcuts.forEach({ downloadedShortcut in
+            if let index = allShortcuts.firstIndex(where: {$0.id == downloadedShortcut.id}) {
+                shortcutsUserDownloaded.append(allShortcuts[index])
             }
-        }
+        })
+        user.likedShortcuts.forEach({ shortcutID in
+            if let index = allShortcuts.firstIndex(where: {$0.id == shortcutID}) {
+                shortcutsUserLiked.append(allShortcuts[index])
+            }
+        })
     }
-    //MARK: 단축어 정렬기준에 따라 마지막 데이터가 저장된 인덱스 값을 반환하는 함수
-    
-    func checkShortcutIndex(orderBy: String) -> Int {
-        
-        var index = -1
-        
-        switch orderBy {
-        case "numberOfDownload":
-            index = 0
-        case "numberOfLike":
-            index = 1
-        case "author":
-            index = 2
-        default:
-            index = 0
+    func initShortcut() {
+        sortedShortcutsByDownload = allShortcuts.sorted(by: {$0.numberOfDownload > $1.numberOfDownload})
+        sortedShortcutsByLike = allShortcuts.filter { $0.numberOfLike > minimumOfLike }
+        for category in Category.allCases {
+            shortcutsInCategory[category.index] = allShortcuts.filter { $0.category.contains(category.rawValue) }
         }
-        return index
-    }
-    
-    //MARK: 큐레이션 정렬기준에 따라 마지막 데이터가 저장된 인덱스 값을 반환하는 함수
-    
-    func checkCurationIndex(isAdmin: Bool) -> Int {
-        var index = -1
-        
-        switch isAdmin {
-        case true:
-            index = 0
-        case false:
-            index = 1
-        }
-        return index
     }
     
     
@@ -145,370 +86,185 @@ class ShortcutsZipViewModel: ObservableObject {
     
     //MARK: - 단축어
     
-    //MARK: 단축어를 (다운로드 수, 좋아요 수) 정렬 및 10개씩 가져오는 함수 (단축어 둘러보기)
-    
-    func fetchShortcutLimit(
-        orderBy: String,
+    func fetchShortcutAll(
         completionHandler: @escaping ([Shortcuts])->()) {
             
             var shortcuts: [Shortcuts] = []
             var query: Query!
-            let index = checkShortcutIndex(orderBy: orderBy)
             
-            if let next = self.lastShortcutDocumentSnapshot[index] {
-                query  = db.collection("Shortcut")
-                    .order(by: orderBy, descending: true)
-                    .limit(to: numberOfPageLimit)
-                    .start(afterDocument: next)
-            } else {
-                query = db.collection("Shortcut")
-                    .order(by: orderBy, descending: true)
-                    .limit(to: numberOfPageLimit)
-            }
+            query = db.collection("Shortcut").order(by: "date", descending: false)
             
-            query.getDocuments() { querySnapshot, error in
-                if let error {
-                    print("Error getting documents: \(error)")
-                } else {
-                    guard let documents = querySnapshot?.documents else { return }
-                    let decoder = JSONDecoder()
-                    for document in documents {
-                        do {
-                            let data = document.data()
-                            let jsonData = try JSONSerialization.data(withJSONObject: data)
-                            let shortcut = try decoder.decode(Shortcuts.self, from: jsonData)
-                            shortcuts.append(shortcut)
-                        } catch let error {
-                            print("error: \(error)")
-                        }
-                    }
-                    self.lastShortcutDocumentSnapshot[index] = documents.last
-                    completionHandler(shortcuts)
+            query.addSnapshotListener { snapshot, error in
+                guard let snapshot else {
+                    print("Error fetching snapshots: \(error!)")
+                    return
                 }
-            }
-        }
-    
-    //MARK: 좋아요가 numberOfLike보다 크거나 같은 단축어를 10개씩 가져오는 함수 (단축어 둘러보기)
-    
-    func fetchShortcutLimitByLiked(completionHandler: @escaping ([Shortcuts])->()) {
-            
-            var shortcuts: [Shortcuts] = []
-            var query: Query!
-            let index = 1
-            
-            if let next = self.lastShortcutDocumentSnapshot[index] {
-                query  = db.collection("Shortcut")
-                    .whereField("numberOfLike", isGreaterThan: numberOfLike)
-                    .limit(to: numberOfPageLimit)
-                    .start(afterDocument: next)
-            } else {
-                query = db.collection("Shortcut")
-                    .whereField("numberOfLike", isGreaterThan: numberOfLike)
-                    .limit(to: numberOfPageLimit)
-            }
-            
-            query.getDocuments() { querySnapshot, error in
-                if let error {
-                    print("Error getting documents: \(error)")
-                } else {
-                    guard let documents = querySnapshot?.documents else { return }
-                    let decoder = JSONDecoder()
-                    for document in documents {
-                        do {
-                            let data = document.data()
-                            let jsonData = try JSONSerialization.data(withJSONObject: data)
-                            let shortcut = try decoder.decode(Shortcuts.self, from: jsonData)
-                            shortcuts.append(shortcut)
-                        } catch let error {
-                            print("error: \(error)")
-                        }
-                    }
-                    self.lastShortcutDocumentSnapshot[index] = documents.last
-                    completionHandler(shortcuts)
-                }
-            }
-        }
-    
-    //MARK: 선택한 카테고리에 해당하는 단축어를 정렬하여 10개씩 가져오는 함수 (카테고리 단축어)
-    
-    func fetchCategoryShortcutLimit(
-        category: Category,
-        orderBy: String,
-        completionHandler: @escaping ([Shortcuts])->()) {
-            var shortcuts: [Shortcuts] = []
-            
-            var query: Query!
-            let index = category.index
-            
-            if let next = self.lastCategoryDocumentSnapshot[index] {
-                query  = db.collection("Shortcut")
-                    .whereField("category", arrayContains: category.rawValue)
-                    .order(by: orderBy, descending: true)
-                    .limit(to: numberOfPageLimit)
-                    .start(afterDocument: next)
-            } else {
-                query = db.collection("Shortcut")
-                    .whereField("category", arrayContains: category.rawValue)
-                    .order(by: orderBy, descending: true)
-                    .limit(to: numberOfPageLimit)
-            }
-            
-            query.getDocuments() { (querySnapshot, error) in
-                if let error {
-                    print("Error getting documents: \(error)")
-                } else {
-                    guard let documents = querySnapshot?.documents else { return }
-                    let decoder = JSONDecoder()
-                    for document in documents {
-                        do {
-                            let data = document.data()
-                            let jsonData = try JSONSerialization.data(withJSONObject: data)
-                            let shortcut = try decoder.decode(Shortcuts.self, from: jsonData)
-                            shortcuts.append(shortcut)
-                        } catch let error {
-                            print("error: \(error)")
-                        }
-                    }
-                    self.lastCategoryDocumentSnapshot[category.index] = documents.last
-                    completionHandler(shortcuts)
-                }
-            }
-        }
-    
-    // MARK: 현재 user가 만들었던 shortcuts을 10개씩 받아오는 함수 (나의 단축어)
-    
-    func fetchShortcutByAuthor(author: String, completionHandler: @escaping ([Shortcuts])->()) {
-        
-        var shortcuts: [Shortcuts] = []
-        
-        db.collection("Shortcut")
-            .whereField("author", isEqualTo: author)
-            .order(by: "date", descending: true)
-//            .limit(to: numberOfPageLimit)
-            .getDocuments { (querySnapshot, error) in
-                if let error {
-                    print("Error getting documents: \(error)")
-                } else {
-                    guard let documents = querySnapshot?.documents else { return }
+                snapshot.documentChanges.forEach { diff in
                     let decoder = JSONDecoder()
                     
-                    for document in documents {
-                        do {
-                            let data = document.data()
-                            let jsonData = try JSONSerialization.data(withJSONObject: data)
-                            let shortcut = try decoder.decode(Shortcuts.self, from: jsonData)
-                            shortcuts.append(shortcut)
-                        } catch let error {
-                            print("error: \(error)")
-                        }
-                    }
-                    completionHandler(shortcuts)
-                }
-            }
-    }
-    
-    // MARK: shortcut Id 배열로 shortcut 배열 가져오는 함수
-    
-    func fetchShortcutByIds(shortcutIds: [String], completionHandler: @escaping ([Shortcuts])->()) {
-        
-        var shortcuts: [Shortcuts] = []
-        
-        for shortcutId in shortcutIds {
-            db.collection("Shortcut")
-                .whereField("id", isEqualTo: shortcutId)
-                .getDocuments { (querySnapshot, error) in
-                    if let error {
-                        print("Error getting documents: \(error)")
-                    } else {
-                        guard let documents = querySnapshot?.documents else { return }
-                        let decoder = JSONDecoder()
-                        
-                        for document in documents {
-                            do {
-                                let data = document.data()
-                                let jsonData = try JSONSerialization.data(withJSONObject: data)
-                                let shortcut = try decoder.decode(Shortcuts.self, from: jsonData)
-                                shortcuts.append(shortcut)
-                            } catch let error {
-                                print("error: \(error)")
-                            }
-                        }
-                        completionHandler(shortcuts)
-                    }
-                }
-        }
-    }
-    
-    //MARK: Curation -> ShortcutDetail로 이동 시 Shortcut의 세부 정보를 가져오는 함수
-    
-    func fetchShortcutDetail(id: String, completionHandler: @escaping (Shortcuts)->()) {
-        db.collection("Shortcut").whereField("id", isEqualTo: id).getDocuments { (querySnapshot, error) in
-            if let error {
-                print("Error getting documents: \(error)")
-            } else {
-                guard let documents = querySnapshot?.documents else { return }
-                let decoder = JSONDecoder()
-                
-                for document in documents {
                     do {
-                        let data = document.data()
+                        let data = diff.document.data()
                         let jsonData = try JSONSerialization.data(withJSONObject: data)
                         let shortcut = try decoder.decode(Shortcuts.self, from: jsonData)
-                        completionHandler(shortcut)
+                        
+                        if (diff.type == .added) {
+                            shortcuts.insert(shortcut, at: 0)
+                            self.sortedShortcutsByDownload.append(shortcut)
+                            shortcut.category.forEach { category in
+                                self.shortcutsInCategory[Category(rawValue: category)!.index].insert(shortcut, at: 0)
+                            }
+                        }
+                        if (diff.type == .modified) {
+                            if let index = shortcuts.firstIndex(where: { $0.id == shortcut.id}) {
+                                shortcuts[index] = shortcut
+                            }
+                            self.updateShortcutInList(shortcut: shortcut)
+                        }
+                        if (diff.type == .removed) {
+                            shortcuts.removeAll(where: { $0.id == shortcut.id})
+                            self.deleteShortcutInList(shortcut: shortcut)
+                        }
                     } catch let error {
                         print("error: \(error)")
                     }
                 }
+                completionHandler(shortcuts)
             }
         }
+    
+    func updateShortcutInList(shortcut: Shortcuts) {
+        if let index = self.allShortcuts.firstIndex(where: {$0.id == shortcut.id}) {
+            self.allShortcuts[index] = shortcut
+        }
+        if let index = self.shortcutsUserLiked.firstIndex(where: { $0.id == shortcut.id}) {
+            self.shortcutsUserLiked[index] = shortcut
+        }
+        if let index = self.shortcutsUserDownloaded.firstIndex(where: { $0.id == shortcut.id}) {
+            self.shortcutsUserDownloaded[index] = shortcut
+        }
+        if let index = self.shortcutsMadeByUser.firstIndex(where: { $0.id == shortcut.id}) {
+            self.shortcutsMadeByUser[index] = shortcut
+        }
+        if let index = self.sortedShortcutsByDownload.firstIndex(where: { $0.id == shortcut.id}) {
+            self.sortedShortcutsByDownload[index] = shortcut
+        }
+        if shortcut.numberOfLike >= 5 {
+            self.sortedShortcutsByLike.append(shortcut)
+        }
+        //카테고리별 리스트에서 처리
+    }
+    
+    func deleteShortcutInList(shortcut: Shortcuts) {
+        self.allShortcuts.removeAll(where: {$0.id == shortcut.id})
+        self.shortcutsUserLiked.removeAll(where: {$0.id == shortcut.id})
+        self.shortcutsUserDownloaded.removeAll(where: {$0.id == shortcut.id})
+        self.shortcutsMadeByUser.removeAll(where: {$0.id == shortcut.id})
+        self.sortedShortcutsByDownload.removeAll(where: {$0.id == shortcut.id})
+        self.sortedShortcutsByLike.removeAll(where: {$0.id == shortcut.id})
+        shortcut.category.forEach { category in
+            self.shortcutsInCategory[Category(rawValue: category)!.index].removeAll(where: { $0.id == shortcut.id })
+        }
+    }
+    
+    //MARK: Shortcut의 세부 정보를 가져오는 함수
+    
+    func fetchShortcutDetail(id: String) -> Shortcuts? {
+        if let index = allShortcuts.firstIndex(where: {$0.id == id}) {
+            return allShortcuts[index]
+        }
+        return nil
     }
     
     //MARK: ReadShortcutView에서 해당 단축어에 좋아요를 눌렀는지 확인하는 함수 completionHandler로 bool값을 전달
     
-    func checkLikedShortrcut(shortcutID: String, completionHandler: @escaping (Bool)->()) {
-        var result = false
-        fetchUser(userID: currentUser()) { data in
-            result = data.likedShortcuts.contains(shortcutID)
-            completionHandler(result)
-        }
+    func checkLikedShortrcut(shortcutID: String) -> Bool {
+        userInfo?.likedShortcuts.contains(shortcutID) ?? false
     }
     
     //MARK: 현재 사용자가 작성한 Shortcuts -> ShortcutCellModel 형태로 변환하여 가져오는 함수 -> 큐레이션 작성
     
-    func fetchMadeShortcutCell(completionHandler: @escaping ([ShortcutCellModel])->()) {
+    func fetchMadeShortcutCell() -> [ShortcutCellModel] {
         var shortcutCells: [ShortcutCellModel] = []
         
-        db.collection("Shortcut")
-            .whereField("author", isEqualTo: currentUser())
-            .getDocuments() { (querySnapshot, error) in
-                if let error {
-                    print("Error getting documents: \(error)")
-                } else {
-                    guard let documents = querySnapshot?.documents else { return }
-                    let decoder = JSONDecoder()
-                    for document in documents {
-                        do {
-                            let data = document.data()
-                            let jsonData = try JSONSerialization.data(withJSONObject: data)
-                            let shortcut = try decoder.decode(Shortcuts.self, from: jsonData)
-                            let shortcutCell = ShortcutCellModel(
-                                id: shortcut.id,
-                                sfSymbol: shortcut.sfSymbol,
-                                color: shortcut.color,
-                                title: shortcut.title,
-                                subtitle: shortcut.subtitle,
-                                downloadLink: shortcut.downloadLink.last!
-                            )
-                            shortcutCells.append(shortcutCell)
-                        } catch let error {
-                            print("error: \(error)")
-                        }
-                    }
-                    completionHandler(shortcutCells)
-                }
-            }
+        for shortcut in shortcutsMadeByUser {
+            let shortcutCell = ShortcutCellModel(
+                id: shortcut.id,
+                sfSymbol: shortcut.sfSymbol,
+                color: shortcut.color,
+                title: shortcut.title,
+                subtitle: shortcut.subtitle,
+                downloadLink: shortcut.downloadLink[0]
+            )
+            shortcutCells.append(shortcutCell)
+        }
+        return shortcutCells
     }
     
     // MARK: 현재 사용자가 좋아요한 Shortcuts -> ShortcutCellModel 형태로 변환 -> 큐레이션 작성
     
-    func fetchLikedShortcutCell(completionHandler: @escaping ([ShortcutCellModel])->()) {
+    func fetchLikedShortcutCell() -> [ShortcutCellModel] {
         var shortcutCells: [ShortcutCellModel] = []
         
-        self.fetchUser(userID: self.currentUser()) { user in
-            let shortcutIds = user.likedShortcuts
-            
-            for shortcutId in shortcutIds {
-                self.db.collection("Shortcut")
-                    .whereField("id", isEqualTo: shortcutId)
-                    .getDocuments { (querySnapshot, error) in
-                        if let error {
-                            print("Error getting documents: \(error)")
-                        } else {
-                            guard let documents = querySnapshot?.documents else { return }
-                            let decoder = JSONDecoder()
-                            
-                            for document in documents {
-                                do {
-                                    let data = document.data()
-                                    let jsonData = try JSONSerialization.data(withJSONObject: data)
-                                    let shortcut = try decoder.decode(Shortcuts.self, from: jsonData)
-                                    let shortcutCell = ShortcutCellModel(
-                                        id: shortcut.id,
-                                        sfSymbol: shortcut.sfSymbol,
-                                        color: shortcut.color,
-                                        title: shortcut.title,
-                                        subtitle: shortcut.subtitle,
-                                        downloadLink: shortcut.downloadLink.last!
-                                    )
-                                    shortcutCells.append(shortcutCell)
-                                } catch let error {
-                                    print("error: \(error)")
-                                }
-                            }
-                            completionHandler(shortcutCells)
-                        }
-                    }
-            }
+        for shortcut in shortcutsUserLiked {
+            let shortcutCell = ShortcutCellModel(
+                id: shortcut.id,
+                sfSymbol: shortcut.sfSymbol,
+                color: shortcut.color,
+                title: shortcut.title,
+                subtitle: shortcut.subtitle,
+                downloadLink: shortcut.downloadLink[0]
+            )
+            shortcutCells.append(shortcutCell)
         }
+        return shortcutCells
+    }
+    
+    //MARK: 큐레이션 작성 - 선택 가능한 단축어 리스트
+    
+    func fetchShortcutMakeCuration() -> [ShortcutCellModel] {
+        var shortcutCells = Set<ShortcutCellModel>()
+        
+        for shortcut in shortcutsUserLiked {
+            let shortcutCell = ShortcutCellModel(
+                id: shortcut.id,
+                sfSymbol: shortcut.sfSymbol,
+                color: shortcut.color,
+                title: shortcut.title,
+                subtitle: shortcut.subtitle,
+                downloadLink: shortcut.downloadLink[0]
+            )
+            shortcutCells.insert(shortcutCell)
+        }
+        
+        for shortcut in shortcutsMadeByUser {
+            let shortcutCell = ShortcutCellModel(
+                id: shortcut.id,
+                sfSymbol: shortcut.sfSymbol,
+                color: shortcut.color,
+                title: shortcut.title,
+                subtitle: shortcut.subtitle,
+                downloadLink: shortcut.downloadLink[0]
+            )
+            shortcutCells.insert(shortcutCell)
+        }
+        
+        return Array(shortcutCells)
     }
     
     
     //MARK: - 큐레이션
     
+     
+    //MARK: Curation을 (admin, user) 구분하여 가져오는 함수
     
-    // MARK: Author에 의한 큐레이션들 받아오는 함수 (나의 큐레이션)
-    
-    func fetchCurationByAuthor (author: String, completionHandler: @escaping ([Curation])->()) {
-        
-        let index = 2
-        var curations: [Curation] = []
-        
-        db.collection("Curation")
-            .whereField("author", isEqualTo: author)
-            .order(by: "dateTime", descending: true)
-            .getDocuments { (querySnapshot, error) in
-                if let error {
-                    print("Error getting documents: \(error)")
-                } else {
-                    guard let documents = querySnapshot?.documents else { return }
-                    let decoder = JSONDecoder()
-                    
-                    for document in documents {
-                        do {
-                            let data = document.data()
-                            let jsonData = try JSONSerialization.data(withJSONObject: data)
-                            let curation = try decoder.decode(Curation.self, from: jsonData)
-                            curations.append(curation)
-                        } catch let error {
-                            print("error: \(error)")
-                        }
-                    }
-                    self.lastCurationDocumentSnapshot[index] = documents.last
-                    completionHandler(curations)
-                }
-            }
-    }
-    
-    //MARK: Curation을 (admin, user) 구분하여 10개씩 가져오는 함수
-    
-    func fetchCurationLimit(isAdmin: Bool, completionHandler: @escaping ([Curation])->()) {
+    func fetchCuration(isAdmin: Bool, completionHandler: @escaping ([Curation])->()) {
         var curations: [Curation] = []
         
         var query: Query!
-        let index = checkCurationIndex(isAdmin: isAdmin)
         
-        if let next = self.lastCurationDocumentSnapshot[index] {
-            query  = db.collection("Curation")
-                .whereField("isAdmin", isEqualTo: isAdmin)
-                .order(by: "dateTime", descending: true)
-                .limit(to: numberOfPageLimit)
-                .start(afterDocument: next)
-        } else {
-            query = db.collection("Curation")
-                .whereField("isAdmin", isEqualTo: isAdmin)
-                .order(by: "dateTime", descending: true)
-                .limit(to: numberOfPageLimit)
-        }
+        query = db.collection("Curation")
+            .whereField("isAdmin", isEqualTo: isAdmin)
+            .order(by: "dateTime", descending: true)
         
         query.addSnapshotListener { snapshot, error in
             guard let snapshot else {
@@ -530,23 +286,51 @@ class ShortcutsZipViewModel: ObservableObject {
                         if let index = curations.firstIndex(where: { $0.id == curation.id}) {
                             curations[index] = curation
                         }
-                        if let authorCurationIndex = self.curationsMadeByUser.firstIndex(where: { $0.id == curation.id}) {
-                            self.curationsMadeByUser[authorCurationIndex] = curation
-                        }
-                        if let adminCurationIndex = self.adminCurations.firstIndex(where: { $0.id == curation.id}) {
-                            self.adminCurations[adminCurationIndex] = curation
-                        }
                     }
                     if (diff.type == .removed) {
                         curations.removeAll(where: { $0.id == curation.id})
                     }
-                    self.lastCurationDocumentSnapshot[index] = diff.document
                 } catch let error {
                     print("error: \(error)")
                 }
             }
             completionHandler(curations)
         }
+    }
+    
+    // MARK: Author에 의한 큐레이션들 받아오는 함수 (나의 큐레이션)
+    
+    func fetchCurationByAuthor(author: String) -> [Curation] {
+        userCurations.filter { $0.author == author }
+    }
+    
+    //MARK: id값으로 큐레이션 정보를 받아오는 함수
+    
+    func fetchCurationDetail(curationID: String) -> Curation? {
+        if let index = userCurations.firstIndex(where: {$0.id == curationID}) {
+            return userCurations[index]
+        }
+        return nil
+    }
+    
+    //MARK: 유저와 관련된 큐레이션을 가져오는 함수
+    
+    func fetchUserRelatedCuration() -> [Curation] {
+        var relatedCurations = Set<Curation>()
+        
+        if let userInfo = self.userInfo {
+            let downloadedShortcut = userInfo.downloadedShortcuts
+            for shortcut in downloadedShortcut {
+                if let curationIDs = fetchShortcutDetail(id: shortcut.id)?.curationIDs {
+                    for curationID in curationIDs {
+                        if let relatedCuration = fetchCurationDetail(curationID: curationID) {
+                            relatedCurations.insert(relatedCuration)
+                        }
+                    }
+                }
+            }
+        }
+        return Array(relatedCurations)
     }
     
     
@@ -563,8 +347,6 @@ class ShortcutsZipViewModel: ObservableObject {
             db.collection("Curation").document((model as! Curation).id).setData((model as! Curation).dictionary)
         case _ as User:
             db.collection("User").document((model as! User).id).setData((model as! User).dictionary)
-        case _ as Comments:
-            db.collection("Comment").document((model as! Comments).id).setData((model as! Comments).dictionary)
         default:
             print("this is not a model.")
         }
@@ -574,49 +356,16 @@ class ShortcutsZipViewModel: ObservableObject {
     
     func updateShortcutInCuration(shortcutCell: ShortcutCellModel, curationIDs: [String]) {
         for curationID in curationIDs {
-            db.collection("Curation")
-                .whereField("id", isEqualTo: curationID)
-                .getDocuments() { (querySnapshot, error) in
-                    if let error {
-                        print("Error getting documents: \(error)")
-                    } else {
-                        guard let documents = querySnapshot?.documents else { return }
-                        let decoder = JSONDecoder()
-                        for document in documents {
-                            do {
-                                let data = document.data()
-                                let jsonData = try JSONSerialization.data(withJSONObject: data)
-                                var curation = try decoder.decode(Curation.self, from: jsonData)
-                                
-                                //서버 데이터 업데이트
-                                if let index = curation.shortcuts.firstIndex(where: { $0.id == shortcutCell.id }) {
-                                    curation.shortcuts[index] = shortcutCell
-                                }
-                                self.setData(model: curation)
-                                //뷰모델 업데이트
-                            } catch let error {
-                                print("error: \(error)")
-                            }
-                        }
-                    }
+            if let index = userCurations.firstIndex(where: { $0.id == curationID}) {
+                var updateCuration = userCurations[index]
+                if let shortcutIndex = updateCuration.shortcuts.firstIndex(where: { $0.id == shortcutCell.id }) {
+                    updateCuration.shortcuts[shortcutIndex] = shortcutCell
+                    self.setData(model: updateCuration)
                 }
+            }
         }
         
     }
-    
-//    func updateShortcutInCurationUI(curation: Curation, curationIDs: [String]) {
-//        curationIDs.forEach { curationID in
-//            if let userCurationsIndex = self.userCurations.firstIndex(where: { $0.id == curationID }) {
-//                self.userCurations[userCurationsIndex] = curation
-//            }
-//            if let adminCurationsIndex = self.adminCurations.firstIndex(where: { $0.id == curationID }) {
-//                self.adminCurations[adminCurationsIndex] = curation
-//            }
-//            if let curationsMadeByUserIndex = self.curationsMadeByUser.firstIndex(where: { $0.id == curationID }) {
-//                self.curationsMadeByUser[curationsMadeByUserIndex] = curation
-//            }
-//        }
-//    }
     
     //MARK: 좋아요 수를 업데이트하는 함수
     
@@ -660,89 +409,33 @@ class ShortcutsZipViewModel: ObservableObject {
     //MARK: 다운로드 수를 업데이트하는 함수
     
     func updateNumberOfDownload(shortcut: Shortcuts) {
-        if let index = userInfo?.downloadedShortcuts.firstIndex(where: { $0.id == shortcut.id}) {
-            if userInfo?.downloadedShortcuts[index].downloadLink != shortcut.downloadLink[0] {
-                self.userInfo!.downloadedShortcuts[index].downloadLink = shortcut.downloadLink[0]
-                if let userInfo = self.userInfo {
-                    self.setData(model: userInfo)
-                }
-            }
-        } else {
-            self.db.collection("Shortcut").document(shortcut.id)
-                .updateData([
-                    "numberOfDownload" : FieldValue.increment(Int64(1))
-                ]) { error in
-                    if let error {
-                        print(error.localizedDescription)
+        self.fetchUser(userID: currentUser()) { data in
+            var user = data
+            if !data.downloadedShortcuts.contains(where: { $0.id == shortcut.id }) {
+                self.db.collection("Shortcut").document(shortcut.id)
+                    .updateData([
+                        "numberOfDownload" : FieldValue.increment(Int64(1))
+                    ]) { error in
+                        if let error {
+                            print(error.localizedDescription)
+                        }
                     }
-                }
-            let downloadShortcut = DownloadedShortcut(id: shortcut.id, downloadLink: shortcut.downloadLink[0])
-            userInfo?.downloadedShortcuts.insert(downloadShortcut, at: 0)
-            if let userInfo = self.userInfo {
-                self.setData(model: userInfo)
+                let shortcutInfo = DownloadedShortcut(id: shortcut.id, downloadLink: shortcut.downloadLink[0])
+                user.downloadedShortcuts.append(shortcutInfo)
+                self.setData(model: user)
             }
         }
-    }
-    
-    //MARK: 단축어 버전 업데이트하는 함수
-    
-    func updateShortcutVersion(shortcut: Shortcuts, updateDescription: String, updateLink: String) {
-        var data = shortcut
-        //서버 - 단축어 업데이트
-        data.downloadLink.insert(updateLink, at: 0)
-        data.updateDescription.insert(updateDescription, at: 0)
-        data.date.insert(Date().getDate(), at: 0)
-        
-        //뷰모델 - 단축어 업데이트
-        
-        //다운로드순 정렬 단축어
-        if let index = sortedShortcutsByDownload.firstIndex(where: { $0.id == shortcut.id}) {
-            sortedShortcutsByDownload[index] = shortcut
-        }
-        // 좋아요 정렬 단축어
-        if let index = sortedShortcutsByLike.firstIndex(where: { $0.id == shortcut.id}) {
-            sortedShortcutsByLike[index] = shortcut
-        }
-        //내가 다운로드 한
-        if let index = shortcutsUserDownloaded.firstIndex(where: { $0.id == shortcut.id}) {
-            shortcutsUserDownloaded[index] = shortcut
-        }
-        //내가 좋아요 한
-        if let index = shortcutsUserLiked.firstIndex(where: { $0.id == shortcut.id}) {
-            shortcutsUserLiked[index] = shortcut
-        }
-        //내가 작성한
-        if let index = shortcutsMadeByUser.firstIndex(where: { $0.id == shortcut.id}) {
-            shortcutsMadeByUser[index] = shortcut
-        }
-        //카테고리별 단축어
-        shortcut.category.forEach { category in
-            if let index = shortcutsInCategory[Category(rawValue: category)!.index].firstIndex(where: { $0.id == shortcut.id}) {
-                shortcutsInCategory[Category(rawValue: category)!.index][index] = shortcut
-            }
-        }
-        setData(model: data)
-        
-        //서버 - 큐레이션 업데이트
-        let shortcutCell = ShortcutCellModel(
-            id: data.id,
-            sfSymbol: data.sfSymbol,
-            color: data.color,
-            title: data.title,
-            subtitle: data.subtitle,
-            downloadLink: data.downloadLink[0]
-        )
-        updateShortcutInCuration(shortcutCell: shortcutCell, curationIDs: data.curationIDs)
     }
     
     //MARK: 큐레이션 생성 시 포함된 단축어에 큐레이션 아이디를 저장하는 함수
     
     func updateShortcutCurationID (shortcutCells: [ShortcutCellModel], curationID: String) {
         shortcutCells.forEach { shortcutCell in
-            fetchShortcutDetail(id: shortcutCell.id) { data in
-                var shortcut = data
-                shortcut.curationIDs.append(curationID)
-                self.setData(model: shortcut)
+            if var shortcut = fetchShortcutDetail(id: shortcutCell.id) {
+                if !shortcut.curationIDs.contains(curationID) {
+                    shortcut.curationIDs.append(curationID)
+                    self.setData(model: shortcut)
+                }
             }
         }
     }
@@ -768,116 +461,83 @@ class ShortcutsZipViewModel: ObservableObject {
     //MARK: 단축어 삭제 시 유저 정보에 포함된 id 삭제하는 함수
     
     func deleteShortcutIDInUser(shortcutID: String) {
+        self.userInfo?.likedShortcuts.removeAll(where: { $0 == shortcutID })
+        self.userInfo?.downloadedShortcuts.removeAll(where: { $0.id == shortcutID })
+        self.setData(model: userInfo!)
         
-        //좋아요한 목록에서 삭제
-        db.collection("User")
-            .whereField("likedShortcuts", arrayContains: shortcutID)
-            .getDocuments() { (querySnapshot, error) in
-                if let error {
-                    print("Error getting documents: \(error)")
-                } else {
-                    guard let documents = querySnapshot?.documents else { return }
-                    let decoder = JSONDecoder()
-                    for document in documents {
-                        do {
-                            let data = document.data()
-                            let jsonData = try JSONSerialization.data(withJSONObject: data)
-                            var user = try decoder.decode(User.self, from: jsonData)
-                            
-                            user.likedShortcuts.removeAll(where: { $0 == shortcutID })
-                            user.downloadedShortcuts.removeAll(where: { $0.id == shortcutID })
-                            self.setData(model: user)
-                            
-                        } catch let error {
-                            print("error: \(error)")
-                        }
-                    }
-                }
-            }
+//        //좋아요한 목록에서 삭제
+//        db.collection("User")
+//            .whereField("likedShortcuts", arrayContains: shortcutID)
+//            .getDocuments() { (querySnapshot, error) in
+//                if let error {
+//                    print("Error getting documents: \(error)")
+//                } else {
+//                    guard let documents = querySnapshot?.documents else { return }
+//                    let decoder = JSONDecoder()
+//                    for document in documents {
+//                        do {
+//                            let data = document.data()
+//                            let jsonData = try JSONSerialization.data(withJSONObject: data)
+//                            var user = try decoder.decode(User.self, from: jsonData)
+//
+//                            user.likedShortcuts.removeAll(where: { $0 == shortcutID })
+//                            user.downloadedShortcuts.removeAll(where: { $0 == shortcutID })
+//                            self.setData(model: user)
+//
+//                        } catch let error {
+//                            print("error: \(error)")
+//                        }
+//                    }
+//                }
+//            }
         
-        //다운로드한 목록에서 삭제
-        db.collection("User")
-            .whereField("downloadedShortcuts", arrayContains: shortcutID)
-            .getDocuments() { (querySnapshot, error) in
-                if let error {
-                    print("Error getting documents: \(error)")
-                } else {
-                    guard let documents = querySnapshot?.documents else { return }
-                    let decoder = JSONDecoder()
-                    for document in documents {
-                        do {
-                            let data = document.data()
-                            let jsonData = try JSONSerialization.data(withJSONObject: data)
-                            var user = try decoder.decode(User.self, from: jsonData)
-                            
-                            user.downloadedShortcuts.removeAll(where: { $0.id == shortcutID })
-                            user.likedShortcuts.removeAll(where: { $0 == shortcutID })
-                            self.setData(model: user)
-                            
-                        } catch let error {
-                            print("error: \(error)")
-                        }
-                    }
-                }
-            }
+//        //다운로드한 목록에서 삭제
+//        db.collection("User")
+//            .whereField("downloadedShortcuts", arrayContains: shortcutID)
+//            .getDocuments() { (querySnapshot, error) in
+//                if let error {
+//                    print("Error getting documents: \(error)")
+//                } else {
+//                    guard let documents = querySnapshot?.documents else { return }
+//                    let decoder = JSONDecoder()
+//                    for document in documents {
+//                        do {
+//                            let data = document.data()
+//                            let jsonData = try JSONSerialization.data(withJSONObject: data)
+//                            var user = try decoder.decode(User.self, from: jsonData)
+//
+//                            user.downloadedShortcuts.removeAll(where: { $0 == shortcutID })
+//                            user.likedShortcuts.removeAll(where: { $0 == shortcutID })
+//                            self.setData(model: user)
+//
+//                        } catch let error {
+//                            print("error: \(error)")
+//                        }
+//                    }
+//                }
+//            }
     }
     
     //MARK: 단축어 삭제 시 해당 단축어를 포함하는 큐레이션에서 삭제하는 함수
     
     func deleteShortcutInCuration(curationsIDs: [String], shortcutID: String) {
         curationsIDs.forEach { curationID in
-            db.collection("Curation")
-                .whereField("id", isEqualTo: curationID)
-                .getDocuments() { (querySnapshot, error) in
-                    if let error {
-                        print("Error getting documents: \(error)")
-                    } else {
-                        guard let documents = querySnapshot?.documents else { return }
-                        let decoder = JSONDecoder()
-                        for document in documents {
-                            do {
-                                let data = document.data()
-                                let jsonData = try JSONSerialization.data(withJSONObject: data)
-                                var curation = try decoder.decode(Curation.self, from: jsonData)
-                                
-                                curation.shortcuts.removeAll(where: { $0.id == shortcutID })
-                                self.setData(model: curation)
-                                    
-                            } catch let error {
-                                print("error: \(error)")
-                            }
-                        }
-                    }
-                }
+            if var curation = fetchCurationDetail(curationID: curationID) {
+                curation.shortcuts.removeAll(where: { $0.id == shortcutID })
+                self.setData(model: curation)
+            }
         }
     }
     
-    //MARK: 큐레이션 삭제 시 단축어의 curationIDs에서 id삭제하는 함수
+    //MARK: 큐레이션 삭제 시 단축어에서 curationID를 삭제하는 함수
     
     func deleteCurationIDInShortcut(curationID: String) {
-        db.collection("Shortcut")
-            .whereField("curationIDs", arrayContains: curationID)
-            .getDocuments() { (querySnapshot, error) in
-                if let error {
-                    print("Error getting documents: \(error)")
-                } else {
-                    guard let documents = querySnapshot?.documents else { return }
-                    let decoder = JSONDecoder()
-                    for document in documents {
-                        do {
-                            let data = document.data()
-                            let jsonData = try JSONSerialization.data(withJSONObject: data)
-                            var shortcut = try decoder.decode(Shortcuts.self, from: jsonData)
-                            
-                            shortcut.curationIDs.removeAll(where: {$0 == curationID})
-                            self.setData(model: shortcut)
-                            
-                        } catch let error {
-                            print("error: \(error)")
-                        }
-                    }
-                }
-            }
+        let shortcutsContainsCuration = allShortcuts.filter { $0.curationIDs.contains(curationID) }
+        shortcutsContainsCuration.forEach { data in
+            var shortcut = data
+            shortcut.curationIDs.removeAll(where: {$0 == curationID})
+            self.setData(model: shortcut)
+        }
     }
     
     
@@ -897,23 +557,23 @@ class ShortcutsZipViewModel: ObservableObject {
             .whereField("id", isEqualTo: userID)
             .getDocuments { (querySnapshot, error) in
                 if let error {
-                    print("Error getting documents: \(error)")
-                } else {
-                    guard let documents = querySnapshot?.documents else { return }
-                    let decoder = JSONDecoder()
-                    
-                    for document in documents {
-                        do {
-                            let data = document.data()
-                            let jsonData = try JSONSerialization.data(withJSONObject: data)
-                            let shortcut = try decoder.decode(User.self, from: jsonData)
-                            completionHandler(shortcut)
-                        } catch let error {
-                            print("error: \(error)")
-                        }
+                print("Error getting documents: \(error)")
+            } else {
+                guard let documents = querySnapshot?.documents else { return }
+                let decoder = JSONDecoder()
+                
+                for document in documents {
+                    do {
+                        let data = document.data()
+                        let jsonData = try JSONSerialization.data(withJSONObject: data)
+                        let shortcut = try decoder.decode(User.self, from: jsonData)
+                        completionHandler(shortcut)
+                    } catch let error {
+                        print("error: \(error)")
                     }
                 }
             }
+        }
     }
     
     //MARK: user 닉네임 검사함수 - 중복이면 true, 중복되지않으면 false반환
@@ -956,98 +616,6 @@ class ShortcutsZipViewModel: ObservableObject {
                         result = false
                     }
                     completionHandler(result)
-                }
-            }
-    }
-    
-// MARK: - 검색 관련 함수
-    
-    //MARK: 연관 앱으로 단축어 검색
-    func searchShortcutByRequiredApp(word: String, completionHandler: @escaping ([Shortcuts]) -> ()) {
-        var shortcuts: [Shortcuts] = []
-        
-        var query: Query!
-        
-        query = db.collection("Shortcut")
-            .whereField("requiredApp", arrayContains: word)
-            .order(by: "requiredApp", descending: true)
-        
-        query.getDocuments { (querySnapshot, error) in
-            if let error {
-                print("Error getting documents: \(error)")
-            } else {
-                guard let documents = querySnapshot?.documents else { return }
-                let decoder = JSONDecoder()
-                
-                for document in documents {
-                    do {
-                        let data = document.data()
-                        let jsonData = try JSONSerialization.data(withJSONObject: data)
-                        let shortcut = try decoder.decode(Shortcuts.self, from: jsonData)
-                        shortcuts.append(shortcut)
-                    } catch let error {
-                        print("error: \(error)")
-                    }
-                }
-                self.lastSearchShortcutDocumentSnapshot = documents.last
-                completionHandler(shortcuts)
-            }
-        }
-    }
-    
-    //MARK: 제목으로 단축어 검색
-    ///prefix기준으로만 검색이 가능
-    func searchShortcutByTitlePrefix(keyword: String, completionHandler: @escaping ([Shortcuts]) -> ()) {
-        var shortcuts: [Shortcuts] = []
-        
-        var query: Query!
-        
-        query = db.collection("Shortcut")
-            .whereField("title", isGreaterThanOrEqualTo: keyword)
-            .whereField("title", isLessThanOrEqualTo: keyword + "\u{f8ff}")
-        
-        query.getDocuments { (querySnapshot, error) in
-            if let error {
-                print("Error getting documents: \(error)")
-            } else {
-                guard let documents = querySnapshot?.documents else { return }
-                let decoder = JSONDecoder()
-                
-                for document in documents {
-                    do {
-                        let data = document.data()
-                        let jsonData = try JSONSerialization.data(withJSONObject: data)
-                        let shortcut = try decoder.decode(Shortcuts.self, from: jsonData)
-                        shortcuts.append(shortcut)
-                    } catch let error {
-                        print("error: \(error)")
-                    }
-                }
-                self.lastSearchShortcutDocumentSnapshot = documents.last
-                completionHandler(shortcuts)
-            }
-        }
-    }
-    func fetchComment(shortcutID: String, completionHandler: @escaping (Comments) -> ()) {
-        db.collection("Comment")
-            .whereField("id", isEqualTo: shortcutID)
-            .getDocuments { (querySnapshot, error) in
-                if let error {
-                    print("Error getting documents: \(error)")
-                } else {
-                    guard let documents = querySnapshot?.documents else { return }
-                    let decoder = JSONDecoder()
-                    
-                    for document in documents {
-                        do {
-                            let data = document.data()
-                            let jsonData = try JSONSerialization.data(withJSONObject: data)
-                            let comments = try decoder.decode(Comments.self, from: jsonData)
-                            completionHandler(comments)
-                        } catch let error {
-                            print("error: \(error)")
-                        }
-                    }
                 }
             }
     }

--- a/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
+++ b/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
@@ -362,6 +362,8 @@ class ShortcutsZipViewModel: ObservableObject {
             db.collection("Curation").document((model as! Curation).id).setData((model as! Curation).dictionary)
         case _ as User:
             db.collection("User").document((model as! User).id).setData((model as! User).dictionary)
+        case _ as Comments:
+            db.collection("Comment").document((model as! Comments).id).setData((model as! Comments).dictionary)
         default:
             print("this is not a model.")
         }
@@ -468,6 +470,8 @@ class ShortcutsZipViewModel: ObservableObject {
             db.collection("Curation").document((model as! Curation).id).delete()
         case _ as User:
             db.collection("User").document((model as! User).id).delete()
+        case _ as Comments:
+            db.collection("Comment").document((model as! Comments).id).delete()
         default:
             print("this is not a model.")
         }
@@ -730,5 +734,28 @@ class ShortcutsZipViewModel: ObservableObject {
             return allComments[index]
         }
         return nil
+    }
+    
+    func updateComment(shortcutID: String, comment: Comment) {
+        if var comments = fetchComment(shortcutID: shortcutID) {
+            comments.comments.append(comment)
+            setData(model: comments)
+        }
+    }
+    
+    //대댓글 삭제 시 이용
+    func deleteComment(shortcutID: String, commentID: String) {
+        if var comments = fetchComment(shortcutID: shortcutID) {
+            comments.comments.removeAll(where: { $0.id == commentID })
+            setData(model: comments)
+        }
+    }
+    
+    //원댓글 삭제 시 이용
+    func deleteCommentByBundleID(shortcutID: String, bundleID: String) {
+        if var comments = fetchComment(shortcutID: shortcutID) {
+            comments.comments.removeAll(where: { $0.bundel_id == bundleID })
+            setData(model: comments)
+        }
     }
 }

--- a/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
+++ b/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
@@ -44,7 +44,6 @@ class ShortcutsZipViewModel: ObservableObject {
     var allShortcuts: [Shortcuts] = []
 
     init() {
-        print("**init")
         fetchUser(userID: self.currentUser()) { user in
             self.userInfo = user
             self.initUserShortcut(user: user)
@@ -505,6 +504,14 @@ class ShortcutsZipViewModel: ObservableObject {
     
     
 //MARK: - 유저 관련 함수
+    
+    //MARK: 로그인 정보 제거
+    
+    func resetUser() {
+        self.userInfo = nil
+        self.shortcutsMadeByUser.removeAll()
+        self.curationsMadeByUser.removeAll()
+    }
     
     // MARK: 현재 로그인한 아이디 리턴
     

--- a/HappyAnding/HappyAnding/Views/Components/ListShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ListShortcutView.swift
@@ -36,7 +36,7 @@ struct ListShortcutView: View {
                                                                         navigationParentView: self.data.navigationParentView)
                         
                         NavigationLink(value: navigationData) {
-                            if data.sectionType == .download {
+                            if data.sectionType == .download && index < 100 {
                                 ShortcutCell(shortcut: shortcut,
                                              rankNumber: index + 1,
                                              navigationParentView: data.navigationParentView)

--- a/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
@@ -60,7 +60,7 @@ struct ShortcutCell: View {
                     .onTapGesture {
                         if let url = URL(string: shortcutCell.downloadLink) {
                             openURL(url)
-                            shortcutsZipViewModel.fetchShortcutDetail(id: shortcutCell.id)  { shortcut in
+                            if let shortcut = shortcutsZipViewModel.fetchShortcutDetail(id: shortcutCell.id) {
                                 shortcutsZipViewModel.updateNumberOfDownload(shortcut: shortcut)
                             }
                         }

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ExploreCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ExploreCurationView.swift
@@ -10,41 +10,37 @@ import SwiftUI
 struct ExploreCurationView: View {
     
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
-    @StateObject var navigation = CurationNavigation()
     
     var body: some View {
-        NavigationStack(path: $navigation.navigationPath) {
-            ScrollView {
-                VStack(spacing: 0) {
-                    
-                    //앱 큐레이션
-                    adminCurationsFrameiew(adminCurations: shortcutsZipViewModel.adminCurations)
-                        .padding(.top, 20)
-                        .padding(.bottom, 32)
-                    
-                    //나의 큐레이션
-                    UserCurationListView(data: NavigationListCurationType(type: .myCuration,
-                                                                          title: "내가 작성한 큐레이션",
-                                                                          isAllUser: false,
-                                                                          navigationParentView: .curations),
-                                         userCurations: $shortcutsZipViewModel.curationsMadeByUser)
-                        .padding(.bottom, 20)
-                    
-                    //추천 유저 큐레이션
-                    CurationListView(data: NavigationListCurationType(type: .userCuration,
-                                                                     title: "큐레이션 모아보기",
-                                                                     isAllUser: true,
-                                                                     navigationParentView: .curations),
-                                     userCurations: $shortcutsZipViewModel.userCurations)
-                }
-                .padding(.bottom, 32)
+        ScrollView {
+            VStack(spacing: 0) {
+                
+                //앱 큐레이션
+                adminCurationsFrameiew(adminCurations: shortcutsZipViewModel.adminCurations)
+                    .padding(.top, 20)
+                    .padding(.bottom, 32)
+                
+                //나의 큐레이션
+                UserCurationListView(data: NavigationListCurationType(type: .myCuration,
+                                                                      title: "내가 작성한 큐레이션",
+                                                                      isAllUser: false,
+                                                                      navigationParentView: .curations),
+                                     userCurations: $shortcutsZipViewModel.curationsMadeByUser)
+                .padding(.bottom, 20)
+                
+                //추천 유저 큐레이션
+                CurationListView(data: NavigationListCurationType(type: .userCuration,
+                                                                  title: "큐레이션 모아보기",
+                                                                  isAllUser: true,
+                                                                  navigationParentView: .curations),
+                                 userCurations: $shortcutsZipViewModel.userCurations)
             }
-            .navigationBarTitle(Text("큐레이션 둘러보기"))
-            .navigationBarTitleDisplayMode(.large)
-            .scrollIndicators(.hidden)
-            .background(Color.Background)
+            .padding(.bottom, 32)
         }
-        .environmentObject(navigation)
+        .navigationBarTitle(Text("큐레이션 둘러보기"))
+        .navigationBarTitleDisplayMode(.large)
+        .scrollIndicators(.hidden)
+        .background(Color.Background)
     }
 }
 
@@ -61,14 +57,14 @@ struct adminCurationsFrameiew: View {
                     .onTapGesture { }
                 Spacer()
                 //추후에 어드민큐레이션에도 더보기 버튼 들어갈 수 있을 것 같아서 추가해놓은 코드입니다.
-//                NavigationLink(destination: 더보기 눌렀을 때 뷰이름 입력) {
-//                    Text("더보기")
-//                        .Footnote()
-//                        .foregroundColor(.Gray4)
-//                }
+                //                NavigationLink(destination: 더보기 눌렀을 때 뷰이름 입력) {
+                //                    Text("더보기")
+                //                        .Footnote()
+                //                        .foregroundColor(.Gray4)
+                //                }
             }
             .padding(.horizontal, 16)
-
+            
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 0) {
                     ForEach(adminCurations, id: \.id) { curation in

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ListCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ListCurationView.swift
@@ -43,13 +43,9 @@ struct ListCurationView: View {
                         .padding(.bottom, index == userCurations.count - 1 ? 32 : 0)
                         
                         .onAppear {
-                            if userCurations.last == curation && userCurations.count % 10 == 0 {
-                                print(userCurations.count)
-                                if self.data.isAllUser {
-                                    shortcutsZipViewModel.fetchCurationLimit(isAdmin: false) { curations in
-                                        userCurations.append(contentsOf: curations)
-                                    }
-                                }
+                            //TODO: 10개씩 불러오도록 변경 필요
+                            if self.data.isAllUser {
+                                self.userCurations = shortcutsZipViewModel.userCurations
                             }
                         }
                     }

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadAdminCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadAdminCurationView.swift
@@ -105,6 +105,7 @@ struct ReadAdminCurationView: View {
     var btnBack : some View { Button(action: {
         self.presentationMode.wrappedValue.dismiss()
         }) {
+            //TODO: 위치와 두께, 색상 조정 필요
             Image(systemName: "chevron.backward") // set image here
                 .foregroundColor(Color.Gray5)
                 .bold()

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
@@ -57,8 +57,9 @@ struct ReadUserCurationView: View {
         }
         .onChange(of: isWriting) { _ in
             if !isWriting {
-                // TODO: - Curation update 함수 적용
-                print("update curation")
+                if let updatedCuration = shortcutsZipViewModel.fetchCurationDetail(curationID: data.userCuration.id) {
+                    data.userCuration = updatedCuration
+                }
             }
         }
         .navigationDestination(for: NavigationReadShortcutType.self) { data in

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
@@ -158,7 +158,8 @@ struct ReadUserCurationView: View {
         Button(action: {
         self.presentation.wrappedValue.dismiss()
         }) {
-            Image(systemName: "chevron.backward") // set image here
+            //TODO: 위치와 두께, 색상 조정 필요
+            Image(systemName: "chevron.backward")
                 .foregroundColor(Color.Gray5)
                 .bold()
         }

--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView/ExploreShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView/ExploreShortcutView.swift
@@ -10,46 +10,44 @@ import SwiftUI
 struct ExploreShortcutView: View {
     
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
-    @StateObject var navigation = ShortcutNavigation()
     
     enum NavigationSearch: Hashable, Equatable {
         case first
     }
     
     var body: some View {
-        NavigationStack(path: $navigation.shortcutPath) {
-            ScrollView {
-                MyShortcutCardListView(shortcuts: shortcutsZipViewModel.shortcutsMadeByUser,
-                                       navigationParentView: .shortcuts)
-                    .padding(.top, 20)
-                    .padding(.bottom, 32)
-                DownloadRankView(shortcuts: $shortcutsZipViewModel.sortedShortcutsByDownload,
-                                 navigationParentView: .shortcuts)
-                    .padding(.bottom, 32)
-                
-                CategoryView()
-                    .padding(.bottom, 32)
-                LovedShortcutView(shortcuts: $shortcutsZipViewModel.sortedShortcutsByLike)
-                    .padding(.bottom, 44)
-            }
-            .scrollIndicators(.hidden)
-            .navigationBarTitle(Text("단축어 둘러보기"))
-            .navigationBarTitleDisplayMode(.large)
-            .background(Color.Background)
-            .toolbar {
-                ToolbarItem {
-                    NavigationLink(value: NavigationSearch.first) {
-                        Image(systemName: "magnifyingglass")
-                            .Headline()
-                            .foregroundColor(.Gray5)
-                    }
-                    .navigationDestination(for: NavigationSearch.self) { _ in
-                        SearchView()
-                    }
+        ScrollView {
+            MyShortcutCardListView(shortcuts: shortcutsZipViewModel.shortcutsMadeByUser,
+                                   navigationParentView: .shortcuts)
+            .padding(.top, 20)
+            .padding(.bottom, 32)
+            
+            DownloadRankView(shortcuts: $shortcutsZipViewModel.sortedShortcutsByDownload,
+                             navigationParentView: .shortcuts)
+            .padding(.bottom, 32)
+            
+            CategoryView()
+                .padding(.bottom, 32)
+            
+            LovedShortcutView(shortcuts: $shortcutsZipViewModel.sortedShortcutsByLike)
+                .padding(.bottom, 44)
+        }
+        .scrollIndicators(.hidden)
+        .navigationBarTitle(Text("단축어 둘러보기"))
+        .navigationBarTitleDisplayMode(.large)
+        .background(Color.Background)
+        .toolbar {
+            ToolbarItem {
+                NavigationLink(value: NavigationSearch.first) {
+                    Image(systemName: "magnifyingglass")
+                        .Headline()
+                        .foregroundColor(.Gray5)
+                }
+                .navigationDestination(for: NavigationSearch.self) { _ in
+                    SearchView()
                 }
             }
         }
-        .environmentObject(navigation)
     }
 }
 

--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ShortcutsListView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ShortcutsListView.swift
@@ -35,16 +35,7 @@ struct ShortcutsListView: View {
                         .listRowInsets(EdgeInsets())
                         .listRowSeparator(.hidden)
                         .onAppear {
-                            if shortcuts.count-1 == index && !isLastShortcut {
-                                self.shortcutsZipViewModel.fetchCategoryShortcutLimit(category: categoryName, orderBy: "date") { newShortcuts in
-                                    if Set(newShortcuts).intersection(Set(shortcuts)) == [] {
-                                        self.shortcuts.append(contentsOf: newShortcuts)
-                                    }
-                                    else {
-                                        isLastShortcut = true
-                                    }
-                                }
-                            }
+                            
                         }
                     }
                 }
@@ -58,12 +49,7 @@ struct ShortcutsListView: View {
         .navigationBarTitleDisplayMode(.inline)
         .background(Color.Background)
         .onAppear {
-            if shortcutsZipViewModel.isFirstFetchInCategory[categoryName.index] {
-                self.shortcutsZipViewModel.fetchCategoryShortcutLimit(category: categoryName, orderBy: "date") { newShortcuts in
-                    self.shortcuts.append(contentsOf: newShortcuts)
-                }
-                shortcutsZipViewModel.isFirstFetchInCategory[categoryName.index] = false
-            }
+            self.shortcuts = shortcutsZipViewModel.shortcutsInCategory[categoryName.index]
         }
     }
     

--- a/HappyAnding/HappyAnding/Views/HappyAndingApp.swift
+++ b/HappyAnding/HappyAnding/Views/HappyAndingApp.swift
@@ -33,8 +33,24 @@ struct HappyAndingApp: App {
                 if userAuth.isLoggedIn {
                     WriteNicknameView()
                         .environmentObject(shorcutsZipViewModel)
+                        .onDisappear() {
+                            if shorcutsZipViewModel.userInfo == nil {
+                                shorcutsZipViewModel.fetchUser(userID: shorcutsZipViewModel.currentUser()) { user in
+                                    shorcutsZipViewModel.userInfo = user
+                                }
+                            }
+                        }
                 } else {
                     SignInWithAppleView()
+                        .onDisappear() {
+                            if shorcutsZipViewModel.userInfo == nil {
+                                shorcutsZipViewModel.fetchUser(userID: shorcutsZipViewModel.currentUser()) { user in
+                                    shorcutsZipViewModel.userInfo = user
+                                    shorcutsZipViewModel.initUserShortcut(user: user)
+                                    shorcutsZipViewModel.curationsMadeByUser = shorcutsZipViewModel.fetchCurationByAuthor(author: user.id)
+                                }
+                            }
+                        }
                 }
             }
         }

--- a/HappyAnding/HappyAnding/Views/HappyAndingApp.swift
+++ b/HappyAnding/HappyAnding/Views/HappyAndingApp.swift
@@ -16,6 +16,7 @@ struct HappyAndingApp: App {
     
     @StateObject var userAuth = UserAuth.shared
     @StateObject var shorcutsZipViewModel = ShortcutsZipViewModel()
+    @AppStorage("signInStatus") var signInStatus = false
     
     init() {
         FirebaseApp.configure()
@@ -24,9 +25,18 @@ struct HappyAndingApp: App {
     
     var body: some Scene {
         WindowGroup {
-            ShortcutTabView()
-                .environmentObject(userAuth)
-                .environmentObject(shorcutsZipViewModel)
+            if signInStatus {
+                ShortcutTabView()
+                    .environmentObject(userAuth)
+                    .environmentObject(shorcutsZipViewModel)
+            }  else {
+                if userAuth.isLoggedIn {
+                    WriteNicknameView()
+                        .environmentObject(shorcutsZipViewModel)
+                } else {
+                    SignInWithAppleView()
+                }
+            }
         }
     }
 }

--- a/HappyAnding/HappyAnding/Views/MyPageViews/MyPageView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/MyPageView.swift
@@ -10,14 +10,12 @@ import SwiftUI
 struct MyPageView: View {
     
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
-    @StateObject var navigation = ProfileNavigation()
     
     enum NavigationSettingView: Hashable, Equatable {
         case first
     }
     
     var body: some View {
-        NavigationStack(path: $navigation.navigationPath) {
             ScrollView {
                 VStack(spacing: 32) {
                     
@@ -91,15 +89,13 @@ struct MyPageView: View {
                             .Headline()
                             .foregroundColor(.Gray5)
                     }
-                    .navigationDestination(for: NavigationSettingView.self) { _ in
-                        SettingView()
-                    }
                 }
             }
             .scrollIndicators(.hidden)
             .background(Color.Background)
-        }
-        .environmentObject(navigation)
+            .navigationDestination(for: NavigationSettingView.self) { _ in
+                SettingView()
+            }
     }
 }
 
@@ -107,6 +103,7 @@ struct MyPageShortcutList: View {
     
     var shortcuts: [Shortcuts]?
     var type: SectionType
+    
     var body: some View {
         VStack(spacing: 0) {
             MyPageListHeader(type: type, shortcuts: shortcuts)

--- a/HappyAnding/HappyAnding/Views/MyPageViews/SettingView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/SettingView.swift
@@ -154,6 +154,7 @@ struct SettingView: View {
             try firebaseAuth.signOut()
             userAuth.signOut()
             self.signInStatus = false
+            shortcutsZipViewModel.resetUser()
         } catch {
             print(error.localizedDescription)
         }

--- a/HappyAnding/HappyAnding/Views/MyPageViews/SettingView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/SettingView.swift
@@ -16,7 +16,7 @@ struct SettingView: View {
     @StateObject var userAuth = UserAuth.shared
     @ObservedObject var webViewModel = WebViewModel(url: "https://noble-satellite-574.notion.site/60d8fa2f417c40cca35e9c784f74b7fd")
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
-
+    
     @State var result: Result<MFMailComposeResult, Error>? = nil
     @State var isShowingMailView = false
     @State var isTappedLogOutButton = false
@@ -26,7 +26,7 @@ struct SettingView: View {
     enum NavigationLisence: Hashable, Equatable {
         case first
     }
-
+    
     enum NavigationWithdrawal: Hashable, Equatable {
         case first
     }
@@ -97,8 +97,17 @@ struct SettingView: View {
                 SettingCell(title: "로그아웃")
             }
             .alert("로그아웃", isPresented: $isTappedLogOutButton) {
-                Button("닫기", role: .cancel) { isTappedLogOutButton.toggle() }
-                Button("로그아웃", role: .destructive) { logOut() }
+                Button(role: .cancel) {
+                    
+                } label: {
+                    Text("닫기")
+                }
+                
+                Button(role: .destructive) {
+                    logOut()
+                } label: {
+                    Text("로그아웃")
+                }
             } message: {
                 Text("로그아웃 하시겠습니까?")
             }

--- a/HappyAnding/HappyAnding/Views/MyPageViews/SettingViews/WithdrawalView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/SettingViews/WithdrawalView.swift
@@ -79,12 +79,20 @@ struct WithdrawalView: View {
             }
             .disabled(!isTappedCheckToggle)
             .padding(.bottom, 44)
-            .alert(isPresented: $isTappedSignOutButton) {
-                Alert(title: Text("탈퇴하기"),
-                      message: Text("ShortcutsZip에서 탈퇴하시겠습니까?"),
-                      primaryButton: .default(Text("취소")
-                                              ,action: { self.isTappedSignOutButton = false }),
-                      secondaryButton: .destructive(Text("탈퇴"), action: { signOut() }))
+            .alert("탈퇴하기", isPresented: $isTappedSignOutButton) {
+                Button(role: .cancel) {
+                    
+                } label: {
+                    Text("닫기")
+                }
+                
+                Button(role: .destructive) {
+                    signOut()
+                } label: {
+                    Text("탈퇴")
+                }
+            } message: {
+                Text("ShortcutsZip에서 탈퇴하시겠습니까?")
             }
         }
         .padding(.horizontal, 16)

--- a/HappyAnding/HappyAnding/Views/MyPageViews/SettingViews/WithdrawalView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/SettingViews/WithdrawalView.swift
@@ -109,6 +109,7 @@ struct WithdrawalView: View {
             } else {
                 if let user = shortcutsZipViewModel.userInfo {
                     shortcutsZipViewModel.deleteData(model: user)
+                    shortcutsZipViewModel.resetUser()
                     withAnimation(.easeInOut) {
                         self.signInStatus = false
                         userAuth.signOut()

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutCommentView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutCommentView.swift
@@ -1,0 +1,106 @@
+//
+//  ReadShortcutCommentView.swift
+//  HappyAnding
+//
+//  Created by 이지원 on 2022/11/21.
+//
+
+import SwiftUI
+
+struct ReadShortcutCommentView: View {
+    @Binding var addedComment: Comment
+    @State var comments = [Comment]()
+    @State var isReply = true
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            if comments.isEmpty {
+                Text("등록된 댓글이 없습니다")
+                    .Body2()
+                    .foregroundColor(.Gray4)
+                
+            } else {
+                comment
+                Spacer()
+            }
+        }
+        .padding(.top, 16)
+        .onAppear {
+            //TODO: 댓글 데이터 불러오기
+            for _ in 0...10 {
+                let comment = Comment(user_id: "1", date: "2022112211",
+                                      depth: Int.random(in: 0...1),
+                                      contents: "댓글을남겨요")
+                comments.append(comment)
+            }
+        }
+    }
+    
+    var comment: some View {
+        ForEach(comments, id: \.self) { comment in
+            
+            HStack(alignment: .top, spacing: 8) {
+                if comment.depth == 0 {
+                    Image(systemName: "arrow.turn.down.right")
+                        .foregroundColor(.Gray4)
+                }
+                VStack(alignment: .leading, spacing: 8) {
+                    
+                    // MARK: 유저 정보
+                    
+                    HStack(spacing: 8) {
+                        
+                        Circle()
+                            .frame(width: 24, height: 24)
+                            .foregroundColor(.Gray4)
+                        
+                        Text(comment.user_id)
+                            .Body2()
+                            .foregroundColor(.Gray4)
+                    }
+                    .padding(.bottom, 4)
+                    
+                    
+                    // MARK: 댓글 내용
+                    
+                    Text(comment.contents)
+                        .Body2()
+                        .foregroundColor(.Gray5)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    
+                    // MARK: Button
+                    HStack(spacing: 16) {
+                        Button {
+                            print("답글")
+                            addedComment.bundel_id = comment.bundel_id
+                            addedComment.depth = 1
+                        } label: {
+                            Text("답글")
+                                .Footnote()
+                                .foregroundColor(.Gray4)
+                        }
+                        
+                        Button {
+                            print("수정")
+                        } label: {
+                            Text("수정")
+                                .Footnote()
+                                .foregroundColor(.Gray4)
+                        }
+                        
+                        Button {
+                            print("삭제")
+                        } label: {
+                            Text("삭제")
+                                .Footnote()
+                                .foregroundColor(.Gray4)
+                        }
+                    }
+                    Divider()
+                        .background(Color.Gray1)
+                }
+            }
+            .padding(.bottom, 16)
+        }
+    }
+}

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutContentView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutContentView.swift
@@ -9,55 +9,32 @@ import SwiftUI
 
 struct ReadShortcutContentView: View {
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
-    @State var userInformation: User? = nil
     
     @Binding var shortcut: Shortcuts
     let profileImage: String = "person.crop.circle"
     
     var body: some View {
-        ScrollView {
             VStack(alignment: .leading) {
-                Text("작성자")
-                    .Body2()
-                    .foregroundColor(Color.Gray4)
-                HStack {
-                    Image(systemName: profileImage)
-                    Text(userInformation?.nickname ?? "닉네임")
-                        .Body2()
-                        .foregroundColor(Color.Gray5)
-                }
-                .padding(.bottom, 24)
                 
                 ReusableTextView(title: "단축어 설명", contents: shortcut.description, contentsArray: nil)
-                    .padding(.bottom, 20)
+                    .padding(.bottom, 24)
+                    .padding(.top, 16)
+                
                 categoryView
-                    .padding(.bottom, 20)
+                    .padding(.bottom, 24)
                 
                 if !shortcut.requiredApp.isEmpty {
                     ReusableTextView(title: "단축어 사용에 필요한 앱", contents: nil, contentsArray: shortcut.requiredApp)
-                        .padding(.bottom, 20)
+                        .padding(.bottom, 24)
                 }
                 
                 if !shortcut.shortcutRequirements.isEmpty {
                     ReusableTextView(title: "단축어 사용을 위한 요구사항", contents: shortcut.shortcutRequirements, contentsArray: nil)
                 }
+                Spacer()
+                    .frame(maxHeight: .infinity)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(20)
-        }
-        .onAppear {
-            shortcutsZipViewModel.fetchUser(userID: shortcut.author) { user in
-                userInformation = user
-            }
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .overlay {
-            RoundedRectangle(cornerRadius: 12)
-                .strokeBorder(Color.Gray2,lineWidth: 1)
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 20)
-        .scrollIndicators(.hidden)
     }
     
     var categoryView: some View {
@@ -113,6 +90,8 @@ private struct ReusableTextView: View {
     let contents: String?
     let contentsArray: [String]?
     
+    @State var heigth: CGFloat = 10000
+    
     var body: some View {
         VStack(alignment: .leading) {
             Text(title)
@@ -122,6 +101,7 @@ private struct ReusableTextView: View {
                 Text(contents)
                     .Body2()
                     .foregroundColor(Color.Gray5)
+                    .lineLimit(nil)
             }
             if let contentsArray {
                 ForEach(contentsArray, id: \.self) {
@@ -129,9 +109,20 @@ private struct ReusableTextView: View {
                     Text(content)
                         .Body2()
                         .foregroundColor(Color.Gray5)
+                        .lineLimit(nil)
                 }
             }
         }
+        .background(
+            GeometryReader { geometryProxy in
+                Color.clear
+                    .preference(key: SizePreferenceKey.self,
+                                value: geometryProxy.size)
+            })
+        .onPreferenceChange(SizePreferenceKey.self) { newSize in
+            self.heigth = newSize.height
+        }
+        .frame(height: self.heigth)
     }
 }
 

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutHeaderView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutHeaderView.swift
@@ -75,8 +75,6 @@ struct ReadShortcutHeaderView: View {
             } else {
                 self.shortcut.numberOfLike -= 1
             }
-            //데이터 상의 좋아요 추가, 취소 기능 동작
-            shortcutsZipViewModel.updateNumberOfLike(isMyLike: isMyLike, shortcut: shortcut)
         })
     }
     

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutHeaderView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutHeaderView.swift
@@ -12,7 +12,7 @@ struct ReadShortcutHeaderView: View {
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
     
     @Binding var shortcut: Shortcuts
-    @State var isMyLike: Bool = false
+    @Binding var isMyLike: Bool
     @State var userInformation: User? = nil
     
     var body: some View {
@@ -38,7 +38,6 @@ struct ReadShortcutHeaderView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 16)
         .onAppear() {
-            isMyLike = shortcutsZipViewModel.checkLikedShortrcut(shortcutID: shortcut.id)
             shortcutsZipViewModel.fetchUser(userID: shortcut.author) { user in
                 userInformation = user
             }
@@ -118,10 +117,3 @@ struct ReadShortcutHeaderView: View {
         }
     }
 }
-
-
-//struct ReadShortcutHeaderView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        ReadShortcutHeaderView(icon: "book", color: "Coral", numberOfLike: 99, name: "주변 커피집 걸어가기", oneline: "걸어가보자!!!")
-//    }
-//}

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutHeaderView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutHeaderView.swift
@@ -24,6 +24,7 @@ struct ReadShortcutHeaderView: View {
                 Spacer()
                 
                 likeButton
+
             }
             VStack(alignment: .leading, spacing: 4) {
                 Text("\(shortcut.title)")

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutHeaderView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutHeaderView.swift
@@ -13,46 +13,27 @@ struct ReadShortcutHeaderView: View {
     
     @Binding var shortcut: Shortcuts
     @State var isMyLike: Bool = false
+    @State var userInformation: User? = nil
     
     var body: some View {
-        VStack(alignment: .leading) {
+        VStack(alignment: .leading, spacing: 16) {
             HStack {
-                VStack {
-                    Image(systemName: shortcut.sfSymbol)
-                        .Title2()
-                        .foregroundColor(Color.Text_icon)
-                }
-                .frame(width: 52, height: 52)
-                .background(Color.fetchGradient(color: shortcut.color))
-                .cornerRadius(8)
+                
+                icon
                 
                 Spacer()
                 
-                Text("\(isMyLike ? Image(systemName: "heart.fill") : Image(systemName: "heart")) \(shortcut.numberOfLike)")
-
-                .Body2()
-                .padding(10)
-                .foregroundColor(isMyLike ? Color.Text_icon : Color.Gray4)
-                .background(isMyLike ? Color.Primary : Color.Gray1)
-                .cornerRadius(12)
-                .onTapGesture(perform: {
-                    isMyLike.toggle()
-                    //화면 상의 좋아요 추가, 취소 기능 동작
-                    if isMyLike {
-                        self.shortcut.numberOfLike += 1
-                    } else {
-                        self.shortcut.numberOfLike -= 1
-                    }
-                    //데이터 상의 좋아요 추가, 취소 기능 동작
-                    shortcutsZipViewModel.updateNumberOfLike(isMyLike: isMyLike, shortcut: shortcut)
-                })
+                likeButton
             }
-            Text("\(shortcut.title)")
-                .Title1()
-                .foregroundColor(Color.Gray5)
-            Text("\(shortcut.subtitle)")
-                .Body1()
-                .foregroundColor(Color.Gray3)
+            VStack(alignment: .leading, spacing: 4) {
+                Text("\(shortcut.title)")
+                    .Title1()
+                    .foregroundColor(Color.Gray5)
+                Text("\(shortcut.subtitle)")
+                    .Body1()
+                    .foregroundColor(Color.Gray3)
+            }
+            userInfo
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 16)
@@ -60,6 +41,82 @@ struct ReadShortcutHeaderView: View {
             shortcutsZipViewModel.checkLikedShortrcut(shortcutID: shortcut.id) { result in
                 isMyLike = result
             }
+            shortcutsZipViewModel.fetchUser(userID: shortcut.author) { user in
+                userInformation = user
+            }
+            
+        }
+    }
+    
+    // MARK: 단축어 아이콘
+    var icon: some View {
+        VStack {
+            Image(systemName: shortcut.sfSymbol)
+                .Title2()
+                .foregroundColor(Color.Text_icon)
+        }
+        .frame(width: 52, height: 52)
+        .background(Color.fetchGradient(color: shortcut.color))
+        .cornerRadius(8)
+    }
+    
+    // MARK: 좋아요 버튼
+    var likeButton: some View {
+        Text("\(isMyLike ? Image(systemName: "heart.fill") : Image(systemName: "heart")) \(shortcut.numberOfLike)")
+
+        .Body2()
+        .padding(10)
+        .foregroundColor(isMyLike ? Color.Text_icon : Color.Gray4)
+        .background(isMyLike ? Color.Primary : Color.Gray1)
+        .cornerRadius(12)
+        .onTapGesture(perform: {
+            isMyLike.toggle()
+            //화면 상의 좋아요 추가, 취소 기능 동작
+            if isMyLike {
+                self.shortcut.numberOfLike += 1
+            } else {
+                self.shortcut.numberOfLike -= 1
+            }
+            //데이터 상의 좋아요 추가, 취소 기능 동작
+            shortcutsZipViewModel.updateNumberOfLike(isMyLike: isMyLike, shortcut: shortcut)
+        })
+    }
+    
+    // MARK: - 유저 정보
+    var userInfo: some View {
+        HStack(spacing: 8) {
+            
+            Circle()
+                .frame(width: 24, height: 24)
+                .foregroundColor(.Gray4)
+                .padding(.leading, 16)
+            
+            Text(userInformation?.nickname ?? "닉네임")
+                .Body2()
+                .foregroundColor(.Gray4)
+            
+            Spacer()
+                .frame(maxWidth: .infinity)
+            
+            
+            // TODO: 신고기능
+            
+            /*
+            Image(systemName: "light.beacon.max.fill")
+                .Headline()
+                .foregroundColor(.Gray5)
+                .padding(.trailing, 16)
+                .onTapGesture {
+                    print("Tapped!")
+                }
+             */
+            
+        }
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity, maxHeight: 44)
+        .overlay {
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Color.Gray1, lineWidth: 1)
         }
     }
 }

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutHeaderView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutHeaderView.swift
@@ -38,9 +38,7 @@ struct ReadShortcutHeaderView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 16)
         .onAppear() {
-            shortcutsZipViewModel.checkLikedShortrcut(shortcutID: shortcut.id) { result in
-                isMyLike = result
-            }
+            isMyLike = shortcutsZipViewModel.checkLikedShortrcut(shortcutID: shortcut.id)
             shortcutsZipViewModel.fetchUser(userID: shortcut.author) { user in
                 userInformation = user
             }

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutVersionView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutVersionView.swift
@@ -1,0 +1,60 @@
+//
+//  ReadShortcutVersionView.swift
+//  HappyAnding
+//
+//  Created by 이지원 on 2022/11/21.
+//
+
+import SwiftUI
+
+struct ReadShortcutVersionView: View {
+    
+    @State var shortcut: Shortcuts
+    @State var updateDate = ""
+    var body: some View {
+        if shortcut.updateDescription.count == 1 {
+            Text("아직 업데이트된 버전이 없습니다.")
+                .Body2()
+                .foregroundColor(.Gray4)
+        } else {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("업데이트 내용")
+                    .Body2()
+                    .foregroundColor(.Gray4)
+                ForEach(Array(zip(shortcut.updateDescription, shortcut.updateDescription.indices)), id: \.0) { data, index in
+                    VStack(alignment: .leading, spacing: 12) {
+                        HStack {
+                            Text("Ver \(shortcut.updateDescription.count - index).0")
+                                .Body2()
+                                .foregroundColor(.Gray5)
+                            
+                            Spacer()
+                            Text(updateDate)
+                                .Body2()
+                                .foregroundColor(.Gray3)
+                        }
+                        .onAppear {
+                            self.updateDate = shortcut.date[index].getVersionUpdateDateFormat()
+                        }
+                        if data != "" {
+                            Text(data)
+                                .Body2()
+                                .foregroundColor(.Gray5)
+                        }
+                        if index != 0 {
+                            let link = "[이전 버전 다운로드](\(shortcut.downloadLink[index]))"
+                            Text(.init(link))
+                                .tint(.Primary)
+                        }
+                        Divider()
+                            .foregroundColor(.Gray1)
+                        
+                    }
+                }
+                Spacer()
+                    .frame(maxHeight: .infinity)
+            }
+            .padding(.top, 16)
+        }
+    }
+}

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -44,7 +44,7 @@ struct ReadShortcutView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 0) {
-                if shortcut != nil {
+                if data.shortcut != nil {
                     
                     // MARK: - 단축어 타이틀
                     
@@ -110,7 +110,7 @@ struct ReadShortcutView: View {
                     textField
                 }
                 if !isFocused {
-                    if let shortcut {
+                    if let shortcut = data.shortcut {
                         Button {
                             if let url = URL(string: shortcut.downloadLink[0]) {
                                 if (shortcutsZipViewModel.userInfo?.downloadedShortcuts.firstIndex(where: { $0.id == data.shortcutID })) == nil {
@@ -133,7 +133,6 @@ struct ReadShortcutView: View {
             }
             .ignoresSafeArea(.keyboard)
         }
-        .padding(.vertical, 20)
         .background(Color.Background)
         .onAppear() {
             data.shortcut = shortcutsZipViewModel.fetchShortcutDetail(id: data.shortcutID)
@@ -157,13 +156,6 @@ struct ReadShortcutView: View {
                 }
                 if isMyLike != isFirstMyLike {
                     shortcutsZipViewModel.updateNumberOfLike(isMyLike: isMyLike, shortcut: shortcut)
-                    if isMyLike {
-                        shortcutsZipViewModel.userInfo?.likedShortcuts.insert(self.data.shortcutID, at: 0)
-                        shortcutsZipViewModel.shortcutsUserLiked.insert(shortcut, at: 0)
-                    } else {
-                        shortcutsZipViewModel.userInfo?.likedShortcuts.removeAll(where: { $0 == self.data.shortcutID })
-                        shortcutsZipViewModel.shortcutsUserLiked.removeAll(where: { $0.id == self.data.shortcutID })
-                    }
                 }
             }
         }
@@ -186,7 +178,7 @@ struct ReadShortcutView: View {
             }
             
             Button(role: .destructive) {
-                if let shortcut {
+                if let shortcut = data.shortcut {
                     shortcutsZipViewModel.deleteShortcutIDInUser(shortcutID: shortcut.id)
                     shortcutsZipViewModel.deleteShortcutInCuration(curationsIDs: shortcut.curationIDs, shortcutID: shortcut.id)
                     shortcutsZipViewModel.deleteData(model: shortcut)
@@ -210,7 +202,7 @@ struct ReadShortcutView: View {
             .environmentObject(writeNavigation)
         }
         .fullScreenCover(isPresented: $isUpdating) {
-            UpdateShortcutView(isUpdating: $isUpdating, shortcut: $shortcut)
+            UpdateShortcutView(isUpdating: $isUpdating, shortcut: $data.shortcut)
         }
         .toolbar(.hidden, for: .tabBar)
         .toolbarBackground(
@@ -313,7 +305,7 @@ extension ReadShortcutView {
     }
     
     func share() {
-        if let shortcut {
+        if let shortcut = data.shortcut {
             guard let deepLink = URL(string: "ShortcutsZip://myPage/detailView?shortcutID=\(shortcut.id)") else { return }
             let activityVC = UIActivityViewController(activityItems: [deepLink], applicationActivities: nil)
             let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
@@ -330,7 +322,7 @@ extension ReadShortcutView {
     
     var detailInformationView: some View {
         VStack {
-            if let shortcut {
+            if let shortcut = data.shortcut {
                 ZStack {
                     TabView(selection: self.$currentTab) {
                         Color.clear.tag(0)
@@ -342,7 +334,7 @@ extension ReadShortcutView {
                     
                     switch(currentTab) {
                     case 0:
-                        ReadShortcutContentView(shortcut: self.$shortcut.unwrap()!)
+                        ReadShortcutContentView(shortcut: $data.shortcut.unwrap()!)
                             .background(
                                 GeometryReader { geometryProxy in
                                     Color.clear

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -17,6 +17,7 @@ struct ReadShortcutView: View {
     @State var isTappedDeleteButton = false
     @State var shortcut: Shortcuts?
     @State var isEdit = false
+    @State var isUpdating = false
     
     @State var data: NavigationReadShortcutType
     
@@ -106,6 +107,9 @@ struct ReadShortcutView: View {
             }
             .environmentObject(writeNavigation)
         }
+        .fullScreenCover(isPresented: $isUpdating) {
+            UpdateShortcutView(isUpdating: $isUpdating, shortcut: $shortcut)
+        }
     }
 }
 
@@ -119,6 +123,12 @@ extension ReadShortcutView {
                 isEdit.toggle()
             } label: {
                 Label("편집", systemImage: "square.and.pencil")
+            }
+            
+            Button {
+                isUpdating.toggle()
+            } label: {
+                Label("업데이트", systemImage: "clock.arrow.circlepath")
             }
             
             Button(action: {

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -75,28 +75,26 @@ struct ReadShortcutView: View {
             Image(systemName: "ellipsis")
                 .foregroundColor(.Gray4)
         }))
-        .alert(isPresented: $isTappedDeleteButton) {
-            Alert(title: Text("글 삭제").foregroundColor(.Gray5),
-                  message: Text("글을 삭제하시겠습니까?").foregroundColor(.Gray5),
-                  primaryButton: .default(
-                    Text("닫기"),
-                    action: {
-                        self.isTappedDeleteButton.toggle()
-                    }),
-                  secondaryButton: .destructive(
-                    Text("삭제"),
-                    action: {
-                        if let shortcut {
-                            shortcutsZipViewModel.deleteShortcutIDInUser(shortcutID: shortcut.id)
-                            shortcutsZipViewModel.deleteShortcutInCuration(curationsIDs: shortcut.curationIDs, shortcutID: shortcut.id)
-                            shortcutsZipViewModel.deleteData(model: shortcut)
-                            //FIXME: 뷰모델에서 실제 데이터를 삭제하도록 변경 필요
-                            shortcutsZipViewModel.shortcutsMadeByUser = shortcutsZipViewModel.shortcutsMadeByUser.filter { $0.id != shortcut.id }
-                            self.presentation.wrappedValue.dismiss()
-                        }
-                    }
-                  )
-            )
+        .alert("글 삭제", isPresented: $isTappedDeleteButton) {
+            Button(role: .cancel) {
+                
+            } label: {
+                Text("닫기")
+            }
+            
+            Button(role: .destructive) {
+                if let shortcut {
+                    shortcutsZipViewModel.deleteShortcutIDInUser(shortcutID: shortcut.id)
+                    shortcutsZipViewModel.deleteShortcutInCuration(curationsIDs: shortcut.curationIDs, shortcutID: shortcut.id)
+                    shortcutsZipViewModel.deleteData(model: shortcut)
+                    shortcutsZipViewModel.shortcutsMadeByUser = shortcutsZipViewModel.shortcutsMadeByUser.filter { $0.id != shortcut.id }
+                    self.presentation.wrappedValue.dismiss()
+                }
+            } label: {
+                Text("삭제")
+            }
+        } message: {
+            Text("글을 삭제하시겠습니까?")
         }
         .fullScreenCover(isPresented: $isEdit) {
             NavigationStack(path: $writeNavigation.navigationPath) {
@@ -131,9 +129,9 @@ extension ReadShortcutView {
             
             Button(role: .destructive, action: {
                 isTappedDeleteButton.toggle()
-             }) {
-                 Label("삭제", systemImage: "trash.fill")
-             }
+            }) {
+                Label("삭제", systemImage: "trash.fill")
+            }
         }
         
     }
@@ -159,7 +157,9 @@ extension ReadShortcutView {
         if let shortcut {
             guard let downloadLink = URL(string: shortcut.downloadLink.last!) else { return }
             let activityVC = UIActivityViewController(activityItems: [downloadLink], applicationActivities: nil)
-            UIApplication.shared.windows.first?.rootViewController?.present(activityVC, animated: true, completion: nil)
+            let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+            guard let window = windowScene?.windows.first else { return }
+            window.rootViewController?.present(activityVC, animated: true, completion: nil)
         }
     }
 }

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -68,18 +68,12 @@ struct ReadShortcutView: View {
         }
         .background(Color.Background)
         .onAppear() {
-            shortcutsZipViewModel.fetchShortcutDetail(id: self.data.shortcutID) { shortcut in
-                self.shortcut = shortcut
-                print("hellohello \(self.$shortcut.unwrap()!)")
-            }
+            self.shortcut = shortcutsZipViewModel.fetchShortcutDetail(id: self.data.shortcutID)
         }
         .onAppear(perform: {UINavigationBar.appearance().standardAppearance.configureWithTransparentBackground() })
         .onChange(of: isEdit) { _ in
             if !isEdit {
-                shortcutsZipViewModel.fetchShortcutDetail(id: self.data.shortcutID) { shortcut in
-                    self.shortcut = shortcut
-                    print(shortcut)
-                }
+                self.shortcut = shortcutsZipViewModel.fetchShortcutDetail(id: self.data.shortcutID)
             }
         }
         .safeAreaInset(edge: .bottom, spacing: 0) {

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -257,8 +257,8 @@ extension ReadShortcutView {
     
     func share() {
         if let shortcut {
-            guard let downloadLink = URL(string: shortcut.downloadLink.last!) else { return }
-            let activityVC = UIActivityViewController(activityItems: [downloadLink], applicationActivities: nil)
+            guard let deepLink = URL(string: "ShortcutsZip://myPage/detailView?shortcutID=\(shortcut.id)") else { return }
+            let activityVC = UIActivityViewController(activityItems: [deepLink], applicationActivities: nil)
             let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
             guard let window = windowScene?.windows.first else { return }
             window.rootViewController?.present(activityVC, animated: true, completion: nil)

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -133,6 +133,40 @@ struct ReadShortcutView: View {
             }
             .ignoresSafeArea(.keyboard)
         }
+        .padding(.vertical, 20)
+        .background(Color.Background)
+        .onAppear() {
+            data.shortcut = shortcutsZipViewModel.fetchShortcutDetail(id: data.shortcutID)
+            isMyLike = shortcutsZipViewModel.checkLikedShortrcut(shortcutID: data.shortcutID)
+            isFirstMyLike = isMyLike
+        }
+        .onChange(of: isEdit) { _ in
+            if !isEdit {
+                data.shortcut = shortcutsZipViewModel.fetchShortcutDetail(id: data.shortcutID)
+            }
+        }
+        .onDisappear() {
+            if let shortcut = data.shortcut {
+                let isAlreadyContained = shortcutsZipViewModel.userInfo?.downloadedShortcuts.firstIndex(where: { $0.id == self.data.shortcutID}) == nil
+                if isClickDownload && isAlreadyContained {
+                    shortcutsZipViewModel.updateNumberOfDownload(shortcut: shortcut)
+                    shortcutsZipViewModel.shortcutsUserDownloaded.insert(shortcut, at: 0)
+
+                    let downloadedShortcut = DownloadedShortcut(id: shortcut.id, downloadLink: shortcut.downloadLink[0])
+                    shortcutsZipViewModel.userInfo?.downloadedShortcuts.insert(downloadedShortcut, at: 0)
+                }
+                if isMyLike != isFirstMyLike {
+                    shortcutsZipViewModel.updateNumberOfLike(isMyLike: isMyLike, shortcut: shortcut)
+                    if isMyLike {
+                        shortcutsZipViewModel.userInfo?.likedShortcuts.insert(self.data.shortcutID, at: 0)
+                        shortcutsZipViewModel.shortcutsUserLiked.insert(shortcut, at: 0)
+                    } else {
+                        shortcutsZipViewModel.userInfo?.likedShortcuts.removeAll(where: { $0 == self.data.shortcutID })
+                        shortcutsZipViewModel.shortcutsUserLiked.removeAll(where: { $0.id == self.data.shortcutID })
+                    }
+                }
+            }
+        }
         .navigationBarTitleDisplayMode(NavigationBarItem.TitleDisplayMode.inline)
         .navigationBarItems(trailing: Menu(content: {
             if self.data.shortcut?.author == shortcutsZipViewModel.currentUser() {

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/UpdateShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/UpdateShortcutView.swift
@@ -1,0 +1,85 @@
+//
+//  UpdateShortcutView.swift
+//  HappyAnding
+//
+//  Created by kimjimin on 2022/11/21.
+//
+
+import SwiftUI
+
+struct UpdateShortcutView: View {
+    @Binding var isUpdating: Bool
+    @Binding var shortcut: Shortcuts?
+    
+    @State var updatedLink = ""
+    @State var updateDescription = ""
+    @State var isLinkValid = false
+    @State var isDescriptionValid = false
+    
+    var body: some View {
+        VStack {
+            HStack {
+                Button(action: {
+                    isUpdating.toggle()
+                }, label: {
+                    Text("취소")
+                        .foregroundColor(.Gray5)
+                })
+                .frame(maxWidth: .infinity, alignment: .leading)
+                
+                Text("업데이트")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                
+                Text("")
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+            }
+            .padding(.top, 12)
+            .padding(.horizontal, 16)
+            ValidationCheckTextField(textType: .mandatory,
+                                     isMultipleLines: false,
+                                     title: "업데이트된 단축어 링크",
+                                     placeholder: "업데이트된 단축어 링크를 추가하세요",
+                                     lengthLimit: 100,
+                                     isDownloadLinkTextField: true,
+                                     content: $updatedLink,
+                                     isValid: $isLinkValid
+            )
+            .onAppear(perform : UIApplication.shared.hideKeyboard)
+            .padding(.top, 30)
+            
+            ValidationCheckTextField(textType: .mandatory,
+                                     isMultipleLines: false,
+                                     title: "업데이트 설명",
+                                     placeholder: "업데이트된 내용을 입력해주세요",
+                                     lengthLimit: 50,
+                                     isDownloadLinkTextField: false,
+                                     content: $updateDescription,
+                                     isValid: $isDescriptionValid
+            )
+            
+            Spacer()
+            
+            Button(action: {
+                
+                // TODO: updatedLink, updateDescription을 shortcut에 저장
+                
+                isUpdating.toggle()
+            }, label: {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 12)
+                        .foregroundColor(isLinkValid && isDescriptionValid ? .Primary : .Primary.opacity(0.13))
+                        .frame(maxWidth: .infinity, maxHeight: 52)
+                    
+                    Text("업데이트")
+                        .foregroundColor(isLinkValid && isDescriptionValid ? .Text_Button : .Text_Button_Disable)
+                        .Body1()
+                }
+            })
+            .disabled(!isLinkValid || !isDescriptionValid)
+            .padding(.horizontal, 16)
+            .padding(.bottom, 24)
+        }
+        .background(Color.Background)
+    }
+}

--- a/HappyAnding/HappyAnding/Views/SignInViews/WriteNicknameView.swift
+++ b/HappyAnding/HappyAnding/Views/SignInViews/WriteNicknameView.swift
@@ -36,6 +36,8 @@ struct WriteNicknameView: View {
     @State private var isTappedPrivacyButton = false
     @State var isNormalString = true
     
+    @FocusState private var isFocused: Bool
+    
     let user = Auth.auth().currentUser
     
     var body: some View {
@@ -103,17 +105,18 @@ struct WriteNicknameView: View {
             HStack {
                 TextField("닉네임 (최대 8글자)", text: $nickname)
                     .Body2()
+                    .focused($isFocused)
                     .foregroundColor(.Gray5)
                     .frame(height: 20)
                     .padding(.leading, 16)
                     .padding(.vertical, 12)
+                    .onAppear(perform : UIApplication.shared.hideKeyboard)
                     .onChange(of: nickname) {_ in
                         isValidLength = nickname.count <= 8 && !nickname.isEmpty
                         isNicknameChecked = false
                         //isNormalString = nickname.isNormalString()
                         isNormalString = nickname.checkCorrectNickname()
                     }
-                
                 if !nickname.isEmpty {
                     textFieldSFSymbol
                 }
@@ -121,7 +124,7 @@ struct WriteNicknameView: View {
             .overlay(
                 RoundedRectangle(cornerRadius: 12)
                     .strokeBorder(lineWidth: 1)
-                    .foregroundColor(isNicknameChecked ? .Success : (isValidLength ? .Gray3 : (nickname.isEmpty ? .Gray3 : .red)))
+                    .foregroundColor(isNicknameChecked ? .Success : (isValidLength && isNormalString ? .Gray3 : (nickname.isEmpty ? .Gray3 : .red)))
             )
         }
     }
@@ -164,6 +167,8 @@ struct WriteNicknameView: View {
                 isDuplicatedNickname = result
                 isNicknameChecked = !result
             }
+            
+            isFocused = false
         }, label: {
             ZStack {
                 RoundedRectangle(cornerRadius: 12)
@@ -175,10 +180,14 @@ struct WriteNicknameView: View {
         })
         .disabled(!isValidLength || !isNormalString)
         ///alert 띄우는 코드
-        .alert(isPresented: $checkNicknameDuplicate){
-            Alert(title: Text("닉네임 중복 확인"),
-                  message: Text(isDuplicatedNickname ? "중복된 닉네임이 있습니다" : "중복된 닉네임이 없습니다"),
-                  dismissButton: .default(Text(isDuplicatedNickname ? "다시 입력하기" : "확인")))
+        .alert("닉네임 중복 확인", isPresented: $checkNicknameDuplicate) {
+            Button(role: .cancel) {
+                
+            } label: {
+                Text(isDuplicatedNickname ? "다시 입력하기" : "확인")
+            }
+        } message: {
+            Text(isDuplicatedNickname ? "중복된 닉네임이 있습니다" : "중복된 닉네임이 없습니다")
         }
     }
     

--- a/HappyAnding/HappyAnding/Views/TabView/ShortcutTabView.swift
+++ b/HappyAnding/HappyAnding/Views/TabView/ShortcutTabView.swift
@@ -14,6 +14,7 @@ struct ShortcutTabView: View {
     @Environment(\.scenePhase) private var phase
     @EnvironmentObject var userAuth: UserAuth
     @EnvironmentObject var shorcutsZipViewModel: ShortcutsZipViewModel
+    
     @AppStorage("signInStatus") var signInStatus = false
     @StateObject var viewModel = ShortcutsZipViewModel()
     @State private var isOpenURL = false
@@ -48,73 +49,64 @@ struct ShortcutTabView: View {
     )}
     
     var body: some View {
-        
-        if signInStatus {
-            TabView(selection: handler) {
-                NavigationStack(path: $shortcutNavigation.navigationPath) {
-                    ExploreShortcutView()
-                        .onChange(of: tappedTwice, perform: { tappedTwice in
-                            guard tappedTwice else { return }
-                            shortcutNavigation.navigationPath.removeLast(shortcutNavigation.navigationPath.count)
-                            self.tappedTwice = false
-                        })
-                }
-                .environmentObject(shortcutNavigation)
-                .tabItem {
-                    Label("단축어", systemImage: "square.stack.3d.up.fill")
-                }
-                .tag(1)
-                
-                NavigationStack(path: $curationNavigation.navigationPath) {
-                    ExploreCurationView()
-                        .onChange(of: tappedTwice, perform: { tappedTwice in
-                            guard tappedTwice else { return }
-                            curationNavigation.navigationPath.removeLast(curationNavigation.navigationPath.count)
-                            self.tappedTwice = false
-                        })
-                }
-                .environmentObject(curationNavigation)
-                .tabItem {
-                    Label("큐레이션", systemImage: "folder.fill")
-                }
-                .tag(2)
-                
-                NavigationStack(path: $profileNavigation.navigationPath) {
-                    MyPageView()
-                        .onChange(of: tappedTwice, perform: { tappedTwice in
-                            guard tappedTwice else { return }
-                            profileNavigation.navigationPath.removeLast(profileNavigation.navigationPath.count)
-                            self.tappedTwice = false
-                        })
-                }
-                .environmentObject(profileNavigation)
-                .tabItem {
-                    Label("프로필", systemImage: "person.crop.circle.fill")
-                }
-                .tag(3)
+        TabView(selection: handler) {
+            NavigationStack(path: $shortcutNavigation.navigationPath) {
+                ExploreShortcutView()
+                    .onChange(of: tappedTwice, perform: { tappedTwice in
+                        guard tappedTwice else { return }
+                        shortcutNavigation.navigationPath.removeLast(shortcutNavigation.navigationPath.count)
+                        self.tappedTwice = false
+                    })
             }
-            .environmentObject(ShortcutsZipViewModel())
-            .sheet(isPresented: self.$isOpenURL) {
-                let data = NavigationReadShortcutType(shortcutID: self.tempShortcutId,
-                                                      navigationParentView: .myPage)
-                ReadShortcutView(data: data)
+            .environmentObject(shortcutNavigation)
+            .tabItem {
+                Label("단축어", systemImage: "square.stack.3d.up.fill")
             }
-            .onChange(of: phase) { newPhase in
-                switch newPhase {
-                case .background: isOpenURL = false
-                default: break
-                }
+            .tag(1)
+            
+            NavigationStack(path: $curationNavigation.navigationPath) {
+                ExploreCurationView()
+                    .onChange(of: tappedTwice, perform: { tappedTwice in
+                        guard tappedTwice else { return }
+                        curationNavigation.navigationPath.removeLast(curationNavigation.navigationPath.count)
+                        self.tappedTwice = false
+                    })
             }
-            .onOpenURL { url in
-                fetchShortcutIdFromUrl(urlString: url.absoluteString)
-                isOpenURL = true
+            .environmentObject(curationNavigation)
+            .tabItem {
+                Label("큐레이션", systemImage: "folder.fill")
             }
-        } else {
-            if userAuth.isLoggedIn {
-                WriteNicknameView()
-            } else {
-                SignInWithAppleView()
+            .tag(2)
+            
+            NavigationStack(path: $profileNavigation.navigationPath) {
+                MyPageView()
+                    .onChange(of: tappedTwice, perform: { tappedTwice in
+                        guard tappedTwice else { return }
+                        profileNavigation.navigationPath.removeLast(profileNavigation.navigationPath.count)
+                        self.tappedTwice = false
+                    })
             }
+            .environmentObject(profileNavigation)
+            .tabItem {
+                Label("프로필", systemImage: "person.crop.circle.fill")
+            }
+            .tag(3)
+        }
+        .environmentObject(ShortcutsZipViewModel())
+        .sheet(isPresented: self.$isOpenURL) {
+            let data = NavigationReadShortcutType(shortcutID: self.tempShortcutId,
+                                                  navigationParentView: .myPage)
+            ReadShortcutView(data: data)
+        }
+        .onChange(of: phase) { newPhase in
+            switch newPhase {
+            case .background: isOpenURL = false
+            default: break
+            }
+        }
+        .onOpenURL { url in
+            fetchShortcutIdFromUrl(urlString: url.absoluteString)
+            isOpenURL = true
         }
     }
     

--- a/HappyAnding/HappyAnding/Views/TabView/ShortcutTabView.swift
+++ b/HappyAnding/HappyAnding/Views/TabView/ShortcutTabView.swift
@@ -16,7 +16,6 @@ struct ShortcutTabView: View {
     @EnvironmentObject var shorcutsZipViewModel: ShortcutsZipViewModel
     @AppStorage("signInStatus") var signInStatus = false
     @StateObject var viewModel = ShortcutsZipViewModel()
-    @State private var tabSelection = Tab.exploreShortcut.tag
     @State private var isOpenURL = false
     @State private var tempShortcutId = ""
     
@@ -107,9 +106,6 @@ struct ShortcutTabView: View {
                 }
             }
             .onOpenURL { url in
-                if let tab = url.tabIdentifier {
-                    tabSelection = tab.tag
-                }
                 fetchShortcutIdFromUrl(urlString: url.absoluteString)
                 isOpenURL = true
             }

--- a/HappyAnding/HappyAnding/Views/TabView/ShortcutTabView.swift
+++ b/HappyAnding/HappyAnding/Views/TabView/ShortcutTabView.swift
@@ -15,6 +15,12 @@ struct ShortcutTabView: View {
     @AppStorage("signInStatus") var signInStatus = false
     @StateObject var viewModel = ShortcutsZipViewModel()
     
+    @StateObject var shortcutNavigation = ShortcutNavigation()
+    @StateObject var curationNavigation = CurationNavigation()
+    @StateObject var profileNavigation = ProfileNavigation()
+    @State private var tabSelection = 1
+    @State private var tappedTwice = false
+    
     init() {
         let transparentAppearence = UITabBarAppearance()
         transparentAppearence.configureWithTransparentBackground()
@@ -27,17 +33,62 @@ struct ShortcutTabView: View {
         Theme.navigationBarColors()
     }
     
+    var handler: Binding<Int> { Binding(
+        get: { self.tabSelection },
+        set: {
+            if $0 == self.tabSelection {
+                tappedTwice = true
+            }
+            self.tabSelection = $0
+        }
+    )}
+    
     var body: some View {
         
         if signInStatus {
-//            let _ = shorcutsZipViewModel.initUserInfo()
-            TabView {
-                ForEach(Tab.allCases, id: \.self) { tab in
-                    tab.view
-                        .tabItem {
-                            Label(tab.tabName, systemImage: tab.systemImage)
-                        }
+            //            let _ = shorcutsZipViewModel.initUserInfo()
+            TabView(selection: handler) {
+                NavigationStack(path: $shortcutNavigation.navigationPath) {
+                    ExploreShortcutView()
+                        .onChange(of: tappedTwice, perform: { tappedTwice in
+                            guard tappedTwice else { return }
+                            shortcutNavigation.navigationPath.removeLast(shortcutNavigation.navigationPath.count)
+                            self.tappedTwice = false
+                        })
                 }
+                .environmentObject(shortcutNavigation)
+                .tabItem {
+                    Label("단축어", systemImage: "square.stack.3d.up.fill")
+                }
+                .tag(1)
+                
+                NavigationStack(path: $curationNavigation.navigationPath) {
+                    ExploreCurationView()
+                        .onChange(of: tappedTwice, perform: { tappedTwice in
+                            guard tappedTwice else { return }
+                            curationNavigation.navigationPath.removeLast(curationNavigation.navigationPath.count)
+                            self.tappedTwice = false
+                        })
+                }
+                .environmentObject(curationNavigation)
+                .tabItem {
+                    Label("큐레이션", systemImage: "folder.fill")
+                }
+                .tag(2)
+                
+                NavigationStack(path: $profileNavigation.navigationPath) {
+                    MyPageView()
+                        .onChange(of: tappedTwice, perform: { tappedTwice in
+                            guard tappedTwice else { return }
+                            profileNavigation.navigationPath.removeLast(profileNavigation.navigationPath.count)
+                            self.tappedTwice = false
+                        })
+                }
+                .environmentObject(profileNavigation)
+                .tabItem {
+                    Label("프로필", systemImage: "person.crop.circle.fill")
+                }
+                .tag(3)
             }
             .environmentObject(ShortcutsZipViewModel())
         } else {

--- a/HappyAnding/HappyAnding/Views/TabView/ShortcutTabView.swift
+++ b/HappyAnding/HappyAnding/Views/TabView/ShortcutTabView.swift
@@ -6,14 +6,19 @@
 //
 
 import SwiftUI
+import BackgroundTasks
 
 struct ShortcutTabView: View {
     
     // TODO: StateObject로 선언할 수 있는 다른 로직 구현해보기
+    @Environment(\.scenePhase) private var phase
     @EnvironmentObject var userAuth: UserAuth
     @EnvironmentObject var shorcutsZipViewModel: ShortcutsZipViewModel
     @AppStorage("signInStatus") var signInStatus = false
     @StateObject var viewModel = ShortcutsZipViewModel()
+    @State private var tabSelection = Tab.exploreShortcut.tag
+    @State private var isOpenURL = false
+    @State private var tempShortcutId = ""
     
     @StateObject var shortcutNavigation = ShortcutNavigation()
     @StateObject var curationNavigation = CurationNavigation()
@@ -46,7 +51,6 @@ struct ShortcutTabView: View {
     var body: some View {
         
         if signInStatus {
-            //            let _ = shorcutsZipViewModel.initUserInfo()
             TabView(selection: handler) {
                 NavigationStack(path: $shortcutNavigation.navigationPath) {
                     ExploreShortcutView()
@@ -91,6 +95,24 @@ struct ShortcutTabView: View {
                 .tag(3)
             }
             .environmentObject(ShortcutsZipViewModel())
+            .sheet(isPresented: self.$isOpenURL) {
+                let data = NavigationReadShortcutType(shortcutID: self.tempShortcutId,
+                                                      navigationParentView: .myPage)
+                ReadShortcutView(data: data)
+            }
+            .onChange(of: phase) { newPhase in
+                switch newPhase {
+                case .background: isOpenURL = false
+                default: break
+                }
+            }
+            .onOpenURL { url in
+                if let tab = url.tabIdentifier {
+                    tabSelection = tab.tag
+                }
+                fetchShortcutIdFromUrl(urlString: url.absoluteString)
+                isOpenURL = true
+            }
         } else {
             if userAuth.isLoggedIn {
                 WriteNicknameView()
@@ -98,6 +120,25 @@ struct ShortcutTabView: View {
                 SignInWithAppleView()
             }
         }
+    }
+    
+    private func fetchShortcutIdFromUrl(urlString: String) {
+        
+        guard urlString.contains("shortcutID") else { return }
+        
+        let components = URLComponents(string: urlString)
+        let urlQueryItems = components?.queryItems ?? []
+        
+        var dictionaryData = [String: String]()
+        urlQueryItems.forEach {
+            dictionaryData[$0.name] = $0.value
+        }
+        
+        guard let shortcutIDfromURL = dictionaryData["shortcutID"] else { return }
+        
+        print("shortcutIDfromURL = \(shortcutIDfromURL)")
+        
+        tempShortcutId  = shortcutIDfromURL
     }
 }
 

--- a/HappyAnding/HappyAnding/Views/TabView/ShortcutTabView.swift
+++ b/HappyAnding/HappyAnding/Views/TabView/ShortcutTabView.swift
@@ -13,10 +13,8 @@ struct ShortcutTabView: View {
     // TODO: StateObject로 선언할 수 있는 다른 로직 구현해보기
     @Environment(\.scenePhase) private var phase
     @EnvironmentObject var userAuth: UserAuth
-    @EnvironmentObject var shorcutsZipViewModel: ShortcutsZipViewModel
     
     @AppStorage("signInStatus") var signInStatus = false
-    @StateObject var viewModel = ShortcutsZipViewModel()
     @State private var isOpenURL = false
     @State private var tempShortcutId = ""
     
@@ -91,9 +89,7 @@ struct ShortcutTabView: View {
                 Label("프로필", systemImage: "person.crop.circle.fill")
             }
             .tag(3)
-        }
-        .environmentObject(ShortcutsZipViewModel())
-        .sheet(isPresented: self.$isOpenURL) {
+        }        .sheet(isPresented: self.$isOpenURL) {
             let data = NavigationReadShortcutType(shortcutID: self.tempShortcutId,
                                                   navigationParentView: .myPage)
             ReadShortcutView(data: data)

--- a/HappyAnding/HappyAnding/Views/TabView/TabRouter.swift
+++ b/HappyAnding/HappyAnding/Views/TabView/TabRouter.swift
@@ -4,7 +4,6 @@
 //
 //  Created by KiWoong Hong on 2022/10/21.
 //
-
 //import SwiftUI
 //
 //enum Tab: CaseIterable {

--- a/HappyAnding/HappyAnding/Views/TabView/TabRouter.swift
+++ b/HappyAnding/HappyAnding/Views/TabView/TabRouter.swift
@@ -5,35 +5,35 @@
 //  Created by KiWoong Hong on 2022/10/21.
 //
 
-import SwiftUI
-
-enum Tab: CaseIterable {
-    case exploreShortcut
-    case collect
-    case myPage
-    
-    var tabName: String {
-        switch self {
-        case .exploreShortcut : return "단축어"
-        case .collect: return "큐레이션"
-        case .myPage: return "프로필"
-        }
-    }
-    
-    var systemImage: String {
-        switch self {
-        case .exploreShortcut : return "square.stack.3d.up.fill"
-        case .collect: return "folder.fill"
-        case .myPage: return "person.crop.circle.fill"
-        }
-    }
-    
-    @ViewBuilder
-    var view: some View {
-        switch self {
-        case .exploreShortcut : ExploreShortcutView()
-        case .collect: ExploreCurationView()
-        case .myPage: MyPageView()
-        }
-    }
-}
+//import SwiftUI
+//
+//enum Tab: CaseIterable {
+//    case exploreShortcut
+//    case collect
+//    case myPage
+//    
+//    var tabName: String {
+//        switch self {
+//        case .exploreShortcut : return "단축어"
+//        case .collect: return "큐레이션"
+//        case .myPage: return "프로필"
+//        }
+//    }
+//    
+//    var systemImage: String {
+//        switch self {
+//        case .exploreShortcut : return "square.stack.3d.up.fill"
+//        case .collect: return "folder.fill"
+//        case .myPage: return "person.crop.circle.fill"
+//        }
+//    }
+//    
+//    @ViewBuilder
+//    var view: some View {
+//        switch self {
+//        case .exploreShortcut : ExploreShortcutView()
+//        case .collect: ExploreCurationView()
+//        case .myPage: MyPageView()
+//        }
+//    }
+//}

--- a/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationInfoView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationInfoView.swift
@@ -52,28 +52,18 @@ struct WriteCurationInfoView: View {
                 .frame(maxHeight: .infinity)
             
             Button {
-                
-                print(" tapped \(curation)")
                 curation.author = shortcutsZipViewModel.currentUser()
-                
-                if isEdit {
-                    if let index = shortcutsZipViewModel.curationsMadeByUser.firstIndex(where: { $0.id == curation.id}) {
-                        shortcutsZipViewModel.curationsMadeByUser[index] = curation
-                    }
-                } else {
-                    shortcutsZipViewModel.curationsMadeByUser.insert(curation, at: 0)
-                    shortcutsZipViewModel.userCurations.insert(curation, at: 0)
-                }
                 shortcutsZipViewModel.setData(model: curation)
                 shortcutsZipViewModel.updateShortcutCurationID(
                     shortcutCells: curation.shortcuts,
                     curationID: curation.id
                 )
+                if let index = shortcutsZipViewModel.userCurations.firstIndex(where: { $0.id == curation.id}) {
+                    shortcutsZipViewModel.userCurations[index] = curation
+                }
                 
                 self.isWriting.toggle()
-                
                 writeCurationNavigation.navigationPath = .init()
-                
             } label: {
                 ZStack {
                     RoundedRectangle(cornerRadius: 12)

--- a/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationSetView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationSetView.swift
@@ -78,7 +78,7 @@ struct WriteCurationSetView: View {
                 Button {
                     self.isWriting.toggle()
                 } label: {
-                    Text("닫기")
+                    Text("취소")
                         .foregroundColor(.Gray5)
                 }
             }

--- a/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationSetView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationSetView.swift
@@ -13,7 +13,7 @@ struct WriteCurationSetView: View {
     
     @Binding var isWriting: Bool
     
-    @State var shortcutCells = Set<ShortcutCellModel>()
+    @State var shortcutCells = [ShortcutCellModel]()
     @State var isSelected = false
     @State var curation = Curation(title: "",
                                    subtitle: "",
@@ -56,12 +56,7 @@ struct WriteCurationSetView: View {
             .navigationTitle(isEdit ? "큐레이션 편집" : "큐레이션 만들기")
             .navigationBarTitleDisplayMode(.inline)
             .onAppear {
-                shortcutsZipViewModel.fetchMadeShortcutCell { shortcuts in
-                    self.shortcutCells = self.shortcutCells.union(shortcuts)
-                }
-                shortcutsZipViewModel.fetchLikedShortcutCell { shortcuts in
-                    self.shortcutCells = self.shortcutCells.union(shortcuts)
-                }
+                self.shortcutCells = shortcutsZipViewModel.fetchShortcutMakeCuration()
             }
             
             if isTappedQuestionMark {

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTagView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTagView.swift
@@ -69,29 +69,14 @@ struct WriteShortcutTagView: View {
             Spacer()
             
             Button(action: {
-                shortcut.author = shortcutsZipViewModel.currentUser()
+                if let index = shortcutsZipViewModel.allShortcuts.firstIndex(where: {$0.id == shortcut.id}) {
+                    shortcutsZipViewModel.allShortcuts[index] = shortcut
+                }
                 
+                shortcut.author = shortcutsZipViewModel.currentUser()
                 if isEdit {
-                    
-                    newCategory = shortcut.category
-                    
-                    //뷰모델에서 변경
-                    if let index = shortcutsZipViewModel.shortcutsUserLiked.firstIndex(where: { $0.id == shortcut.id}) {
-                        shortcutsZipViewModel.shortcutsUserLiked[index] = shortcut
-                    }
-                    if let index = shortcutsZipViewModel.shortcutsUserDownloaded.firstIndex(where: { $0.id == shortcut.id}) {
-                        shortcutsZipViewModel.shortcutsUserDownloaded[index] = shortcut
-                    }
-                    if let index = shortcutsZipViewModel.shortcutsMadeByUser.firstIndex(where: { $0.id == shortcut.id}) {
-                        shortcutsZipViewModel.shortcutsMadeByUser[index] = shortcut
-                    }
-                    if let index = shortcutsZipViewModel.sortedShortcutsByDownload.firstIndex(where: { $0.id == shortcut.id}) {
-                        shortcutsZipViewModel.sortedShortcutsByDownload[index] = shortcut
-                    }
-                    if let index = shortcutsZipViewModel.sortedShortcutsByLike.firstIndex(where: { $0.id == shortcut.id}) {
-                        shortcutsZipViewModel.sortedShortcutsByLike[index] = shortcut
-                    }
                     //뷰모델의 카테고리별 단축어 목록에서 정보 수정
+                    newCategory = shortcut.category
                     existingCategory.forEach { category in
                         if !shortcut.category.contains(category) {
                             newCategory.removeAll(where: { $0 == category })
@@ -123,17 +108,11 @@ struct WriteShortcutTagView: View {
                         ),
                         curationIDs: shortcut.curationIDs
                     )
-                    
                 } else {
                     //새로운 단축어 생성 및 저장
                     // 뷰모델에 추가
                     shortcutsZipViewModel.shortcutsMadeByUser.insert(shortcut, at: 0)
-                    shortcutsZipViewModel.sortedShortcutsByDownload.append(shortcut)
-                    shortcut.category.forEach { category in
-                        if !shortcutsZipViewModel.isFirstFetchInCategory[Category(rawValue: category)!.index] {
-                            shortcutsZipViewModel.shortcutsInCategory[Category(rawValue: category)!.index].insert(shortcut, at: 0)
-                        }
-                    }
+                    
                     // 서버에 추가
                     shortcutsZipViewModel.setData(model: shortcut)
                 }

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTagView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTagView.swift
@@ -218,9 +218,11 @@ struct WriteShortcutTagView: View {
                                 isFocused = true
                             }
                             .onChange(of: isFocused) { _ in
-                                if !isFocused && !relatedApp.isEmpty {
-                                    relatedApps.append(relatedApp)
-                                    relatedApp = ""
+                                if !isFocused {
+                                    if !relatedApp.isEmpty {
+                                        relatedApps.append(relatedApp)
+                                        relatedApp = ""
+                                    }
                                     isTextFieldShowing = false
                                 }
                             }

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTitleView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTitleView.swift
@@ -127,7 +127,7 @@ struct WriteShortcutTitleView: View {
                 Button {
                     self.presentationMode.wrappedValue.dismiss()
                 } label: {
-                    Text("닫기")
+                    Text("취소")
                         .foregroundColor(.Gray5)
                 }
             }


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->

## 관련 이슈
- closes #244 

## 구현/변경 사항
- ShortcutsZipViewModel의 fetch 함수 변경
- 기존에 각 종류별로 리스트를 fetch해오는 방식에서 한번에 모든 단축어/큐레이션을 fetch한 후 내부에서 각 리스트로 분류하도록 변경
- ShortcutsZipViewModel초기 선언 위치 변경
- 유저 로그아웃 / 탈퇴 시 뷰모델 정보 리셋함수 생성 및 적용
- 로그인 / 회원가입 시 유저 정보 받아오도록 적용
- 단축어 좋아요/다운로드 클릭 시 바로 정보 업데이트하는 것이 아닌 해당 뷰 disappear시에 업데이트 되도록 변경

(검수 필요)
- 단축어 업데이트 함수 추가
- 댓글 기능 함수 추가

## 확인된 이슈
- 큐레이션 편집에서 단축어 선택 변경 시 화면에서 지워진 단축어가 제대로 반영되지 않음 -> 정보는 제대로 수정되지만 뷰가 초기화되지 않아서 생기는 문제로 보입니다.
- 좋아요한 단축어 리스트에서 단축어 좋아요 취소 시 맨 아래의 셀이 지워지는 문제 -> 뷰가 제대로 초기화되지 않아서 생기는 문제로 추정

## To Reviewer
- 새롭게 추가되는 기능들은 반영되지 않았습니다. 곧 추가해서 한번 더 올리겠습니다!
- 10개씩 불러오는 기능은 추후..추가하도록하겠습니다
- 제가 QA를 열심히 한다고 했지만 아직 부족한 부분이 있을 수 있으니 꼭 한번 씩 확인 부탁드립니다.

## 스크린샷
화면 상의 변경점이 없어 생략합니다.