### PR TITLE
[Feat] 다운로드 버튼 기능 업데이트

### DIFF
--- a/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
+++ b/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
@@ -482,6 +482,15 @@ class ShortcutsZipViewModel: ObservableObject {
         }
     }
     
+    //MARK: 다운로드 링크 업데이트하는 함수
+    
+    func updateDownloadLinkUpdate(shortcut: Shortcuts) {
+        if let index = self.userInfo?.downloadedShortcuts.firstIndex(where: { $0.id == shortcut.id}) {
+            self.userInfo?.downloadedShortcuts[index].downloadLink = shortcut.downloadLink[0]
+            self.setData(model: userInfo)
+        }
+    }
+    
     //MARK: 큐레이션 생성 시 포함된 단축어에 큐레이션 아이디를 저장하는 함수
     
     func updateShortcutCurationID (shortcutCells: [ShortcutCellModel], curationID: String) {

--- a/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
+++ b/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
@@ -46,6 +46,7 @@ class ShortcutsZipViewModel: ObservableObject {
     var allShortcuts: [Shortcuts] = []
 
     init() {
+        print("**init \(userInfo) \(shortcutsMadeByUser) \(curationsMadeByUser)")
         fetchUser(userID: self.currentUser()) { user in
             self.userInfo = user
             self.initUserShortcut(user: user)
@@ -575,6 +576,8 @@ class ShortcutsZipViewModel: ObservableObject {
         self.userInfo = nil
         self.shortcutsMadeByUser.removeAll()
         self.curationsMadeByUser.removeAll()
+        self.shortcutsUserDownloaded.removeAll()
+        self.shortcutsUserLiked.removeAll()
     }
     
     // MARK: 현재 로그인한 아이디 리턴

--- a/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
+++ b/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
@@ -46,7 +46,6 @@ class ShortcutsZipViewModel: ObservableObject {
     var allShortcuts: [Shortcuts] = []
 
     init() {
-        print("**init \(userInfo) \(shortcutsMadeByUser) \(curationsMadeByUser)")
         fetchUser(userID: self.currentUser()) { user in
             self.userInfo = user
             self.initUserShortcut(user: user)
@@ -762,7 +761,6 @@ class ShortcutsZipViewModel: ObservableObject {
                 print("Error fetching snapshots: \(error!)")
                 return
             }
-            print(snapshot.metadata.isFromCache ? "**local cache" : "**server")
             snapshot.documentChanges.forEach { diff in
                 let decoder = JSONDecoder()
                 

--- a/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
+++ b/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
@@ -463,7 +463,7 @@ class ShortcutsZipViewModel: ObservableObject {
     
     //MARK: 다운로드 수를 업데이트하는 함수
     
-    func updateNumberOfDownload(shortcut: Shortcuts) {
+    func updateNumberOfDownload(shortcut: Shortcuts, downloadlinkIndex: Int) {
         self.fetchUser(userID: currentUser()) { data in
             var user = data
             if !data.downloadedShortcuts.contains(where: { $0.id == shortcut.id }) {
@@ -475,7 +475,7 @@ class ShortcutsZipViewModel: ObservableObject {
                             print(error.localizedDescription)
                         }
                     }
-                let shortcutInfo = DownloadedShortcut(id: shortcut.id, downloadLink: shortcut.downloadLink[0])
+                let shortcutInfo = DownloadedShortcut(id: shortcut.id, downloadLink: shortcut.downloadLink[downloadlinkIndex])
                 user.downloadedShortcuts.append(shortcutInfo)
                 self.setData(model: user)
             }
@@ -487,7 +487,7 @@ class ShortcutsZipViewModel: ObservableObject {
     func updateDownloadLinkUpdate(shortcut: Shortcuts) {
         if let index = self.userInfo?.downloadedShortcuts.firstIndex(where: { $0.id == shortcut.id}) {
             self.userInfo?.downloadedShortcuts[index].downloadLink = shortcut.downloadLink[0]
-            self.setData(model: userInfo)
+            self.setData(model: userInfo as Any)
         }
     }
     

--- a/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
+++ b/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
@@ -463,6 +463,10 @@ class ShortcutsZipViewModel: ObservableObject {
     
     //MARK: 다운로드 수를 업데이트하는 함수
     
+    /**
+    서버 숫자 업데이트
+    
+     */
     func updateNumberOfDownload(shortcut: Shortcuts, downloadlinkIndex: Int) {
         self.fetchUser(userID: currentUser()) { data in
             var user = data

--- a/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
@@ -61,7 +61,7 @@ struct ShortcutCell: View {
                         if let url = URL(string: shortcutCell.downloadLink) {
                             openURL(url)
                             if let shortcut = shortcutsZipViewModel.fetchShortcutDetail(id: shortcutCell.id) {
-                                shortcutsZipViewModel.updateNumberOfDownload(shortcut: shortcut)
+                                shortcutsZipViewModel.updateNumberOfDownload(shortcut: shortcut, downloadlinkIndex: 0)
                             }
                         }
                     }

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutVersionView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutVersionView.swift
@@ -10,8 +10,11 @@ import SwiftUI
 struct ReadShortcutVersionView: View {
     
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
+    @Environment(\.openURL) var openURL
+    
     @Binding var shortcut: Shortcuts
     @Binding var isUpdating: Bool
+    @Binding var isClickDownload: Bool
     
     var body: some View {
         if shortcut.updateDescription.count == 1 {
@@ -41,9 +44,19 @@ struct ReadShortcutVersionView: View {
                                 .foregroundColor(.Gray5)
                         }
                         if index != 0 {
-                            let link = "[이전 버전 다운로드](\(shortcut.downloadLink[index]))"
-                            Text(.init(link))
-                                .tint(.Primary)
+                            Button {
+                                if let url = URL(string: shortcut.downloadLink[index]) {
+                                    isClickDownload = true
+                                    if (shortcutsZipViewModel.userInfo?.downloadedShortcuts.firstIndex(where: { $0.id == shortcut.id })) == nil {
+                                        shortcut.numberOfDownload += 1
+                                    }
+                                    openURL(url)
+                                }
+                            } label: {
+                                Text("이전 버전 다운로드")
+                                    .Body1()
+                                    .foregroundColor(.Primary)
+                            }
                         }
                         Divider()
                             .foregroundColor(.Gray1)

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutVersionView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutVersionView.swift
@@ -46,9 +46,10 @@ struct ReadShortcutVersionView: View {
                         if index != 0 {
                             Button {
                                 if let url = URL(string: shortcut.downloadLink[index]) {
-                                    isClickPreviousDownload = true
                                     if (shortcutsZipViewModel.userInfo?.downloadedShortcuts.firstIndex(where: { $0.id == shortcut.id })) == nil {
                                         shortcut.numberOfDownload += 1
+                                        shortcutsZipViewModel.updateNumberOfDownload(shortcut: shortcut, downloadlinkIndex: index)
+                                        shortcutsZipViewModel.shortcutsUserDownloaded.insert(shortcut, at: 0)
                                     }
                                     openURL(url)
                                 }

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutVersionView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutVersionView.swift
@@ -47,9 +47,8 @@ struct ReadShortcutVersionView: View {
                                 if let url = URL(string: shortcut.downloadLink[index]) {
                                     if (shortcutsZipViewModel.userInfo?.downloadedShortcuts.firstIndex(where: { $0.id == shortcut.id })) == nil {
                                         shortcut.numberOfDownload += 1
-                                        shortcutsZipViewModel.updateNumberOfDownload(shortcut: shortcut, downloadlinkIndex: index)
-                                        shortcutsZipViewModel.shortcutsUserDownloaded.insert(shortcut, at: 0)
                                     }
+                                    shortcutsZipViewModel.updateNumberOfDownload(shortcut: shortcut, downloadlinkIndex: index)
                                     openURL(url)
                                 }
                             } label: {

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutVersionView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutVersionView.swift
@@ -14,7 +14,7 @@ struct ReadShortcutVersionView: View {
     
     @Binding var shortcut: Shortcuts
     @Binding var isUpdating: Bool
-    @Binding var isClickDownload: Bool
+    @Binding var isClickPreviousDownload: Bool
     
     var body: some View {
         if shortcut.updateDescription.count == 1 {
@@ -46,7 +46,7 @@ struct ReadShortcutVersionView: View {
                         if index != 0 {
                             Button {
                                 if let url = URL(string: shortcut.downloadLink[index]) {
-                                    isClickDownload = true
+                                    isClickPreviousDownload = true
                                     if (shortcutsZipViewModel.userInfo?.downloadedShortcuts.firstIndex(where: { $0.id == shortcut.id })) == nil {
                                         shortcut.numberOfDownload += 1
                                     }
@@ -54,7 +54,7 @@ struct ReadShortcutVersionView: View {
                                 }
                             } label: {
                                 Text("이전 버전 다운로드")
-                                    .Body1()
+                                    .Body2()
                                     .foregroundColor(.Primary)
                             }
                         }

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutVersionView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutVersionView.swift
@@ -14,7 +14,6 @@ struct ReadShortcutVersionView: View {
     
     @Binding var shortcut: Shortcuts
     @Binding var isUpdating: Bool
-    @Binding var isClickPreviousDownload: Bool
     
     var body: some View {
         if shortcut.updateDescription.count == 1 {

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -130,11 +130,13 @@ struct ReadShortcutView: View {
             if let shortcut = data.shortcut {
                 let isAlreadyContained = shortcutsZipViewModel.userInfo?.downloadedShortcuts.firstIndex(where: { $0.id == self.data.shortcutID}) == nil
                 if isClickDownload && isAlreadyContained {
-                    shortcutsZipViewModel.updateNumberOfDownload(shortcut: shortcut)
+                    shortcutsZipViewModel.updateNumberOfDownload(shortcut: shortcut, downloadlinkIndex: 0)
                     shortcutsZipViewModel.shortcutsUserDownloaded.insert(shortcut, at: 0)
                     
                     let downloadedShortcut = DownloadedShortcut(id: shortcut.id, downloadLink: shortcut.downloadLink[0])
                     shortcutsZipViewModel.userInfo?.downloadedShortcuts.insert(downloadedShortcut, at: 0)
+                } else if isClickDownload && !isAlreadyContained {
+                    shortcutsZipViewModel.updateDownloadLinkUpdate(shortcut: shortcut)
                 }
                 if isMyLike != isFirstMyLike {
                     shortcutsZipViewModel.updateNumberOfLike(isMyLike: isMyLike, shortcut: shortcut)

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -149,8 +149,7 @@ struct ReadShortcutView: View {
             leading:
                 btnBack
                 .padding(.leading, -8)
-                .frame(width: 30, alignment: .leading)
-                .background(Color.red),
+                .frame(width: 30, alignment: .leading),
             trailing: Menu(content: {
                 if self.data.shortcut?.author == shortcutsZipViewModel.currentUser() {
                     myShortcutMenuSection

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -89,21 +89,7 @@ struct ReadShortcutView: View {
                 if !isFocused {
                     if let shortcut = data.shortcut {
                         Button {
-                            if var user = shortcutsZipViewModel.userInfo {
-                                print("**\(user.downloadedShortcuts)")
-                                if let index = user.downloadedShortcuts.firstIndex(where: { $0.id == shortcut.id}) {
-                                    print("**index \(index)")
-                                    user.downloadedShortcuts[index].downloadLink = shortcut.downloadLink[0]
-                                    shortcutsZipViewModel.setData(model: user)
-                                }
-                                else {
-                                    shortcutsZipViewModel.updateNumberOfDownload(shortcut: shortcut, downloadlinkIndex: 0)
-                                    shortcutsZipViewModel.shortcutsUserDownloaded.insert(shortcut, at: 0)
-                                    let downloadedShortcut = DownloadedShortcut(id: shortcut.id, downloadLink: shortcut.downloadLink[0])
-                                    shortcutsZipViewModel.userInfo?.downloadedShortcuts.insert(downloadedShortcut, at: 0)
-                                    print("**\(shortcutsZipViewModel.userInfo?.downloadedShortcuts)")
-                                }
-                            }
+                            shortcutsZipViewModel.updateNumberOfDownload(shortcut: shortcut, downloadlinkIndex: 0)
                             if let url = URL(string: shortcut.downloadLink[0]) {
                                 if (shortcutsZipViewModel.userInfo?.downloadedShortcuts.firstIndex(where: { $0.id == data.shortcutID })) == nil {
                                     data.shortcut?.numberOfDownload += 1

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -144,16 +144,23 @@ struct ReadShortcutView: View {
             }
         }
         .navigationBarTitleDisplayMode(NavigationBarItem.TitleDisplayMode.inline)
-        .navigationBarItems(trailing: Menu(content: {
-            if self.data.shortcut?.author == shortcutsZipViewModel.currentUser() {
-                myShortcutMenuSection
-            } else {
-                otherShortcutMenuSection
-            }
-        }, label: {
-            Image(systemName: "ellipsis")
-                .foregroundColor(.Gray4)
-        }))
+        
+        .navigationBarItems(
+            leading:
+                btnBack
+                .padding(.leading, -8)
+                .frame(width: 30, alignment: .leading)
+                .background(Color.red),
+            trailing: Menu(content: {
+                if self.data.shortcut?.author == shortcutsZipViewModel.currentUser() {
+                    myShortcutMenuSection
+                } else {
+                    otherShortcutMenuSection
+                }
+            }, label: {
+                Image(systemName: "ellipsis")
+                    .foregroundColor(.Gray4)
+            }))
         .alert("글 삭제", isPresented: $isTappedDeleteButton) {
             Button(role: .cancel) {
                 
@@ -194,7 +201,6 @@ struct ReadShortcutView: View {
                         for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
         .navigationBarBackButtonHidden(true)
-        .navigationBarItems(leading: btnBack.padding(.horizontal, -8))
     }
     
     var btnBack : some View {

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -360,7 +360,7 @@ extension ReadShortcutView {
                                                 value: geometryProxy.size)
                             })
                 case 1:
-                    ReadShortcutVersionView(shortcut: $data.shortcut.unwrap()!, isUpdating: $isUpdating)
+                    ReadShortcutVersionView(shortcut: $data.shortcut.unwrap()!, isUpdating: $isUpdating, isClickDownload: $isClickDownload)
                         .background(
                             GeometryReader { geometryProxy in
                                 Color.clear

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -28,7 +28,6 @@ struct ReadShortcutView: View {
     @State var isMyLike: Bool = false
     @State var isFirstMyLike = false
     @State var isClickDownload = false
-    @State var isClickPreviousDownload = false
     
     @State var data: NavigationReadShortcutType
     @State var comments: Comments = Comments(id: "", comments: [])
@@ -90,6 +89,21 @@ struct ReadShortcutView: View {
                 if !isFocused {
                     if let shortcut = data.shortcut {
                         Button {
+                            if var user = shortcutsZipViewModel.userInfo {
+                                print("**\(user.downloadedShortcuts)")
+                                if let index = user.downloadedShortcuts.firstIndex(where: { $0.id == shortcut.id}) {
+                                    print("**index \(index)")
+                                    user.downloadedShortcuts[index].downloadLink = shortcut.downloadLink[0]
+                                    shortcutsZipViewModel.setData(model: user)
+                                }
+                                else {
+                                    shortcutsZipViewModel.updateNumberOfDownload(shortcut: shortcut, downloadlinkIndex: 0)
+                                    shortcutsZipViewModel.shortcutsUserDownloaded.insert(shortcut, at: 0)
+                                    let downloadedShortcut = DownloadedShortcut(id: shortcut.id, downloadLink: shortcut.downloadLink[0])
+                                    shortcutsZipViewModel.userInfo?.downloadedShortcuts.insert(downloadedShortcut, at: 0)
+                                    print("**\(shortcutsZipViewModel.userInfo?.downloadedShortcuts)")
+                                }
+                            }
                             if let url = URL(string: shortcut.downloadLink[0]) {
                                 if (shortcutsZipViewModel.userInfo?.downloadedShortcuts.firstIndex(where: { $0.id == data.shortcutID })) == nil {
                                     data.shortcut?.numberOfDownload += 1
@@ -128,16 +142,6 @@ struct ReadShortcutView: View {
         }
         .onDisappear() {
             if let shortcut = data.shortcut {
-                let isAlreadyContained = shortcutsZipViewModel.userInfo?.downloadedShortcuts.firstIndex(where: { $0.id == self.data.shortcutID}) == nil
-                if isClickDownload && isAlreadyContained {
-                    shortcutsZipViewModel.updateNumberOfDownload(shortcut: shortcut, downloadlinkIndex: 0)
-                    shortcutsZipViewModel.shortcutsUserDownloaded.insert(shortcut, at: 0)
-                    
-                    let downloadedShortcut = DownloadedShortcut(id: shortcut.id, downloadLink: shortcut.downloadLink[0])
-                    shortcutsZipViewModel.userInfo?.downloadedShortcuts.insert(downloadedShortcut, at: 0)
-                } else if isClickDownload && !isAlreadyContained {
-                    shortcutsZipViewModel.updateDownloadLinkUpdate(shortcut: shortcut)
-                }
                 if isMyLike != isFirstMyLike {
                     shortcutsZipViewModel.updateNumberOfLike(isMyLike: isMyLike, shortcut: shortcut)
                 }
@@ -368,7 +372,7 @@ extension ReadShortcutView {
                                                 value: geometryProxy.size)
                             })
                 case 1:
-                    ReadShortcutVersionView(shortcut: $data.shortcut.unwrap()!, isUpdating: $isUpdating, isClickPreviousDownload: $isClickPreviousDownload)
+                    ReadShortcutVersionView(shortcut: $data.shortcut.unwrap()!, isUpdating: $isUpdating)
                         .background(
                             GeometryReader { geometryProxy in
                                 Color.clear

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -28,6 +28,7 @@ struct ReadShortcutView: View {
     @State var isMyLike: Bool = false
     @State var isFirstMyLike = false
     @State var isClickDownload = false
+    @State var isClickPreviousDownload = false
     
     @State var data: NavigationReadShortcutType
     @State var comments: Comments = Comments(id: "", comments: [])
@@ -360,7 +361,7 @@ extension ReadShortcutView {
                                                 value: geometryProxy.size)
                             })
                 case 1:
-                    ReadShortcutVersionView(shortcut: $data.shortcut.unwrap()!, isUpdating: $isUpdating, isClickDownload: $isClickDownload)
+                    ReadShortcutVersionView(shortcut: $data.shortcut.unwrap()!, isUpdating: $isUpdating, isClickPreviousDownload: $isClickPreviousDownload)
                         .background(
                             GeometryReader { geometryProxy in
                                 Color.clear


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #295 

## 구현/변경 사항
- 이전버전 다운로드 클릭 시 다운로드 숫자 업데이트
- 최신버전 다운로드 클릭 시 현재 가지고 있는 링크와 비교 후 다르면 유저정보 업데이트
- 로그아웃 시 유저가 다운로드한 단축어, 유저가 좋아요한 단축어를 추가적으로 초기화하도록 했습니다.

## 스크린샷
https://user-images.githubusercontent.com/41153398/203975728-aaa9c069-398d-4e6a-b443-aeaae99877d2.mov
