### PR TITLE
[Feat] 댓글 수정 + 네비게이션바 버튼 통일

### DIFF
--- a/HappyAnding/HappyAnding/Extensions/Navigationbar+Extension.swift
+++ b/HappyAnding/HappyAnding/Extensions/Navigationbar+Extension.swift
@@ -37,6 +37,7 @@ struct NavigationBarColorModifier<Background>: ViewModifier where Background: Vi
         
         let scrollAppearance = UINavigationBarAppearance()
         scrollAppearance.configureWithDefaultBackground()
+        scrollAppearance.backgroundColor = UIColor(Color.White)
         scrollAppearance.shadowColor = .clear
         scrollAppearance.largeTitleTextAttributes = [.font : UIFont.LargeTitle, .foregroundColor: UIColor(.Gray5)]
         scrollAppearance.backButtonAppearance = backItemAppearance

--- a/HappyAnding/HappyAnding/Extensions/Navigationbar+Extension.swift
+++ b/HappyAnding/HappyAnding/Extensions/Navigationbar+Extension.swift
@@ -8,15 +8,19 @@
 import SwiftUI
 
 /**
+ 네비게이션바 아이템 색상을 변경하기 위한 클래스 입니다.
  맨 처음 뷰가 선언되는 시점에 Theme.navigationBarColors() 를 선언하여 사용해주세요.
 */
-///네비게이션바 아이템 색상을 변경하기 위한 클래스 입니다.
-class Theme {
-    static func navigationBarColors() {
-        
+
+//출처: https://velog.io/@whale/SwiftUI-NavigationBar-Background-%EC%A1%B0%EC%A0%88%ED%95%98%EA%B8%B0
+struct NavigationBarColorModifier<Background>: ViewModifier where Background: View {
+    
+    let background: () -> Background
+    
+    public init(@ViewBuilder background: @escaping () -> Background) {
         let appearance = UINavigationBarAppearance()
         appearance.configureWithOpaqueBackground()
-        appearance.backgroundColor = UIColor(Color.Background)
+        appearance.backgroundColor = UIColor.clear
         appearance.shadowColor = .clear
         appearance.largeTitleTextAttributes = [.font : UIFont.LargeTitle, .foregroundColor: UIColor(.Gray5)]
         //back button color 지정
@@ -31,9 +35,38 @@ class Theme {
             .withTintColor(UIColor(.Gray4), renderingMode: .alwaysOriginal)
         appearance.setBackIndicatorImage(image, transitionMaskImage: image)
         
-        UINavigationBar.appearance().standardAppearance = appearance
+        let scrollAppearance = UINavigationBarAppearance()
+        scrollAppearance.configureWithDefaultBackground()
+        scrollAppearance.shadowColor = .clear
+        scrollAppearance.largeTitleTextAttributes = [.font : UIFont.LargeTitle, .foregroundColor: UIColor(.Gray5)]
+        scrollAppearance.backButtonAppearance = backItemAppearance
+        scrollAppearance.setBackIndicatorImage(image, transitionMaskImage: image)
+        
+        UINavigationBar.appearance().standardAppearance = scrollAppearance
         UINavigationBar.appearance().scrollEdgeAppearance = appearance
         UINavigationBar.appearance().compactAppearance = appearance
         UINavigationBar.appearance().compactScrollEdgeAppearance = appearance
+
+        self.background = background
+    }
+
+    func body(content: Content) -> some View {
+        // Color(UIColor.secondarySystemBackground)
+        ZStack {
+            content
+            VStack {
+                background()
+                    .edgesIgnoringSafeArea([.top, .leading, .trailing])
+                    .frame(minWidth: 0, maxWidth: .infinity, maxHeight: 0, alignment: .center)
+
+                Spacer() // to move the navigation bar to top
+            }
+        }
+    }
+}
+
+public extension View {
+    func navigationBarBackground<Background: View>(@ViewBuilder _ background: @escaping () -> Background) -> some View {
+        modifier(NavigationBarColorModifier(background: background))
     }
 }

--- a/HappyAnding/HappyAnding/Views/Components/ListShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ListShortcutView.swift
@@ -84,6 +84,7 @@ struct ListShortcutView: View {
                 .scrollContentBackground(.hidden)
                 .navigationTitle(getNavigationTitle(data.sectionType))
                 .navigationBarTitleDisplayMode(.inline)
+                .navigationBarBackground ({ Color.Background })
             }
         }
     }

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ListCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ListCurationView.swift
@@ -68,6 +68,7 @@ struct ListCurationView: View {
             }
             .listStyle(.plain)
             .background(Color.Background.ignoresSafeArea(.all, edges: .all))
+            .navigationBarBackground ({ Color.Background })
             .scrollContentBackground(.hidden)
             .navigationBarTitle(self.data.type.rawValue)
             .navigationBarTitleDisplayMode(.inline)

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadAdminCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadAdminCurationView.swift
@@ -60,9 +60,6 @@ struct ReadAdminCurationView: View {
         .navigationDestination(for: NavigationReadShortcutType.self) { data in
             ReadShortcutView(data: data)
         }
-        .navigationBarBackButtonHidden(true)
-        .navigationBarItems(leading: btnBack)
-        .toolbarBackground(Color.clear, for: .navigationBar)
         .navigationBarTitleDisplayMode(.inline)
         .edgesIgnoringSafeArea(.top)
         .background(Color.Background)
@@ -102,16 +99,6 @@ struct ReadAdminCurationView: View {
             Spacer()
         }
         .padding(.horizontal, 16)
-    }
-    
-    var btnBack : some View { Button(action: {
-        self.presentationMode.wrappedValue.dismiss()
-        }) {
-            //TODO: 위치와 두께, 색상 조정 필요
-            Image(systemName: "chevron.backward") // set image here
-                .foregroundColor(Color.Gray5)
-                .bold()
-        }
     }
 }
 

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
@@ -68,9 +68,6 @@ struct ReadUserCurationView: View {
         .navigationDestination(for: NavigationReadShortcutType.self) { data in
             ReadShortcutView(data: data)
         }
-        .navigationBarBackButtonHidden(true)
-        .navigationBarItems(leading: BackButton)
-        .toolbarBackground(Color.clear, for: .navigationBar)
         .background(Color.Background.ignoresSafeArea(.all, edges: .all))
         .scrollContentBackground(.hidden)
         .edgesIgnoringSafeArea([.top])
@@ -156,16 +153,6 @@ struct ReadUserCurationView: View {
             shortcutsZipViewModel.fetchUser(userID: self.data.userCuration.author) { user in
                 authorInformation = user
             }
-        }
-    }
-    var BackButton: some View {
-        Button(action: {
-        self.presentation.wrappedValue.dismiss()
-        }) {
-            //TODO: 위치와 두께, 색상 조정 필요
-            Image(systemName: "chevron.backward")
-                .foregroundColor(Color.Gray5)
-                .bold()
         }
     }
 }

--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView/ExploreShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView/ExploreShortcutView.swift
@@ -54,6 +54,7 @@ struct ExploreShortcutView: View {
         .navigationDestination(for: NavigationSearch.self) { _ in
             SearchView()
         }
+        .navigationBarBackground ({ Color.Background })
     }
 }
 

--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ShortcutsListView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ShortcutsListView.swift
@@ -39,6 +39,12 @@ struct ShortcutsListView: View {
                         }
                     }
                 }
+                
+                Rectangle()
+                    .fill(Color.Background)
+                    .frame(height: 44)
+                    .listRowInsets(EdgeInsets())
+                    .listRowSeparator(.hidden)
             }
         }
         .scrollIndicators(.hidden)
@@ -48,6 +54,7 @@ struct ShortcutsListView: View {
         .navigationBarTitle(categoryName.translateName())
         .navigationBarTitleDisplayMode(.inline)
         .background(Color.Background)
+        .navigationBarBackground ({ Color.Background })
         .onAppear {
             self.shortcuts = shortcutsZipViewModel.shortcutsInCategory[categoryName.index]
         }

--- a/HappyAnding/HappyAnding/Views/SearchView.swift
+++ b/HappyAnding/HappyAnding/Views/SearchView.swift
@@ -64,6 +64,7 @@ struct SearchView: View {
         }
         .navigationBarTitleDisplayMode(.inline)
         .background(Color.Background)
+        .navigationBarBackground ({ Color.Background })
     }
     
     private func runSearch() {

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutCommentView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutCommentView.swift
@@ -9,9 +9,10 @@ import SwiftUI
 
 struct ReadShortcutCommentView: View {
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
-    @Binding var addedComment: Comment
-    @Binding var comments: Comments
-    @Binding var nestedCommentInfoText: String
+    @Binding var addedComment: Comment                  //추가되는 댓글
+    @Binding var comments: Comments                     //화면에 그려지는 댓글들
+    @Binding var nestedCommentInfoText: String          //대댓글 작성 시 텍스트필드 위에 뜨는 작성자 정보
+    @Binding var isClickCorrenction: Bool
     @State var isTappedDeleteButton = false
     @State var deletedComment: Comment = Comment(user_nickname: "", user_id: "", date: "", depth: 0, contents: "")
     let shortcutID: String
@@ -95,16 +96,21 @@ struct ReadShortcutCommentView: View {
                                 .foregroundColor(.Gray4)
                         }
                         
-                        Button {
-                            print("수정")
-                        } label: {
-                            Text("수정")
-                                .Footnote()
-                                .foregroundColor(.Gray4)
-                        }
-                        
                         if let user = shortcutsZipViewModel.userInfo {
                             if user.id == comment.user_id {
+                                Button {
+                                    print("수정")
+                                    withAnimation(.easeInOut) {
+                                        isClickCorrenction.toggle()
+                                        addedComment = comment
+                                    }
+                                } label: {
+                                    Text("수정")
+                                        .Footnote()
+                                        .foregroundColor(.Gray4)
+                                }
+                                
+                                
                                 Button {
                                     isTappedDeleteButton.toggle()
                                     deletedComment = comment

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutCommentView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutCommentView.swift
@@ -15,6 +15,7 @@ struct ReadShortcutCommentView: View {
     @Binding var isClickCorrenction: Bool
     @State var isTappedDeleteButton = false
     @State var deletedComment: Comment = Comment(user_nickname: "", user_id: "", date: "", depth: 0, contents: "")
+    @FocusState var isFocused: Bool
     let shortcutID: String
     
     var body: some View {
@@ -90,6 +91,7 @@ struct ReadShortcutCommentView: View {
                             nestedCommentInfoText = comment.user_nickname
                             addedComment.bundle_id = comment.bundle_id
                             addedComment.depth = 1
+                            isFocused = true
                         } label: {
                             Text("답글")
                                 .Footnote()

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutCommentView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutCommentView.swift
@@ -95,13 +95,13 @@ struct ReadShortcutCommentView: View {
                                 .foregroundColor(.Gray4)
                         }
                         
-//                        Button {
-//                            print("수정")
-//                        } label: {
-//                            Text("수정")
-//                                .Footnote()
-//                                .foregroundColor(.Gray4)
-//                        }
+                        Button {
+                            print("수정")
+                        } label: {
+                            Text("수정")
+                                .Footnote()
+                                .foregroundColor(.Gray4)
+                        }
                         
                         Button {
                             isTappedDeleteButton.toggle()

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutCommentView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutCommentView.swift
@@ -103,13 +103,17 @@ struct ReadShortcutCommentView: View {
                                 .foregroundColor(.Gray4)
                         }
                         
-                        Button {
-                            isTappedDeleteButton.toggle()
-                            deletedComment = comment
-                        } label: {
-                            Text("삭제")
-                                .Footnote()
-                                .foregroundColor(.Gray4)
+                        if let user = shortcutsZipViewModel.userInfo {
+                            if user.id == comment.user_id {
+                                Button {
+                                    isTappedDeleteButton.toggle()
+                                    deletedComment = comment
+                                } label: {
+                                    Text("삭제")
+                                        .Footnote()
+                                        .foregroundColor(.Gray4)
+                                }
+                            }
                         }
                     }
                     Divider()

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -218,7 +218,7 @@ struct ReadShortcutView: View {
                 TextField("댓글을 입력하세요", text: $commentText, axis: .vertical)
                     .Body2()
                     .focused($isFocused)
-                    .onAppear(perform: UIApplication.shared.hideKeyboard())
+                    .onAppear(perform : UIApplication.shared.hideKeyboard)
                 
                 Button {
                     comment.contents = commentText

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -79,6 +79,7 @@ struct ReadShortcutView: View {
                 }
             }
         }
+        .navigationBarBackground ({ Color.White })
         .background(Color.Background)
         .safeAreaInset(edge: .bottom, spacing: 0) {
             
@@ -152,7 +153,6 @@ struct ReadShortcutView: View {
             }))
         .alert("글 삭제", isPresented: $isTappedDeleteButton) {
             Button(role: .cancel) {
-                
             } label: {
                 Text("닫기")
             }
@@ -185,24 +185,10 @@ struct ReadShortcutView: View {
             UpdateShortcutView(isUpdating: $isUpdating, shortcut: $data.shortcut)
         }
         .toolbar(.hidden, for: .tabBar)
-        .toolbarBackground(
-                        Color.White,
-                        for: .navigationBar)
-        .toolbarBackground(.visible, for: .navigationBar)
-        .navigationBarBackButtonHidden(true)
     }
-    
-    var btnBack : some View {
-        Button(action: {
-            self.presentationMode.wrappedValue.dismiss()
-        }) {
-            HStack {
-                Image(systemName: "chevron.backward") // set image here
-                    .foregroundColor(.Gray4)
-                    .font(Font(UIFont.systemFont(ofSize: 18, weight: .medium)))
-            }
-        }
-    }
+}
+
+extension ReadShortcutView {
     
     var textField: some View {
         
@@ -270,9 +256,6 @@ struct ReadShortcutView: View {
         )
         .padding(.horizontal, 16)
     }
-}
-
-extension ReadShortcutView {
     
     var myShortcutMenuSection: some View {
         

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -40,108 +40,107 @@ struct ReadShortcutView: View {
     @FocusState private var isFocused: Bool
     @Namespace var namespace
     
+    @State var isClickCorrection = false                //댓글 수정버튼 클릭했는지?
+    @State var isCancledCorrection = false              //댓글 수정 중 텍스트필드를 제외한 부분을 터치했는지?
+    
     private let contentSize = UIScreen.screenHeight / 2
     private let tabItems = ["기본 정보", "버전 정보", "댓글"]
     
     var body: some View {
-        ScrollView {
-            VStack(spacing: 0) {
-                if data.shortcut != nil {
-                    
-                    GeometryReader { geo in
-                        let yOffset = geo.frame(in: .global).minY
-                        
-                        Color.White
-                            .frame(width: geo.size.width, height: 40 + (yOffset > 0 ? yOffset : 0))
-                            .offset(y: yOffset > 0 ? -yOffset : 0)
-                    }
-                    .frame(minHeight: 40)
-                    
-                    // MARK: - 단축어 타이틀
-                    
-                    ReadShortcutHeaderView(shortcut: $data.shortcut.unwrap()!, isMyLike: $isMyLike)
-                        .frame(height: 160)
-                        .padding(.bottom, 33)
-                        .background(Color.White)
-                    
-                    
-                    // MARK: - 탭뷰 (기본 정보, 버전 정보, 댓글)
-                    
-                    LazyVStack(pinnedViews: [.sectionHeaders]) {
-                        Section(header: tabBarView
-                            .background(Color.White)
-                        ) {
-                            detailInformationView
-                                .padding(.top, 4)
-                                .padding(.horizontal, 16)
-                        }
-                    }
-                }
-            }
-        }
-        .navigationBarBackground ({ Color.White })
-        .background(Color.Background)
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            
-            VStack {
-                if currentTab == 2 {
-                    textField
-                }
-                if !isFocused {
-                    if let shortcut = data.shortcut {
-                        Button {
-                            shortcutsZipViewModel.updateNumberOfDownload(shortcut: shortcut, downloadlinkIndex: 0)
-                            if let url = URL(string: shortcut.downloadLink[0]) {
-                                if (shortcutsZipViewModel.userInfo?.downloadedShortcuts.firstIndex(where: { $0.id == data.shortcutID })) == nil {
-                                    data.shortcut?.numberOfDownload += 1
-                                }
-                                isClickDownload = true
-                                openURL(url)
-                            }
+        ZStack {
+            ScrollView {
+                VStack(spacing: 0) {
+                    if data.shortcut != nil {
+                        GeometryReader { geo in
+                            let yOffset = geo.frame(in: .global).minY
                             
-                        } label: {
-                            Text("다운로드 | \(Image(systemName: "arrow.down.app.fill")) \(shortcut.numberOfDownload)")
-                                .Body1()
-                                .foregroundColor(Color.Text_icon)
-                                .padding()
-                                .frame(maxWidth: .infinity)
-                                .background(Color.Primary)
+                            Color.White
+                                .frame(width: geo.size.width, height: 40 + (yOffset > 0 ? yOffset : 0))
+                                .offset(y: yOffset > 0 ? -yOffset : 0)
+                        }
+                        .frame(minHeight: 40)
+                        
+                        // MARK: - 단축어 타이틀
+                        
+                        ReadShortcutHeaderView(shortcut: $data.shortcut.unwrap()!, isMyLike: $isMyLike)
+                            .frame(height: 160)
+                            .padding(.bottom, 33)
+                            .background(Color.White)
+                        
+                        
+                        // MARK: - 탭뷰 (기본 정보, 버전 정보, 댓글)
+                        
+                        LazyVStack(pinnedViews: [.sectionHeaders]) {
+                            Section(header: tabBarView
+                                .background(Color.White)
+                            ) {
+                                detailInformationView
+                                    .padding(.top, 4)
+                                    .padding(.horizontal, 16)
+                            }
                         }
                     }
                 }
             }
-            .ignoresSafeArea(.keyboard)
-        }
-        .onAppear() {
-            UINavigationBar.appearance().standardAppearance.configureWithTransparentBackground()
-            data.shortcut = shortcutsZipViewModel.fetchShortcutDetail(id: data.shortcutID)
-            isMyLike = shortcutsZipViewModel.checkLikedShortrcut(shortcutID: data.shortcutID)
-            isFirstMyLike = isMyLike
-            self.comments = shortcutsZipViewModel.fetchComment(shortcutID: data.shortcutID)
-        }
-        .onChange(of: isEdit || isUpdating) { _ in
-            if !isEdit || !isUpdating {
-                data.shortcut = shortcutsZipViewModel.fetchShortcutDetail(id: data.shortcutID)
+            .scrollDisabled(isClickCorrection)
+            .navigationBarBackground ({ Color.White })
+            .background(Color.Background)
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                
+                VStack {
+                    if !isClickCorrection {
+                        if currentTab == 2 {
+                            textField
+                        }
+                        if !isFocused {
+                            if let shortcut = data.shortcut {
+                                Button {
+                                    shortcutsZipViewModel.updateNumberOfDownload(shortcut: shortcut, downloadlinkIndex: 0)
+                                    if let url = URL(string: shortcut.downloadLink[0]) {
+                                        if (shortcutsZipViewModel.userInfo?.downloadedShortcuts.firstIndex(where: { $0.id == data.shortcutID })) == nil {
+                                            data.shortcut?.numberOfDownload += 1
+                                        }
+                                        isClickDownload = true
+                                        openURL(url)
+                                    }
+                                } label: {
+                                    Text("다운로드 | \(Image(systemName: "arrow.down.app.fill")) \(shortcut.numberOfDownload)")
+                                        .Body1()
+                                        .foregroundColor(Color.Text_icon)
+                                        .padding()
+                                        .frame(maxWidth: .infinity)
+                                        .background(Color.Primary)
+                                }
+                            }
+                        }
+                    }
+                }
+                .ignoresSafeArea(.keyboard)
             }
-        }
-        .onChange(of: shortcutsZipViewModel.allComments) { _ in
-            self.comments = shortcutsZipViewModel.fetchComment(shortcutID: data.shortcutID)
-        }
-        .onDisappear() {
-            if let shortcut = data.shortcut {
-                if isMyLike != isFirstMyLike {
-                    shortcutsZipViewModel.updateNumberOfLike(isMyLike: isMyLike, shortcut: shortcut)
+            .onAppear() {
+                UINavigationBar.appearance().standardAppearance.configureWithTransparentBackground()
+                data.shortcut = shortcutsZipViewModel.fetchShortcutDetail(id: data.shortcutID)
+                isMyLike = shortcutsZipViewModel.checkLikedShortrcut(shortcutID: data.shortcutID)
+                isFirstMyLike = isMyLike
+                self.comments = shortcutsZipViewModel.fetchComment(shortcutID: data.shortcutID)
+            }
+            .onChange(of: isEdit || isUpdating) { _ in
+                if !isEdit || !isUpdating {
+                    data.shortcut = shortcutsZipViewModel.fetchShortcutDetail(id: data.shortcutID)
                 }
             }
-        }
-        .navigationBarTitleDisplayMode(NavigationBarItem.TitleDisplayMode.inline)
-        
-        .navigationBarItems(
-            leading:
-                btnBack
-                .padding(.leading, -8)
-                .frame(width: 30, alignment: .leading),
-            trailing: Menu(content: {
+            .onChange(of: shortcutsZipViewModel.allComments) { _ in
+                self.comments = shortcutsZipViewModel.fetchComment(shortcutID: data.shortcutID)
+            }
+            .onDisappear() {
+                if let shortcut = data.shortcut {
+                    if isMyLike != isFirstMyLike {
+                        shortcutsZipViewModel.updateNumberOfLike(isMyLike: isMyLike, shortcut: shortcut)
+                    }
+                }
+            }
+            .navigationBarTitleDisplayMode(NavigationBarItem.TitleDisplayMode.inline)
+            .navigationBarItems(trailing: Menu(content: {
                 if self.data.shortcut?.author == shortcutsZipViewModel.currentUser() {
                     myShortcutMenuSection
                 } else {
@@ -151,40 +150,83 @@ struct ReadShortcutView: View {
                 Image(systemName: "ellipsis")
                     .foregroundColor(.Gray4)
             }))
-        .alert("글 삭제", isPresented: $isTappedDeleteButton) {
-            Button(role: .cancel) {
-            } label: {
-                Text("닫기")
-            }
-            
-            Button(role: .destructive) {
-                if let shortcut = data.shortcut {
-                    shortcutsZipViewModel.deleteShortcutIDInUser(shortcutID: shortcut.id)
-                    shortcutsZipViewModel.deleteShortcutInCuration(curationsIDs: shortcut.curationIDs, shortcutID: shortcut.id)
-                    shortcutsZipViewModel.deleteData(model: shortcut)
-                    shortcutsZipViewModel.shortcutsMadeByUser = shortcutsZipViewModel.shortcutsMadeByUser.filter { $0.id != shortcut.id }
-                    self.presentation.wrappedValue.dismiss()
+            .alert("글 삭제", isPresented: $isTappedDeleteButton) {
+                Button(role: .cancel) {
+                } label: {
+                    Text("닫기")
                 }
-            } label: {
-                Text("삭제")
-            }
-        } message: {
-            Text("글을 삭제하시겠습니까?")
-        }
-        .fullScreenCover(isPresented: $isEdit) {
-            NavigationStack(path: $writeNavigation.navigationPath) {
-                if let shortcut = data.shortcut {
-                    WriteShortcutTitleView(isWriting: $isEdit,
-                                           shortcut: shortcut,
-                                           isEdit: true)
+                
+                Button(role: .destructive) {
+                    if let shortcut = data.shortcut {
+                        shortcutsZipViewModel.deleteShortcutIDInUser(shortcutID: shortcut.id)
+                        shortcutsZipViewModel.deleteShortcutInCuration(curationsIDs: shortcut.curationIDs, shortcutID: shortcut.id)
+                        shortcutsZipViewModel.deleteData(model: shortcut)
+                        shortcutsZipViewModel.shortcutsMadeByUser = shortcutsZipViewModel.shortcutsMadeByUser.filter { $0.id != shortcut.id }
+                        self.presentation.wrappedValue.dismiss()
+                    }
+                } label: {
+                    Text("삭제")
                 }
+            } message: {
+                Text("글을 삭제하시겠습니까?")
             }
-            .environmentObject(writeNavigation)
+            .fullScreenCover(isPresented: $isEdit) {
+                NavigationStack(path: $writeNavigation.navigationPath) {
+                    if let shortcut = data.shortcut {
+                        WriteShortcutTitleView(isWriting: $isEdit,
+                                               shortcut: shortcut,
+                                               isEdit: true)
+                    }
+                }
+                .environmentObject(writeNavigation)
+            }
+            .fullScreenCover(isPresented: $isUpdating) {
+                UpdateShortcutView(isUpdating: $isUpdating, shortcut: $data.shortcut)
+            }
+            .toolbar(.hidden, for: .tabBar)
+            if isClickCorrection {
+                Color.black
+                    .ignoresSafeArea()
+                    .opacity(0.4)
+                    .safeAreaInset(edge: .bottom, spacing: 0) {
+                        textField
+                        .ignoresSafeArea(.keyboard)
+                        .focused($isFocused, equals: true)
+                        .task {
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                                isFocused = true
+                            }
+                        }
+                    }
+                    .onAppear() {
+                        commentText = comment.contents
+                    }
+                    .onTapGesture(count: 1) {
+                        isFocused.toggle()
+                        isCancledCorrection.toggle()
+                    }
+                    .alert("글 삭제", isPresented: $isCancledCorrection) {
+                        Button(role: .cancel) {
+                            isFocused.toggle()
+                        } label: {
+                            Text("계속 작성")
+                        }
+                        
+                        Button(role: .destructive) {
+                            withAnimation(.easeInOut) {
+                                isClickCorrection.toggle()
+                                comment = comment.resetComment()
+                                commentText = ""
+                            }
+                        } label: {
+                            Text("삭제")
+                        }
+                    } message: {
+                        Text("수정사항을 삭제하시겠습니까?")
+                    }
+                
+            }
         }
-        .fullScreenCover(isPresented: $isUpdating) {
-            UpdateShortcutView(isUpdating: $isUpdating, shortcut: $data.shortcut)
-        }
-        .toolbar(.hidden, for: .tabBar)
     }
 }
 
@@ -193,11 +235,11 @@ extension ReadShortcutView {
     var textField: some View {
         
         VStack(spacing: 0) {
-            if comment.depth == 1 {
+            if comment.depth == 1 && !isClickCorrection {
                 nestedCommentInfo
             }
             HStack {
-                if comment.depth == 1 {
+                if comment.depth == 1 && !isClickCorrection {
                     Image(systemName: "arrow.turn.down.right")
                         .foregroundColor(.Gray4)
                 }
@@ -205,16 +247,25 @@ extension ReadShortcutView {
                     .Body2()
                     .focused($isFocused)
                     .onAppear(perform : UIApplication.shared.hideKeyboard)
+                    .onTapGesture {/*터치영역구분을위한부분*/}
                 
                 Button {
-                    comment.contents = commentText
-                    comment.date = Date().getDate()
-                    comment.user_id = shortcutsZipViewModel.userInfo!.id
-                    comment.user_nickname = shortcutsZipViewModel.userInfo!.nickname
-                    comments.comments.append(comment)
+                    if !isClickCorrection {
+                        comment.contents = commentText
+                        comment.date = Date().getDate()
+                        comment.user_id = shortcutsZipViewModel.userInfo!.id
+                        comment.user_nickname = shortcutsZipViewModel.userInfo!.nickname
+                        comments.comments.append(comment)
+                    } else {
+                        if let index = comments.comments.firstIndex(where: { $0.id == comment.id }) {
+                            comments.comments[index].contents = commentText
+                        }
+                        isClickCorrection = false
+                    }
                     shortcutsZipViewModel.setData(model: comments)
                     commentText = ""
                     comment = comment.resetComment()
+                    isFocused.toggle()
                 } label: {
                     Image(systemName: "paperplane.fill")
                         .foregroundColor(commentText == "" ? Color.Gray2 : Color.Gray5)
@@ -226,7 +277,7 @@ extension ReadShortcutView {
             .background(
                 Rectangle()
                     .fill(Color.Gray1)
-                    .cornerRadius(12 ,corners: comment.depth == 0 ? .allCorners : [.bottomLeft, .bottomRight])
+                    .cornerRadius(12 ,corners: (comment.depth == 1) && (!isClickCorrection) ? [.bottomLeft, .bottomRight] : .allCorners)
             )
             .padding(.horizontal, 16)
             .padding(.bottom, 20)
@@ -350,7 +401,7 @@ extension ReadShortcutView {
                                                     geometryProxy.size)
                             })
                 case 2:
-                    ReadShortcutCommentView(addedComment: $comment, comments: $comments, nestedCommentInfoText: $nestedCommentInfoText, shortcutID: data.shortcutID)
+                    ReadShortcutCommentView(addedComment: $comment, comments: $comments, nestedCommentInfoText: $nestedCommentInfoText, isClickCorrenction: $isClickCorrection, shortcutID: data.shortcutID)
                         .background(
                             GeometryReader { geometryProxy in
                                 Color.clear

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -218,6 +218,7 @@ struct ReadShortcutView: View {
                 TextField("댓글을 입력하세요", text: $commentText, axis: .vertical)
                     .Body2()
                     .focused($isFocused)
+                    .onAppear(perform: UIApplication.shared.hideKeyboard())
                 
                 Button {
                     comment.contents = commentText

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -401,7 +401,7 @@ extension ReadShortcutView {
                                                     geometryProxy.size)
                             })
                 case 2:
-                    ReadShortcutCommentView(addedComment: $comment, comments: $comments, nestedCommentInfoText: $nestedCommentInfoText, isClickCorrenction: $isClickCorrection, shortcutID: data.shortcutID)
+                    ReadShortcutCommentView(addedComment: $comment, comments: $comments, nestedCommentInfoText: $nestedCommentInfoText, isClickCorrenction: $isClickCorrection, isFocused: _isFocused, shortcutID: data.shortcutID)
                         .background(
                             GeometryReader { geometryProxy in
                                 Color.clear

--- a/HappyAnding/HappyAnding/Views/TabView/ShortcutTabView.swift
+++ b/HappyAnding/HappyAnding/Views/TabView/ShortcutTabView.swift
@@ -31,7 +31,6 @@ struct ShortcutTabView: View {
         UITabBar.appearance().unselectedItemTintColor = UIColor(Color.Gray2)
         UITabBar.appearance().layer.borderColor = UIColor(Color.clear).cgColor
         UITabBar.appearance().clipsToBounds = true
-        Theme.navigationBarColors()
     }
     
     var handler: Binding<Int> { Binding(
@@ -80,6 +79,7 @@ struct ShortcutTabView: View {
                             }
                             self.tappedTwice = false
                         })
+                        .navigationBarBackground ({ Color.Background })
                 }
                 .environmentObject(curationNavigation)
                 .tabItem {
@@ -100,6 +100,7 @@ struct ShortcutTabView: View {
                             }
                             self.tappedTwice = false
                         })
+                        .navigationBarBackground ({ Color.Background })
                 }
                 .environmentObject(profileNavigation)
                 .tabItem {


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #288
- closes #302   

## 구현/변경 사항
- 네비게이션바 백버튼 위치 통일을 위해 툴바를 사용하던 부분을 모두 네비게이션바로 변경
- 네비게이션바 색상을 화면별로 다르게 지정하기 위해 투명으로 지정 및 네비게이션바 영역까지 지정한 색으로 레이어를 하나 더 깔았습니다.
- 댓글 수정, 삭제 버튼이 댓글 작성자일 경우에만 보이도록 수정
- 댓글 수정 기능 추가
- 댓글 수정 시 키보드 포커스
- 댓글 수정 중 스크롤 불가능
- 댓글 수정 취소 시 (텍스트 필드 제외한 영역 터치 시) alert띄움

##To Reviewer
- 네비게이션 바 색상이 스크롤 시 Color.White로 지정되어 기존에 Color.Background로 지정되어있을 때와 약간 차이가 있습니다. 의도된 것이니 감안하고 확인해주세요! 
- 댓글 수정 시 키보드 포커스 반응이 약간 느린듯 보이는데 반응속도를 현재보다 더 빠르게 지정할 경우 아예 반응하지 않아서 이것이 최선입니다..

## 스크린샷

https://user-images.githubusercontent.com/41153398/204050949-c31cf2ef-0b93-4468-b14e-f9ea6ca4e888.MP4


