### PR TITLE
[Feat] 모달에 핸들 및 닫기 버튼 추가

### DIFF
--- a/HappyAnding/HappyAnding/Views/MyPageViews/SettingView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/SettingView.swift
@@ -14,7 +14,7 @@ struct SettingView: View {
     
     @AppStorage("signInStatus") var signInStatus = false
     @StateObject var userAuth = UserAuth.shared
-    @ObservedObject var webViewModel = WebViewModel(url: "https://noble-satellite-574.notion.site/60d8fa2f417c40cca35e9c784f74b7fd")
+    @ObservedObject var webViewModel = WebViewModel()
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
     
     @State var result: Result<MFMailComposeResult, Error>? = nil
@@ -128,7 +128,9 @@ struct SettingView: View {
         
         .sheet(isPresented: self.$isTappedPrivacyButton) {
             ZStack {
-                PrivacyPolicyView(webViewModel: webViewModel)
+                PrivacyPolicyView(viewModel: webViewModel,
+                                  isTappedPrivacyButton: $isTappedPrivacyButton,
+                                  url: "https://noble-satellite-574.notion.site/60d8fa2f417c40cca35e9c784f74b7fd")
                     .environmentObject(webViewModel)
                     .presentationDetents([.large])
                     .presentationDragIndicator(.visible)

--- a/HappyAnding/HappyAnding/Views/MyPageViews/SettingView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/SettingView.swift
@@ -122,8 +122,6 @@ struct SettingView: View {
         }
         .sheet(isPresented: $isShowingMailView) {
             MailView(isShowing: self.$isShowingMailView, result: self.$result)
-                .presentationDetents([.large])
-                .presentationDragIndicator(.visible)
         }
         
         .sheet(isPresented: self.$isTappedPrivacyButton) {

--- a/HappyAnding/HappyAnding/Views/MyPageViews/SettingView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/SettingView.swift
@@ -122,12 +122,16 @@ struct SettingView: View {
         }
         .sheet(isPresented: $isShowingMailView) {
             MailView(isShowing: self.$isShowingMailView, result: self.$result)
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
         }
         
         .sheet(isPresented: self.$isTappedPrivacyButton) {
             ZStack {
                 PrivacyPolicyView(webViewModel: webViewModel)
                     .environmentObject(webViewModel)
+                    .presentationDetents([.large])
+                    .presentationDragIndicator(.visible)
                 if webViewModel.isLoading {
                     ProgressView()
                 }

--- a/HappyAnding/HappyAnding/Views/MyPageViews/SettingViews/LicenseView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/SettingViews/LicenseView.swift
@@ -20,7 +20,7 @@ struct LicenseView: View {
 
 struct LicenseCell: View {
     
-    @ObservedObject var webViewModel = WebViewModel(url: "https://github.com/firebase")
+    @ObservedObject var webViewModel = WebViewModel()
     
     @State private var isTappedFirebaseButton = false
     var title: String

--- a/HappyAnding/HappyAnding/Views/SignInViews/PrivacyPolicyView.swift
+++ b/HappyAnding/HappyAnding/Views/SignInViews/PrivacyPolicyView.swift
@@ -25,7 +25,7 @@ struct PrivacyPolicyView: View {
     var body: some View {
         
         VStack {
-            HStack {
+            HStack(spacing: 0) {
                 
                 Button {
                     self.isTappedPrivacyButton = false

--- a/HappyAnding/HappyAnding/Views/SignInViews/PrivacyPolicyView.swift
+++ b/HappyAnding/HappyAnding/Views/SignInViews/PrivacyPolicyView.swift
@@ -12,28 +12,58 @@ import WebKit
 
 class WebViewModel: ObservableObject {
     @Published var isLoading = false
+}
+
+struct PrivacyPolicyView: View {
     
-    var url: String
+    @ObservedObject var viewModel: WebViewModel
     
-    init(url: String) {
-        self.url = url 
+    @Binding var isTappedPrivacyButton: Bool
+    
+    let url: String
+    
+    var body: some View {
+        
+        VStack {
+            HStack {
+                
+                Button {
+                    self.isTappedPrivacyButton = false
+                } label: {
+                    Text("닫기")
+                        .foregroundColor(.Gray5)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.leading, 16)
+                }
+                
+                Text("개인정보처리방침")
+                    .Headline()
+                    .frame(maxWidth: .infinity)
+                
+                Spacer()
+                    .frame(maxWidth: .infinity)
+            }
+            .padding(.top, 24)
+            
+            PrivacyPolicyContentView(webViewModel: viewModel, url: self.url)
+        }
     }
 }
 
-
-struct PrivacyPolicyView: UIViewRepresentable {
+struct PrivacyPolicyContentView: UIViewRepresentable {
     
     @ObservedObject var webViewModel: WebViewModel
     
+    let url: String
     let webView = WKWebView()
     
-    func makeCoordinator() -> PrivacyPolicyView.Coordinator {
+    func makeCoordinator() -> PrivacyPolicyContentView.Coordinator {
         Coordinator(self, webViewModel)
     }
     
     func makeUIView(context: Context) -> WKWebView {
         
-        if let url = URL(string: self.webViewModel.url) {
+        if let url = URL(string: self.url) {
             webView.navigationDelegate = context.coordinator
             self.webView.load(URLRequest(url: url))
         }
@@ -41,19 +71,19 @@ struct PrivacyPolicyView: UIViewRepresentable {
     }
     
     func updateUIView(_ uiView: WKWebView,
-                      context: UIViewRepresentableContext<PrivacyPolicyView>) {
+                      context: UIViewRepresentableContext<PrivacyPolicyContentView>) {
         return
     }
 }
 
-extension PrivacyPolicyView {
+extension PrivacyPolicyContentView {
     
     class Coordinator: NSObject, WKNavigationDelegate {
         @ObservedObject private var webViewModel: WebViewModel
         
-        private let parent: PrivacyPolicyView
+        private let parent: PrivacyPolicyContentView
         
-        init(_ parent: PrivacyPolicyView, _ webViewModel: WebViewModel) {
+        init(_ parent: PrivacyPolicyContentView, _ webViewModel: WebViewModel) {
             self.parent = parent
             self.webViewModel = webViewModel
         }

--- a/HappyAnding/HappyAnding/Views/SignInViews/WriteNicknameView.swift
+++ b/HappyAnding/HappyAnding/Views/SignInViews/WriteNicknameView.swift
@@ -25,7 +25,7 @@ struct WriteNicknameView: View {
     
     @AppStorage("signInStatus") var signInStatus = false
     @EnvironmentObject var userAuth: UserAuth
-    @ObservedObject var webViewModel = WebViewModel(url: "https://noble-satellite-574.notion.site/60d8fa2f417c40cca35e9c784f74b7fd")
+    @ObservedObject var webViewModel = WebViewModel()
     @EnvironmentObject var shortcutszipViewModel: ShortcutsZipViewModel
     
     @State var nickname: String = ""
@@ -90,8 +90,9 @@ struct WriteNicknameView: View {
         .background(Color.Background)
         .sheet(isPresented: self.$isTappedPrivacyButton) {
             ZStack {
-                PrivacyPolicyView(webViewModel: webViewModel)
-                    .environmentObject(webViewModel)
+                PrivacyPolicyView(viewModel: webViewModel,
+                         isTappedPrivacyButton: $isTappedPrivacyButton,
+                         url: "https://noble-satellite-574.notion.site/60d8fa2f417c40cca35e9c784f74b7fd")
                     .presentationDetents([.large])
                     .presentationDragIndicator(.visible)
                 if webViewModel.isLoading {

--- a/HappyAnding/HappyAnding/Views/SignInViews/WriteNicknameView.swift
+++ b/HappyAnding/HappyAnding/Views/SignInViews/WriteNicknameView.swift
@@ -92,6 +92,8 @@ struct WriteNicknameView: View {
             ZStack {
                 PrivacyPolicyView(webViewModel: webViewModel)
                     .environmentObject(webViewModel)
+                    .presentationDetents([.large])
+                    .presentationDragIndicator(.visible)
                 if webViewModel.isLoading {
                     ProgressView()
                 }

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/CategoryModalView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/CategoryModalView.swift
@@ -18,8 +18,23 @@ struct CategoryModalView: View {
             Color.Background
                 .ignoresSafeArea()
             VStack {
-                Text("카테고리")
-                    .font(.headline)
+                HStack {
+                    Button {
+                        self.isShowingCategoryModal = false
+                    } label: {
+                        Text("닫기")
+                            .foregroundColor(.Gray5)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.leading, 16)
+                    }
+                    
+                    Text("카테고리")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                    
+                    Spacer()
+                        .frame(maxWidth: .infinity)
+                }
                 
                 Spacer()
                     .frame(height: UIScreen.main.bounds.size.height * 0.7 * 0.04)

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/CategoryModalView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/CategoryModalView.swift
@@ -18,7 +18,7 @@ struct CategoryModalView: View {
             Color.Background
                 .ignoresSafeArea()
             VStack {
-                HStack {
+                HStack(spacing: 0) {
                     Button {
                         self.isShowingCategoryModal = false
                     } label: {

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/IconModalView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/IconModalView.swift
@@ -60,7 +60,7 @@ struct IconModalView: View {
         VStack {
             HStack {
                 Button {
-                    self.isShowingIconModal = true
+                    self.isShowingIconModal = false
                 } label: {
                     Text("닫기")
                         .foregroundColor(.Gray5)

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/IconModalView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/IconModalView.swift
@@ -58,7 +58,7 @@ struct IconModalView: View {
     
     var body: some View {
         VStack {
-            HStack {
+            HStack(spacing: 0) {
                 Button {
                     self.isShowingIconModal = false
                 } label: {

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/IconModalView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/IconModalView.swift
@@ -58,10 +58,25 @@ struct IconModalView: View {
     
     var body: some View {
         VStack {
-            Text("아이콘")
-                .Headline()
-                .padding(.top, 16)
-                .padding(.bottom, 24)
+            HStack {
+                Button {
+                    self.isShowingIconModal = true
+                } label: {
+                    Text("닫기")
+                        .foregroundColor(.Gray5)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.leading, 16)
+                }
+                
+                Text("아이콘")
+                    .Headline()
+                    .frame(maxWidth: .infinity)
+                
+                Spacer()
+                    .frame(maxWidth: .infinity)
+            }
+            .padding(.top, 24)
+            .padding(.bottom, 24)
             
             ZStack(alignment: .center) {
                 Rectangle()

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTagView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTagView.swift
@@ -168,6 +168,7 @@ struct WriteShortcutTagView: View {
                     .sheet(isPresented: $isShowingCategoryModal) {
                         CategoryModalView(isShowingCategoryModal: $isShowingCategoryModal, selectedCategories: $selectedCategories)
                             .presentationDetents([.fraction(0.7)])
+                            .presentationDragIndicator(.visible)
                     }
                 }
             }

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTitleView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTitleView.swift
@@ -72,6 +72,8 @@ struct WriteShortcutTitleView: View {
                 IconModalView(isShowingIconModal: $isShowingIconModal,
                               iconColor: $shortcut.color,
                               iconSymbol: $shortcut.sfSymbol)
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
             }
             
             ValidationCheckTextField(textType: .mandatory,


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #303 

## 구현/변경 사항
- HIG 준수를 위해 핸들 및 닫기 버튼을 추가하였습니다.

## 스크린샷

|아이콘 선택|카테고리|개인정보처리방침|
|:---:|:---:|:---:|
|<img src ="https://user-images.githubusercontent.com/68676844/204090635-8d8589d4-0921-4cb3-9128-3e2993ae4718.png" width = 250>|<img src = "https://user-images.githubusercontent.com/68676844/204090647-45fcde96-dedb-4562-95d9-eb75ae3912f6.png" width = 250>|<img src = "https://user-images.githubusercontent.com/68676844/204090665-9d0cdb50-6fc0-42c3-89e5-fc06ca05c6e0.png" width = 250>|

## TO REVIEWER
- handle의 경우, iOS 16.0부터 적용가능한 방법입니다.
   - 타 버전의 경우 capsule을 ZStack으로 쌓아서 사용하더라고요! 추후 개발시 참고하세요~

```
.presentationDetents([.large])
.presentationDragIndicator(.visible)
```

- 네비게이션 타이틀을 사용해서 닫기 버튼 및 "아이콘" 등의 타이틀을 설정하고 싶었는데, 이를 위해서 네비게이션 타이틀의 높이를 조정하는 코드가 필요했습니다 -> 네비게이션을 커스텀하는 것보다, HStack으로 조정하는 것이 경제적이라고 생각했습니다!

- UIViewRepresentable에 닫기버튼 및 타이틀을 설정하기 위해 webviewmodel을 수정했습니다!

- Mail의 경우, 사용자 드래그 제스처로 모달이 닫히지 않기 때문에, 핸들을 넣지 않았습니다.