### PR TITLE
[Fix] 회원탈퇴 에러

### DIFF
--- a/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
+++ b/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
@@ -17,6 +17,8 @@ import FirebaseAuth
  */
 
 class ShortcutsZipViewModel: ObservableObject {
+    var userAuth = UserAuth.shared
+    @AppStorage("signInStatus") var signInStatus = false
     
     @Published var userInfo: User?                              // 유저정보
     
@@ -533,6 +535,30 @@ class ShortcutsZipViewModel: ObservableObject {
             db.collection("Comment").document((model as! Comments).id).delete()
         default:
             print("this is not a model.")
+        }
+    }
+    
+    func deleteUserData(userID: String) {
+        db.collection("User").document(userID).delete() { err in
+            if let err = err {
+                print("Error removing document: \(err)")
+            } else {
+                print("Document successfully removed!")
+                self.resetUser()
+                
+                let firebaseAuth = Auth.auth()
+                let currentUser = firebaseAuth.currentUser
+                currentUser?.delete { error in
+                    if let error {
+                        print("**\(error.localizedDescription)")
+                    } else {
+                        withAnimation(.easeInOut) {
+                            self.signInStatus = false
+                            self.userAuth.signOut()
+                        }
+                    }
+                }
+            }
         }
     }
     

--- a/HappyAnding/HappyAnding/Views/HappyAndingApp.swift
+++ b/HappyAnding/HappyAnding/Views/HappyAndingApp.swift
@@ -17,6 +17,7 @@ struct HappyAndingApp: App {
     @StateObject var userAuth = UserAuth.shared
     @StateObject var shorcutsZipViewModel = ShortcutsZipViewModel()
     @AppStorage("signInStatus") var signInStatus = false
+    @AppStorage("isReauthenticated") var isReauthenticated = false
     
     init() {
         FirebaseApp.configure()

--- a/HappyAnding/HappyAnding/Views/MyPageViews/SettingView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/SettingView.swift
@@ -13,7 +13,7 @@ import FirebaseAuth
 struct SettingView: View {
     
     @AppStorage("signInStatus") var signInStatus = false
-    @StateObject var userAuth = UserAuth.shared
+    @EnvironmentObject var userAuth: UserAuth
     @ObservedObject var webViewModel = WebViewModel(url: "https://noble-satellite-574.notion.site/60d8fa2f417c40cca35e9c784f74b7fd")
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
     

--- a/HappyAnding/HappyAnding/Views/MyPageViews/SettingViews/WithdrawalView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/SettingViews/WithdrawalView.swift
@@ -109,18 +109,6 @@ struct WithdrawalView: View {
     private func signOut() {
         if let user = shortcutsZipViewModel.userInfo {
             shortcutsZipViewModel.deleteUserData(userID: user.id)
-            let firebaseAuth = Auth.auth()
-            let currentUser = firebaseAuth.currentUser
-            currentUser?.delete { error in
-                if let error {
-                    print("**\(error.localizedDescription)")
-                } else {
-                    withAnimation(.easeInOut) {
-                        self.signInStatus = false
-                        self.userAuth.signOut()
-                    }
-                }
-            }
         }
     }
     

--- a/HappyAnding/HappyAnding/Views/MyPageViews/SettingViews/WithdrawalView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/SettingViews/WithdrawalView.swift
@@ -125,15 +125,8 @@ struct WithdrawalView: View {
     }
     
     private func reauthenticateUser() {
-        let firebaseAuth = Auth.auth()
-        do {
-            try firebaseAuth.signOut()
-            userAuth.signOut()
-            appleLoginCoordinator = AppleAuthCoordinator(window: window, isTappedSignInButton: false)
-            appleLoginCoordinator?.startSignInWithAppleFlow()
-        } catch {
-            print(error.localizedDescription)
-        }
+        appleLoginCoordinator = AppleAuthCoordinator(window: window, isTappedSignInButton: false)
+        appleLoginCoordinator?.startSignInWithAppleFlow()
     }
 }
 

--- a/HappyAnding/HappyAnding/Views/MyPageViews/SettingViews/WithdrawalView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/SettingViews/WithdrawalView.swift
@@ -71,7 +71,7 @@ struct WithdrawalView: View {
             
             Button {
                 isTappedSignOutButton = true
-                reAuthenticateUser()
+                reauthenticateUser()
             } label: {
                 ZStack {
                     RoundedRectangle(cornerRadius: 12)
@@ -107,8 +107,6 @@ struct WithdrawalView: View {
     }
     
     private func signOut() {
-        
-        
         if let user = shortcutsZipViewModel.userInfo {
             shortcutsZipViewModel.deleteUserData(userID: user.id)
             let firebaseAuth = Auth.auth()
@@ -126,12 +124,12 @@ struct WithdrawalView: View {
         }
     }
     
-    private func reAuthenticateUser() {
+    private func reauthenticateUser() {
         let firebaseAuth = Auth.auth()
         do {
             try firebaseAuth.signOut()
             userAuth.signOut()
-            appleLoginCoordinator = AppleAuthCoordinator(window: window)
+            appleLoginCoordinator = AppleAuthCoordinator(window: window, isTappedSignInButton: false)
             appleLoginCoordinator?.startSignInWithAppleFlow()
         } catch {
             print(error.localizedDescription)

--- a/HappyAnding/HappyAnding/Views/SignInViews/AppleAuthCoordinator.swift
+++ b/HappyAnding/HappyAnding/Views/SignInViews/AppleAuthCoordinator.swift
@@ -23,9 +23,11 @@ class AppleAuthCoordinator: NSObject {
     var currentNonce: String?
     let window: UIWindow?
     let shortcutZipViewModel = ShortcutsZipViewModel()
+    let isTappedSignInButton: Bool
     
-    init(window: UIWindow?) {
+    init(window: UIWindow?, isTappedSignInButton: Bool) {
         self.window = window
+        self.isTappedSignInButton = isTappedSignInButton
     }
     
     /// 요청에 nonce의 SHA256 해시를 처리하는 클래스를 포함하여 Apple 로그인 시작
@@ -128,7 +130,7 @@ extension AppleAuthCoordinator: ASAuthorizationControllerDelegate {
                         withAnimation(.easeInOut) {
                             self.signInStatus = true
                         }
-                        if self.isTappedSignOutButton {
+                        if self.isTappedSignOutButton && !self.isTappedSignInButton {
                             self.isReauthenticated = true
                         }
                     } else {

--- a/HappyAnding/HappyAnding/Views/SignInViews/AppleAuthCoordinator.swift
+++ b/HappyAnding/HappyAnding/Views/SignInViews/AppleAuthCoordinator.swift
@@ -145,8 +145,6 @@ extension AppleAuthCoordinator: ASAuthorizationControllerDelegate {
                                  didCompleteWithError error: Error) {
         // Handle error.
         print("Sign in with Apple errored: \(error)")
-        self.signInStatus = false
-        self.isReauthenticated = false
       }
 }
 

--- a/HappyAnding/HappyAnding/Views/SignInViews/AppleAuthCoordinator.swift
+++ b/HappyAnding/HappyAnding/Views/SignInViews/AppleAuthCoordinator.swift
@@ -16,6 +16,8 @@ import CryptoKit
 class AppleAuthCoordinator: NSObject {
     
     @AppStorage("signInStatus") var signInStatus = false
+    @AppStorage("isReauthenticated") var isReauthenticated = false
+    @AppStorage("isTappedSignOutButton") var isTappedSignOutButton = false
     
     var userAuth = UserAuth.shared
     var currentNonce: String?
@@ -126,6 +128,9 @@ extension AppleAuthCoordinator: ASAuthorizationControllerDelegate {
                         withAnimation(.easeInOut) {
                             self.signInStatus = true
                         }
+                        if self.isTappedSignOutButton {
+                            self.isReauthenticated = true
+                        }
                     } else {
                         self.userAuth.signIn()
                     }
@@ -138,6 +143,8 @@ extension AppleAuthCoordinator: ASAuthorizationControllerDelegate {
                                  didCompleteWithError error: Error) {
         // Handle error.
         print("Sign in with Apple errored: \(error)")
+        self.signInStatus = false
+        self.isReauthenticated = false
       }
 }
 

--- a/HappyAnding/HappyAnding/Views/SignInViews/SignInWithAppleView.swift
+++ b/HappyAnding/HappyAnding/Views/SignInViews/SignInWithAppleView.swift
@@ -55,7 +55,7 @@ struct SignInWithAppleView: View {
     }
     
     func appleLogin() {
-        appleLoginCoordinator = AppleAuthCoordinator(window: window)
+        appleLoginCoordinator = AppleAuthCoordinator(window: window, isTappedSignInButton: true)
         appleLoginCoordinator?.startSignInWithAppleFlow()
     }
 }


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #231

## 구현/변경 사항
- 회원탈퇴 과정 중 사용자 재인증 (로그인) 과정 추가
- 기존의 로그인과 재인증 로그인을 구분하는 변수 추가

## To Reviewer
- 기존에 회원탈퇴 버튼을 눌러도 아무런 반응이 없던 문제는 로그인을 하고 5분이상 지났을 경우에 재인증이 필요해서 발생한 문제로 탈퇴 과정 중 재인증 과정을 넣어 해결했습니다.
- 파이어베이스에서 제공해주는 정석?적인 재인증 과정을 찾지 못해 임의로 사용자를 로그아웃 시키고 다시 로그인 시켜서 해결했습니다.
- 사용자 정보가 삭제가 되지 않던 오류는 파이어베이스에 설정된 규칙 중 인증 된 사용자만 읽기, 쓰기가 가능하도록 설정이 되어있는데 이전 회원탈퇴 과정은 사용자 정보 삭제 전 인증 정보가 먼저 삭제되어 인증되지 않은 사용자 상태로 삭제를 시도하여 발생한 문제로 확인되어 사용자 정보 삭제 후 인증 정보를 삭제하도록 순서를 변경하여 해결했습니다.
- 오류 해결 중간에 공유했던 재인증 과정 중 인증을 하지 않고 창을 닫을 경우에 사용자가 로그아웃되어 로그인화면이 나오던 문제는 재인증을 로그아웃 - 로그인 순서로 하던 것을 로그인만 하도록 변경하여 사용자가 로그아웃되지 않도록 변경하여 해결했습니다.

## 스크린샷
- 정상적으로 회원탈퇴 과정을 밟는 경우

https://user-images.githubusercontent.com/41153398/204091403-15f7bdca-9cbb-4d51-99d2-442608e72a33.MP4

- 회원탈퇴 재인증 과정 중 인증하지 않고 창을 닫는 경우 (기존에는 인증 과정 중 창을 닫으면 로그아웃되어 앱을 껐다켜면 회원정보를 받아오지 못함)

https://user-images.githubusercontent.com/41153398/204092195-806828de-7315-419a-b03d-ba54d0536fba.MP4




