### PR TITLE
[Fix] 큐레이션 모아보기 이슈 해결 및 네비게이션 스택 리팩토링

### DIFF
--- a/HappyAnding/HappyAnding/Model/NavigationStackModel.swift
+++ b/HappyAnding/HappyAnding/Model/NavigationStackModel.swift
@@ -40,6 +40,10 @@ struct NavigationListCurationType: Identifiable, Hashable {
     var curation: [Curation]
 }
 
+enum NavigationSearch: Hashable, Equatable {
+    case first
+}
+
 enum NavigationParentView: Int {
     case shortcuts
     case curations

--- a/HappyAnding/HappyAnding/Model/NavigationStackModel.swift
+++ b/HappyAnding/HappyAnding/Model/NavigationStackModel.swift
@@ -37,30 +37,8 @@ struct NavigationListCurationType: Identifiable, Hashable {
     var title: String?
     var isAllUser: Bool
     let navigationParentView: NavigationParentView
+    var curation: [Curation]
 }
-
-//struct NavigationPrivacyPolicy: Hashable, Equatable {
-//    var id = UUID().uuidString
-//}
-//struct NavigationLisence: Hashable, Equatable {
-//    var id = UUID().uuidString
-//}
-//struct NavigationWithdrawal: Hashable, Equatable {
-//    var id = UUID().uuidString
-//}
-
-//enum NavigationPrivacyPolicy: Hashable, Equatable {
-//    case first
-//}
-//
-//enum NavigationLisence: Hashable, Equatable {
-//    case first
-//}
-//
-//enum NavigationWithdrawal: Hashable, Equatable {
-//    case first
-//}
-
 
 enum NavigationParentView: Int {
     case shortcuts

--- a/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
+++ b/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
@@ -69,6 +69,19 @@ class ShortcutsZipViewModel: ObservableObject {
         }
     }
     
+    func refreshPersonalCurations() {
+        print("onAppear data view model, \(self.personalCurations)")
+        let personalCurationIDs = Set(self.shortcutsUserDownloaded.flatMap({ $0.curationIDs }))
+        for curationID in personalCurationIDs {
+            if let curation = self.userCurations.first(where: { $0.id == curationID }) {
+                if !Set(self.personalCurations).contains(curation) {
+                    self.personalCurations.append(curation)
+                }
+            }
+        }
+        print("onAppear data view model2, \(self.personalCurations)")
+    }
+    
     func initUserShortcut(user: User) {
         shortcutsMadeByUser = allShortcuts.filter { $0.author == user.id }
         user.downloadedShortcuts.forEach({ downloadedShortcut in
@@ -81,6 +94,7 @@ class ShortcutsZipViewModel: ObservableObject {
                 shortcutsUserLiked.append(allShortcuts[index])
             }
         })
+        refreshPersonalCurations()
     }
     func initShortcut() {
         sortedShortcutsByDownload = allShortcuts.sorted(by: {$0.numberOfDownload > $1.numberOfDownload})
@@ -501,6 +515,7 @@ class ShortcutsZipViewModel: ObservableObject {
                 self.shortcutsUserDownloaded.insert(shortcut, at: 0)
             }
         }
+        self.refreshPersonalCurations()
     }
     
     //MARK: 큐레이션 생성 시 포함된 단축어에 큐레이션 아이디를 저장하는 함수

--- a/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
+++ b/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
@@ -70,7 +70,6 @@ class ShortcutsZipViewModel: ObservableObject {
     }
     
     func refreshPersonalCurations() {
-        print("onAppear data view model, \(self.personalCurations)")
         let personalCurationIDs = Set(self.shortcutsUserDownloaded.flatMap({ $0.curationIDs }))
         for curationID in personalCurationIDs {
             if let curation = self.userCurations.first(where: { $0.id == curationID }) {
@@ -79,7 +78,6 @@ class ShortcutsZipViewModel: ObservableObject {
                 }
             }
         }
-        print("onAppear data view model2, \(self.personalCurations)")
     }
     
     func initUserShortcut(user: User) {

--- a/HappyAnding/HappyAnding/Views/Components/CurationListView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/CurationListView.swift
@@ -11,14 +11,13 @@ struct CurationListView: View {
     
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
     @State var data: NavigationListCurationType
+    @State var curations = [Curation]()
     
     var body: some View {
         VStack(spacing: 0) {
-            CurationListHeader(userCurations: data.curation,
-                               data: data,
-                               navigationParentView: self.data.navigationParentView)
-            .padding(.bottom, 12)
-            .padding(.horizontal, 16)
+            listHeader
+                .padding(.bottom, 12)
+                .padding(.horizontal, 16)
             
             ForEach(Array(data.curation.enumerated()), id: \.offset) { index, curation in
                 if index < 2 {
@@ -33,34 +32,38 @@ struct CurationListView: View {
             }
         }
         .background(Color.Background.ignoresSafeArea(.all, edges: .all))
-        
-        .onChange(of: shortcutsZipViewModel.personalCurations) { data in
-            if self.data.type == .personalCuration {
-                self.data.curation = data
-            }
-        }
-        .onChange(of: shortcutsZipViewModel.userCurations) { data in
-            if self.data.type == .userCuration {
-                self.data.curation = data
-            }
-        }
-        .onChange(of: shortcutsZipViewModel.curationsMadeByUser) { data in
-            if self.data.type == .myCuration {
-                self.data.curation = data
-            }
-        }
-    }
-}
 
-struct CurationListHeader: View {
+//        .onAppear {
+//            switch data.type {
+//            case .myCuration:
+//                self.curations = shortcutsZipViewModel.curationsMadeByUser
+//            case .userCuration:
+//                self.curations = shortcutsZipViewModel.userCurations
+//            case .personalCuration:
+//
+//                self.curations = shortcutsZipViewModel.personalCurations
+//            }
+//        }
+//        .onChange(of: shortcutsZipViewModel.personalCurations) { data in
+//            if self.data.type == .personalCuration {
+////                shortcutsZipViewModel.refreshPersonalCurations()
+//                self.curations = data
+//            }
+//        }
+//        .onChange(of: shortcutsZipViewModel.userCurations) { data in
+//            if self.data.type == .userCuration {
+////                shortcutsZipViewModel.refreshPersonalCurations()
+//                self.curations = data
+//            }
+//        }
+//        .onChange(of: shortcutsZipViewModel.curationsMadeByUser) { data in
+//            if self.data.type == .myCuration {
+//                self.curations = data
+//            }
+//        }
+    }
     
-    @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
-    let userCurations: [Curation]
-    
-    @State var data: NavigationListCurationType
-    let navigationParentView: NavigationParentView
-    
-    var body: some View {
+    var listHeader: some View {
         HStack(alignment: .bottom) {
             if data.type == .personalCuration {
                 Text("\(shortcutsZipViewModel.userInfo?.nickname ?? "")\(data.type.rawValue)")
@@ -81,23 +84,36 @@ struct CurationListHeader: View {
                     .foregroundColor(.Gray4)
             }
         }
-        .onChange(of: shortcutsZipViewModel.personalCurations) { data in
-            if self.data.type == .personalCuration {
-                self.data.curation = data
-            }
-        }
-        .onChange(of: shortcutsZipViewModel.userCurations) { data in
-            if self.data.type == .userCuration {
-                self.data.curation = data
-            }
-        }
-        .onChange(of: shortcutsZipViewModel.curationsMadeByUser) { data in
-            if self.data.type == .myCuration {
-                self.data.curation = data
-            }
-        }
     }
 }
+
+//struct CurationListHeader: View {
+//
+//    @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
+//    let userCurations: [Curation]
+//
+//    @State var data: NavigationListCurationType
+//    let navigationParentView: NavigationParentView
+//
+//    var body: some View {
+//
+//        .onChange(of: shortcutsZipViewModel.personalCurations) { data in
+//            if self.data.type == .personalCuration {
+//                self.data.curation = data
+//            }
+//        }
+//        .onChange(of: shortcutsZipViewModel.userCurations) { data in
+//            if self.data.type == .userCuration {
+//                self.data.curation = data
+//            }
+//        }
+//        .onChange(of: shortcutsZipViewModel.curationsMadeByUser) { data in
+//            if self.data.type == .myCuration {
+//                self.data.curation = data
+//            }
+//        }
+//    }
+//}
 
 
 //struct CurationListView_Previews: PreviewProvider {

--- a/HappyAnding/HappyAnding/Views/Components/CurationListView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/CurationListView.swift
@@ -11,17 +11,16 @@ struct CurationListView: View {
     
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
     @State var data: NavigationListCurationType
-    @Binding var userCurations: [Curation]
     
     var body: some View {
         VStack(spacing: 0) {
-            CurationListHeader(userCurations: $userCurations,
+            CurationListHeader(userCurations: data.curation,
                                data: data,
                                navigationParentView: self.data.navigationParentView)
-                .padding(.bottom, 12)
-                .padding(.horizontal, 16)
+            .padding(.bottom, 12)
+            .padding(.horizontal, 16)
             
-            ForEach(Array(userCurations.enumerated()), id: \.offset) { index, curation in
+            ForEach(Array(data.curation.enumerated()), id: \.offset) { index, curation in
                 if index < 2 {
                     
                     let data = NavigationReadUserCurationType(userCuration: curation,
@@ -33,18 +32,30 @@ struct CurationListView: View {
                 }
             }
         }
-        .navigationDestination(for: NavigationReadUserCurationType.self) { data in
-            ReadUserCurationView(data: data)
-        }
         .background(Color.Background.ignoresSafeArea(.all, edges: .all))
         
+        .onChange(of: shortcutsZipViewModel.personalCurations) { data in
+            if self.data.type == .personalCuration {
+                self.data.curation = data
+            }
+        }
+        .onChange(of: shortcutsZipViewModel.userCurations) { data in
+            if self.data.type == .userCuration {
+                self.data.curation = data
+            }
+        }
+        .onChange(of: shortcutsZipViewModel.curationsMadeByUser) { data in
+            if self.data.type == .myCuration {
+                self.data.curation = data
+            }
+        }
     }
 }
 
 struct CurationListHeader: View {
     
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
-    @Binding var userCurations: [Curation]
+    let userCurations: [Curation]
     
     @State var data: NavigationListCurationType
     let navigationParentView: NavigationParentView
@@ -70,9 +81,20 @@ struct CurationListHeader: View {
                     .foregroundColor(.Gray4)
             }
         }
-        .navigationDestination(for: NavigationListCurationType.self) { data in
-            ListCurationView(userCurations: $userCurations,
-                             data: data)
+        .onChange(of: shortcutsZipViewModel.personalCurations) { data in
+            if self.data.type == .personalCuration {
+                self.data.curation = data
+            }
+        }
+        .onChange(of: shortcutsZipViewModel.userCurations) { data in
+            if self.data.type == .userCuration {
+                self.data.curation = data
+            }
+        }
+        .onChange(of: shortcutsZipViewModel.curationsMadeByUser) { data in
+            if self.data.type == .myCuration {
+                self.data.curation = data
+            }
         }
     }
 }

--- a/HappyAnding/HappyAnding/Views/Components/CurationListView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/CurationListView.swift
@@ -11,13 +11,10 @@ struct CurationListView: View {
     
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
     @State var data: NavigationListCurationType
-    @State var curations = [Curation]()
     
     var body: some View {
         VStack(spacing: 0) {
             listHeader
-                .padding(.bottom, 12)
-                .padding(.horizontal, 16)
             
             ForEach(Array(data.curation.enumerated()), id: \.offset) { index, curation in
                 if index < 2 {
@@ -32,35 +29,14 @@ struct CurationListView: View {
             }
         }
         .background(Color.Background.ignoresSafeArea(.all, edges: .all))
-
-//        .onAppear {
-//            switch data.type {
-//            case .myCuration:
-//                self.curations = shortcutsZipViewModel.curationsMadeByUser
-//            case .userCuration:
-//                self.curations = shortcutsZipViewModel.userCurations
-//            case .personalCuration:
-//
-//                self.curations = shortcutsZipViewModel.personalCurations
-//            }
-//        }
-//        .onChange(of: shortcutsZipViewModel.personalCurations) { data in
-//            if self.data.type == .personalCuration {
-////                shortcutsZipViewModel.refreshPersonalCurations()
-//                self.curations = data
-//            }
-//        }
-//        .onChange(of: shortcutsZipViewModel.userCurations) { data in
-//            if self.data.type == .userCuration {
-////                shortcutsZipViewModel.refreshPersonalCurations()
-//                self.curations = data
-//            }
-//        }
-//        .onChange(of: shortcutsZipViewModel.curationsMadeByUser) { data in
-//            if self.data.type == .myCuration {
-//                self.curations = data
-//            }
-//        }
+        .onAppear {
+            if self.data.type == .personalCuration {
+                self.data.curation = shortcutsZipViewModel.personalCurations
+            }
+            if self.data.isAllUser {
+                self.data.curation = shortcutsZipViewModel.userCurations
+            }
+        }
     }
     
     var listHeader: some View {
@@ -84,40 +60,8 @@ struct CurationListView: View {
                     .foregroundColor(.Gray4)
             }
         }
+        .padding(.bottom, 12)
+        .padding(.horizontal, 16)
     }
 }
 
-//struct CurationListHeader: View {
-//
-//    @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
-//    let userCurations: [Curation]
-//
-//    @State var data: NavigationListCurationType
-//    let navigationParentView: NavigationParentView
-//
-//    var body: some View {
-//
-//        .onChange(of: shortcutsZipViewModel.personalCurations) { data in
-//            if self.data.type == .personalCuration {
-//                self.data.curation = data
-//            }
-//        }
-//        .onChange(of: shortcutsZipViewModel.userCurations) { data in
-//            if self.data.type == .userCuration {
-//                self.data.curation = data
-//            }
-//        }
-//        .onChange(of: shortcutsZipViewModel.curationsMadeByUser) { data in
-//            if self.data.type == .myCuration {
-//                self.data.curation = data
-//            }
-//        }
-//    }
-//}
-
-
-//struct CurationListView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        CurationListView(curationListTitle:유저 큐레이션", userCurations: UserCuration.fetchData(number: 5))
-//    }
-//}

--- a/HappyAnding/HappyAnding/Views/Components/ListShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ListShortcutView.swift
@@ -75,9 +75,6 @@ struct ListShortcutView: View {
                     }
                 }
                 .scrollIndicators(.hidden)
-                .navigationDestination(for: NavigationReadShortcutType.self) { data in
-                    ReadShortcutView(data: data)
-                }
                 .listRowBackground(Color.Background)
                 .listStyle(.plain)
                 .background(Color.Background.ignoresSafeArea(.all, edges: .all))

--- a/HappyAnding/HappyAnding/Views/Components/MyShortcutCardListView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/MyShortcutCardListView.swift
@@ -67,12 +67,6 @@ struct MyShortcutCardListView: View {
                 .padding(.horizontal, 16)
             }
         }
-        .navigationDestination(for: NavigationListShortcutType.self) { data in
-            ListShortcutView(data: data)
-        }
-        .navigationDestination(for: NavigationReadShortcutType.self) { data in
-            ReadShortcutView(data: data)
-        }
         .navigationBarTitleDisplayMode(.automatic)
         .fullScreenCover(isPresented: $isWriting) {
             NavigationStack(path: $writeNavigation.navigationPath) {

--- a/HappyAnding/HappyAnding/Views/Components/UserCurationListView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/UserCurationListView.swift
@@ -51,9 +51,9 @@ struct UserCurationListView: View {
                 }
             }
         }
-        .navigationDestination(for: NavigationReadUserCurationType.self) { data in
-            ReadUserCurationView(data: data)
-        }
+//        .navigationDestination(for: NavigationReadUserCurationType.self) { data in
+//            ReadUserCurationView(data: data)
+//        }
         .background(Color.Background.ignoresSafeArea(.all, edges: .all))
         .fullScreenCover(isPresented: $isWriting) {
             NavigationStack(path: $writeCurationNavigation.navigationPath) {
@@ -84,9 +84,6 @@ struct UserCurationListView: View {
                     .Footnote()
                     .foregroundColor(.Gray4)
             }
-        }
-        .navigationDestination(for: NavigationListCurationType.self) { data in
-            ListCurationView(data: data)
         }
     }
 }

--- a/HappyAnding/HappyAnding/Views/Components/UserCurationListView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/UserCurationListView.swift
@@ -13,15 +13,13 @@ struct UserCurationListView: View {
     @State var isWriting = false
     @State var data: NavigationListCurationType
     
-    @Binding var userCurations: [Curation]
-    
     var body: some View {
         VStack(spacing: 0) {
-            UserCurationListHeader(userCurations: $userCurations,
+            UserCurationListHeader(userCurations: data.curation,
                                    data: data,
                                    navigationParentView: self.data.navigationParentView)
-                .padding(.bottom, 12)
-                .padding(.horizontal, 16)
+            .padding(.bottom, 12)
+            .padding(.horizontal, 16)
             
             Button {
                 self.isWriting = true
@@ -41,17 +39,15 @@ struct UserCurationListView: View {
                 .padding(.horizontal, 16)
             }
             
-            if let userCurations {
-                ForEach(Array(userCurations.enumerated()), id: \.offset) { index, curation in
-                    
-                    let data = NavigationReadUserCurationType(userCuration: curation,
-                                                              navigationParentView: self.data.navigationParentView)
-                    //TODO: 데이터 변경 필요
-                    if index < 2 {
-                        NavigationLink(value: data) {
-                            UserCurationCell(curation: curation,
-                                             navigationParentView: self.data.navigationParentView)
-                        }
+            ForEach(Array(data.curation.enumerated()), id: \.offset) { index, curation in
+                
+                let data = NavigationReadUserCurationType(userCuration: curation,
+                                                          navigationParentView: self.data.navigationParentView)
+                //TODO: 데이터 변경 필요
+                if index < 2 {
+                    NavigationLink(value: data) {
+                        UserCurationCell(curation: curation,
+                                         navigationParentView: self.data.navigationParentView)
                     }
                 }
             }
@@ -70,7 +66,7 @@ struct UserCurationListView: View {
 }
 
 struct UserCurationListHeader: View {
-    @Binding var userCurations: [Curation]
+    let userCurations: [Curation]
     
     @State var data: NavigationListCurationType
     
@@ -91,9 +87,7 @@ struct UserCurationListHeader: View {
             }
         }
         .navigationDestination(for: NavigationListCurationType.self) { data in
-            ListCurationView(userCurations: $userCurations,
-                             data: data)
-            
+            ListCurationView(data: data)
         }
     }
 }

--- a/HappyAnding/HappyAnding/Views/Components/UserCurationListView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/UserCurationListView.swift
@@ -8,18 +8,17 @@
 import SwiftUI
 
 struct UserCurationListView: View {
-    
+    @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
     @StateObject var writeCurationNavigation = WriteCurationNavigation()
     @State var isWriting = false
     @State var data: NavigationListCurationType
+    @State var curations = [Curation]()
     
     var body: some View {
         VStack(spacing: 0) {
-            UserCurationListHeader(userCurations: data.curation,
-                                   data: data,
-                                   navigationParentView: self.data.navigationParentView)
-            .padding(.bottom, 12)
-            .padding(.horizontal, 16)
+            listHeader
+                .padding(.bottom, 12)
+                .padding(.horizontal, 16)
             
             Button {
                 self.isWriting = true
@@ -39,7 +38,7 @@ struct UserCurationListView: View {
                 .padding(.horizontal, 16)
             }
             
-            ForEach(Array(data.curation.enumerated()), id: \.offset) { index, curation in
+            ForEach(Array(curations.enumerated()), id: \.offset) { index, curation in
                 
                 let data = NavigationReadUserCurationType(userCuration: curation,
                                                           navigationParentView: self.data.navigationParentView)
@@ -62,17 +61,17 @@ struct UserCurationListView: View {
             }
             .environmentObject(writeCurationNavigation)
         }
+        .onAppear {
+            self.data.curation = shortcutsZipViewModel.curationsMadeByUser
+            self.curations = shortcutsZipViewModel.curationsMadeByUser
+        }
+        .onChange(of: shortcutsZipViewModel.curationsMadeByUser) { data in
+            self.data.curation = data
+            self.curations = data
+        }
     }
-}
-
-struct UserCurationListHeader: View {
-    let userCurations: [Curation]
     
-    @State var data: NavigationListCurationType
-    
-    let navigationParentView: NavigationParentView
-    
-    var body: some View {
+    var listHeader: some View {
         HStack(alignment: .bottom) {
             Text(data.title ?? "")
                 .Title2()
@@ -92,8 +91,3 @@ struct UserCurationListHeader: View {
     }
 }
 
-//struct UserCurationListView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        UserCurationListView(userCurations: UserCuration.fetchData(number: 5))
-//    }
-//}

--- a/HappyAnding/HappyAnding/Views/Components/UserCurationListView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/UserCurationListView.swift
@@ -51,9 +51,6 @@ struct UserCurationListView: View {
                 }
             }
         }
-//        .navigationDestination(for: NavigationReadUserCurationType.self) { data in
-//            ReadUserCurationView(data: data)
-//        }
         .background(Color.Background.ignoresSafeArea(.all, edges: .all))
         .fullScreenCover(isPresented: $isWriting) {
             NavigationStack(path: $writeCurationNavigation.navigationPath) {

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ExploreCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ExploreCurationView.swift
@@ -10,6 +10,16 @@ import SwiftUI
 struct ExploreCurationView: View {
     
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
+//    @State var personalCurationData = NavigationListCurationType(type: .personalCuration,
+//                                                          title: "",
+//                                                          isAllUser: false,
+//                                                          navigationParentView: .curations,
+//                                                          curation: [Curation]())
+//    @State var usercurationData = NavigationListCurationType(type: .userCuration,
+//                                                             title: "큐레이션 모아보기",
+//                                                             isAllUser: true,
+//                                                             navigationParentView: .curations,
+//                                                             curation: [Curation]())
     
     var body: some View {
         ScrollView {
@@ -46,6 +56,12 @@ struct ExploreCurationView: View {
             }
             .padding(.bottom, 32)
         }
+        .onAppear {
+            
+//            self.personalCurationData.curation = shortcutsZipViewModel.personalCurations
+//            self.usercurationData.curation = shortcutsZipViewModel.userCurations
+        }
+
         .navigationBarTitle(Text("큐레이션 둘러보기"))
         .navigationBarTitleDisplayMode(.large)
         .scrollIndicators(.hidden)

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ExploreCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ExploreCurationView.swift
@@ -10,16 +10,6 @@ import SwiftUI
 struct ExploreCurationView: View {
     
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
-//    @State var personalCurationData = NavigationListCurationType(type: .personalCuration,
-//                                                          title: "",
-//                                                          isAllUser: false,
-//                                                          navigationParentView: .curations,
-//                                                          curation: [Curation]())
-//    @State var usercurationData = NavigationListCurationType(type: .userCuration,
-//                                                             title: "큐레이션 모아보기",
-//                                                             isAllUser: true,
-//                                                             navigationParentView: .curations,
-//                                                             curation: [Curation]())
     
     var body: some View {
         ScrollView {
@@ -56,12 +46,6 @@ struct ExploreCurationView: View {
             }
             .padding(.bottom, 32)
         }
-        .onAppear {
-            
-//            self.personalCurationData.curation = shortcutsZipViewModel.personalCurations
-//            self.usercurationData.curation = shortcutsZipViewModel.userCurations
-        }
-
         .navigationBarTitle(Text("큐레이션 둘러보기"))
         .navigationBarTitleDisplayMode(.large)
         .scrollIndicators(.hidden)

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ExploreCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ExploreCurationView.swift
@@ -50,17 +50,6 @@ struct ExploreCurationView: View {
         .navigationBarTitleDisplayMode(.large)
         .scrollIndicators(.hidden)
         .background(Color.Background)
-        
-        .navigationDestination(for: Curation.self) { data in
-            ReadAdminCurationView(curation: data)
-        }
-        .navigationDestination(for: NavigationReadUserCurationType.self) { data in
-            ReadUserCurationView(data: data)
-        }
-        .navigationDestination(for: NavigationListCurationType.self) { data in
-            ListCurationView(data: data)
-        }
-
     }
 }
 

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ExploreCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ExploreCurationView.swift
@@ -24,8 +24,8 @@ struct ExploreCurationView: View {
                 CurationListView(data: NavigationListCurationType(type: .personalCuration,
                                                                   title: "",
                                                                   isAllUser: false,
-                                                                  navigationParentView: .curations),
-                                 userCurations: $shortcutsZipViewModel.personalCurations)
+                                                                  navigationParentView: .curations,
+                                                                  curation: shortcutsZipViewModel.personalCurations))
                 .onAppear {
                     shortcutsZipViewModel.personalCurations.removeAll()
                     let personalCurationIDs = Set(shortcutsZipViewModel.shortcutsUserDownloaded.flatMap({ $0.curationIDs }))
@@ -41,8 +41,8 @@ struct ExploreCurationView: View {
                 CurationListView(data: NavigationListCurationType(type: .userCuration,
                                                                   title: "큐레이션 모아보기",
                                                                   isAllUser: true,
-                                                                  navigationParentView: .curations),
-                                 userCurations: $shortcutsZipViewModel.userCurations)
+                                                                  navigationParentView: .curations,
+                                                                  curation: shortcutsZipViewModel.userCurations))
             }
             .padding(.bottom, 32)
         }
@@ -50,6 +50,17 @@ struct ExploreCurationView: View {
         .navigationBarTitleDisplayMode(.large)
         .scrollIndicators(.hidden)
         .background(Color.Background)
+        
+        .navigationDestination(for: Curation.self) { data in
+            ReadAdminCurationView(curation: data)
+        }
+        .navigationDestination(for: NavigationReadUserCurationType.self) { data in
+            ReadUserCurationView(data: data)
+        }
+        .navigationDestination(for: NavigationListCurationType.self) { data in
+            ListCurationView(data: data)
+        }
+
     }
 }
 
@@ -86,9 +97,6 @@ struct adminCurationsFrameiew: View {
                 .padding(.leading, 16)
                 .padding(.trailing, 8)
             }
-        }
-        .navigationDestination(for: Curation.self) { data in
-            ReadAdminCurationView(curation: data)
         }
     }
 }

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ListCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ListCurationView.swift
@@ -23,7 +23,6 @@ struct ListCurationView: View {
     
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
     @State var data: NavigationListCurationType
-    @State var curations = [Curation]()
     
     var body: some View {
         let titleString = data.type == .personalCuration ? (shortcutsZipViewModel.userInfo?.nickname ?? "") : ""
@@ -39,7 +38,7 @@ struct ListCurationView: View {
             ScrollView {
                 LazyVStack(spacing: 0) {
                     
-                    ForEach(Array(curations.enumerated()), id: \.offset) { index, curation in
+                    ForEach(Array(data.curation.enumerated()), id: \.offset) { index, curation in
                         
                         let data = NavigationReadUserCurationType(userCuration: curation,
                                                                   navigationParentView: self.data.navigationParentView)
@@ -52,43 +51,8 @@ struct ListCurationView: View {
                             .listRowBackground(Color.Background)
                             .padding(.top, index == 0 ? 20 : 0 )
                             .padding(.bottom, index == self.data.curation.count - 1 ? 32 : 0)
-                            
-                            .onAppear {
-                                //TODO: 10개씩 불러오도록 변경 필요
-                                if self.data.isAllUser {
-                                    self.data.curation = shortcutsZipViewModel.userCurations
-                                }
-                            }
                         }
                     }
-                }
-            }
-            .onAppear {
-                switch data.type {
-                case .myCuration:
-                    self.curations = shortcutsZipViewModel.curationsMadeByUser
-                case .userCuration:
-                    self.curations = shortcutsZipViewModel.userCurations
-                case .personalCuration:
-                    shortcutsZipViewModel.refreshPersonalCurations()
-                    self.curations = shortcutsZipViewModel.personalCurations
-                }
-            }
-            .onChange(of: shortcutsZipViewModel.personalCurations) { data in
-                if self.data.type == .personalCuration {
-    //                shortcutsZipViewModel.refreshPersonalCurations()
-                    self.curations = data
-                }
-            }
-            .onChange(of: shortcutsZipViewModel.userCurations) { data in
-                if self.data.type == .userCuration {
-    //                shortcutsZipViewModel.refreshPersonalCurations()
-                    self.curations = data
-                }
-            }
-            .onChange(of: shortcutsZipViewModel.curationsMadeByUser) { data in
-                if self.data.type == .myCuration {
-                    self.curations = data
                 }
             }
             .scrollIndicators(.hidden)

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ListCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ListCurationView.swift
@@ -56,9 +56,6 @@ struct ListCurationView: View {
                 }
             }
             .scrollIndicators(.hidden)
-            .navigationDestination(for: NavigationReadUserCurationType.self) { data in
-                ReadUserCurationView(data: data)
-            }
             .listStyle(.plain)
             .background(Color.Background.ignoresSafeArea(.all, edges: .all))
             .navigationBarBackground ({ Color.Background })

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ListCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ListCurationView.swift
@@ -22,12 +22,11 @@ enum CurationType: String {
 struct ListCurationView: View {
     
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
-    @Binding var userCurations: [Curation]
-    let data: NavigationListCurationType
+    @State var data: NavigationListCurationType
     
     var body: some View {
         let titleString = data.type == .personalCuration ? (shortcutsZipViewModel.userInfo?.nickname ?? "") : ""
-        if userCurations.count == 0 {
+        if data.curation.count == 0 {
             Text("\(titleString)\(data.type.rawValue)이(가) 없습니다.")
                 .Body2()
                 .foregroundColor(Color.Gray4)
@@ -39,7 +38,7 @@ struct ListCurationView: View {
             ScrollView {
                 LazyVStack(spacing: 0) {
                     
-                    ForEach(Array(userCurations.enumerated()), id: \.offset) { index, curation in
+                    ForEach(Array(data.curation.enumerated()), id: \.offset) { index, curation in
                         
                         let data = NavigationReadUserCurationType(userCuration: curation,
                                                                   navigationParentView: self.data.navigationParentView)
@@ -51,16 +50,31 @@ struct ListCurationView: View {
                             .listRowSeparator(.hidden)
                             .listRowBackground(Color.Background)
                             .padding(.top, index == 0 ? 20 : 0 )
-                            .padding(.bottom, index == userCurations.count - 1 ? 32 : 0)
+                            .padding(.bottom, index == self.data.curation.count - 1 ? 32 : 0)
                             
                             .onAppear {
                                 //TODO: 10개씩 불러오도록 변경 필요
                                 if self.data.isAllUser {
-                                    self.userCurations = shortcutsZipViewModel.userCurations
+                                    self.data.curation = shortcutsZipViewModel.userCurations
                                 }
                             }
                         }
                     }
+                }
+            }
+            .onChange(of: shortcutsZipViewModel.personalCurations) { data in
+                if self.data.type == .personalCuration {
+                    self.data.curation = data
+                }
+            }
+            .onChange(of: shortcutsZipViewModel.userCurations) { data in
+                if self.data.type == .userCuration {
+                    self.data.curation = data
+                }
+            }
+            .onChange(of: shortcutsZipViewModel.curationsMadeByUser) { data in
+                if self.data.type == .myCuration {
+                    self.data.curation = data
                 }
             }
             .scrollIndicators(.hidden)

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ListCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ListCurationView.swift
@@ -23,6 +23,7 @@ struct ListCurationView: View {
     
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
     @State var data: NavigationListCurationType
+    @State var curations = [Curation]()
     
     var body: some View {
         let titleString = data.type == .personalCuration ? (shortcutsZipViewModel.userInfo?.nickname ?? "") : ""
@@ -38,7 +39,7 @@ struct ListCurationView: View {
             ScrollView {
                 LazyVStack(spacing: 0) {
                     
-                    ForEach(Array(data.curation.enumerated()), id: \.offset) { index, curation in
+                    ForEach(Array(curations.enumerated()), id: \.offset) { index, curation in
                         
                         let data = NavigationReadUserCurationType(userCuration: curation,
                                                                   navigationParentView: self.data.navigationParentView)
@@ -62,19 +63,32 @@ struct ListCurationView: View {
                     }
                 }
             }
+            .onAppear {
+                switch data.type {
+                case .myCuration:
+                    self.curations = shortcutsZipViewModel.curationsMadeByUser
+                case .userCuration:
+                    self.curations = shortcutsZipViewModel.userCurations
+                case .personalCuration:
+                    shortcutsZipViewModel.refreshPersonalCurations()
+                    self.curations = shortcutsZipViewModel.personalCurations
+                }
+            }
             .onChange(of: shortcutsZipViewModel.personalCurations) { data in
                 if self.data.type == .personalCuration {
-                    self.data.curation = data
+    //                shortcutsZipViewModel.refreshPersonalCurations()
+                    self.curations = data
                 }
             }
             .onChange(of: shortcutsZipViewModel.userCurations) { data in
                 if self.data.type == .userCuration {
-                    self.data.curation = data
+    //                shortcutsZipViewModel.refreshPersonalCurations()
+                    self.curations = data
                 }
             }
             .onChange(of: shortcutsZipViewModel.curationsMadeByUser) { data in
                 if self.data.type == .myCuration {
-                    self.data.curation = data
+                    self.curations = data
                 }
             }
             .scrollIndicators(.hidden)

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadAdminCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadAdminCurationView.swift
@@ -57,9 +57,6 @@ struct ReadAdminCurationView: View {
             Spacer()
                 .frame(height: 44)
         }
-        .navigationDestination(for: NavigationReadShortcutType.self) { data in
-            ReadShortcutView(data: data)
-        }
         .navigationBarTitleDisplayMode(.inline)
         .edgesIgnoringSafeArea(.top)
         .background(Color.Background)

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
@@ -65,9 +65,6 @@ struct ReadUserCurationView: View {
                 }
             }
         }
-        .navigationDestination(for: NavigationReadShortcutType.self) { data in
-            ReadShortcutView(data: data)
-        }
         .background(Color.Background.ignoresSafeArea(.all, edges: .all))
         .scrollContentBackground(.hidden)
         .edgesIgnoringSafeArea([.top])

--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView/CategoryCardView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView/CategoryCardView.swift
@@ -54,14 +54,6 @@ struct CategoryCardView: View {
                 .padding(.horizontal, 16)
             }
         }
-        .navigationDestination(for: Category.self) { category in
-            ShortcutsListView(shortcuts: $shortcutsZipViewModel.shortcutsInCategory[category.index],
-                              categoryName: category,
-                              navigationParentView: .shortcuts)
-        }
-        .navigationDestination(for: NavigationReadShortcutType.self) { data in
-            ReadShortcutView(data: data)
-        }
     }
 }
 

--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView/CategoryView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView/CategoryView.swift
@@ -51,11 +51,6 @@ struct CategoryView: View {
                 }
             }
             .padding(.horizontal, 16)
-            .navigationDestination(for: Category.self) { category in
-                ShortcutsListView(shortcuts: $shortcutsZipViewModel.shortcutsInCategory[category.index],
-                                  categoryName: category,
-                                  navigationParentView: .shortcuts)
-            }
         }
     }
 }

--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView/DownloadRankView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView/DownloadRankView.swift
@@ -48,11 +48,5 @@ struct DownloadRankView: View {
             }
             .background(Color.Background)
         }
-        .navigationDestination(for: NavigationReadShortcutType.self) { data in
-            ReadShortcutView(data: data)
-        }
-        .navigationDestination(for: NavigationListShortcutType.self) { data in
-            ListShortcutView(data: data)
-        }
     }
 }

--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView/ExploreShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView/ExploreShortcutView.swift
@@ -11,10 +11,6 @@ struct ExploreShortcutView: View {
     
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
     
-    enum NavigationSearch: Hashable, Equatable {
-        case first
-    }
-    
     var body: some View {
         ScrollView {
             DownloadRankView(shortcuts: $shortcutsZipViewModel.sortedShortcutsByDownload,
@@ -50,9 +46,6 @@ struct ExploreShortcutView: View {
                         .foregroundColor(.Gray5)
                 }
             }
-        }
-        .navigationDestination(for: NavigationSearch.self) { _ in
-            SearchView()
         }
         .navigationBarBackground ({ Color.Background })
     }

--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView/LovedShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView/LovedShortcutView.swift
@@ -47,12 +47,6 @@ struct LovedShortcutView: View {
             }
             
         }
-        .navigationDestination(for: NavigationListShortcutType.self) { data in
-            ListShortcutView(data: data)
-        }
-        .navigationDestination(for: NavigationReadShortcutType.self) { data in
-            ReadShortcutView(data: data)
-        }
         .background(Color.Background)
     }
 }

--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ShortcutsListView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ShortcutsListView.swift
@@ -48,9 +48,6 @@ struct ShortcutsListView: View {
             }
         }
         .scrollIndicators(.hidden)
-        .navigationDestination(for: NavigationReadShortcutType.self) { data in
-            ReadShortcutView(data: data)
-        }
         .navigationBarTitle(categoryName.translateName())
         .navigationBarTitleDisplayMode(.inline)
         .background(Color.Background)

--- a/HappyAnding/HappyAnding/Views/MyPageViews/MyPageView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/MyPageView.swift
@@ -139,8 +139,5 @@ struct MyPageShortcutListCell: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 16)
         }
-        .navigationDestination(for: NavigationListShortcutType.self) { data in
-            ListShortcutView(data: data)
-        }
     }
 }

--- a/HappyAnding/HappyAnding/Views/MyPageViews/MyPageView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/MyPageView.swift
@@ -66,8 +66,8 @@ struct MyPageView: View {
                 UserCurationListView(data: NavigationListCurationType(type: .myCuration,
                                                                       title: "내가 작성한 큐레이션",
                                                                       isAllUser: false,
-                                                                      navigationParentView: .myPage),
-                                     userCurations: $shortcutsZipViewModel.curationsMadeByUser)
+                                                                      navigationParentView: .myPage,
+                                                                      curation: shortcutsZipViewModel.curationsMadeByUser))
                 .frame(maxWidth: .infinity)
                 
                 // MARK: - 좋아요한 단축어

--- a/HappyAnding/HappyAnding/Views/SearchView.swift
+++ b/HappyAnding/HappyAnding/Views/SearchView.swift
@@ -45,9 +45,6 @@ struct SearchView: View {
                 }
             }
         }
-        .navigationDestination(for: NavigationReadShortcutType.self) { data in
-            ReadShortcutView(data: data)
-        }
         .onAppear() {
             self.keywords = shortcutsZipViewModel.keywords
         }

--- a/HappyAnding/HappyAnding/Views/TabView/ShortcutTabView.swift
+++ b/HappyAnding/HappyAnding/Views/TabView/ShortcutTabView.swift
@@ -64,6 +64,20 @@ struct ShortcutTabView: View {
                             }
                             self.tappedTwice = false
                         })
+                        .navigationDestination(for: NavigationSearch.self) { _ in
+                            SearchView()
+                        }
+                        .navigationDestination(for: NavigationListShortcutType.self) { data in
+                            ListShortcutView(data: data)
+                        }
+                        .navigationDestination(for: NavigationReadShortcutType.self) { data in
+                            ReadShortcutView(data: data)
+                        }
+                        .navigationDestination(for: Category.self) { category in
+                            ShortcutsListView(shortcuts: $shortcutsZipViewModel.shortcutsInCategory[category.index],
+                                              categoryName: category,
+                                              navigationParentView: .shortcuts)
+                        }
                 }
                 .environmentObject(shortcutNavigation)
                 .tabItem {
@@ -85,6 +99,19 @@ struct ShortcutTabView: View {
                             self.tappedTwice = false
                         })
                         .navigationBarBackground ({ Color.Background })
+                        .navigationDestination(for: Curation.self) { data in
+                            ReadAdminCurationView(curation: data)
+                        }
+                        .navigationDestination(for: NavigationReadUserCurationType.self) { data in
+                            ReadUserCurationView(data: data)
+                        }
+                        .navigationDestination(for: NavigationListCurationType.self) { data in
+                            ListCurationView(data: data)
+                        }
+                        .navigationDestination(for: NavigationReadShortcutType.self) { data in
+                            ReadShortcutView(data: data)
+                        }
+                    
                 }
                 .environmentObject(curationNavigation)
                 .tabItem {
@@ -106,6 +133,19 @@ struct ShortcutTabView: View {
                             self.tappedTwice = false
                         })
                         .navigationBarBackground ({ Color.Background })
+                    
+                        .navigationDestination(for: NavigationListShortcutType.self) { data in
+                            ListShortcutView(data: data)
+                        }
+                        .navigationDestination(for: NavigationReadShortcutType.self) { data in
+                            ReadShortcutView(data: data)
+                        }
+                        .navigationDestination(for: NavigationReadUserCurationType.self) { data in
+                            ReadUserCurationView(data: data)
+                        }
+                        .navigationDestination(for: NavigationListCurationType.self) { data in
+                            ListCurationView(data: data)
+                        }
                 }
                 .environmentObject(profileNavigation)
                 .tabItem {


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #306 
- closes #310 

## 구현/변경 사항
- NavigationListCurationType 수정
- ListView 에서 2개의 미리보기 목록 및 타이틀과 헤더가 Struct로 분리되어있어 불필요한 요청을 많이 발생하는 것 같아 하나의 구조체 내에서 분리했습니다. (binding, onChange 코드의 중복을 제거하기 위해서)
- 네비게이션 관련 콘솔이 지속적으로 출력되는 문제를 해결했습니다.

## 스크린샷
- 다운로드한 단축어가 없을 때, 단축어 모아보기에 아무것도 출력되지 않던 문제 해결
- 뷰 변경은 존재하지 않아 동영상 녹화로 대체합니다!

https://user-images.githubusercontent.com/68676844/204099733-2fc205b1-f31e-4014-9b18-128fdf459ace.mov


## Todo
- 현재 다운로드 받지 않은 단축어도 ~를 위한 모음집에 뜨는 이유는 큐레이션 편집했을 때, 단축어 정보가 삭제 되어도, 해당 큐레이션 내 단축어 id 정보가 삭제되지 않아서입니다! 해당 작업은 이슈 끊어놨으니 선착순으로 가져가세요!

## To Reviewer
- 네비게이션 스택의 로그가 발생한 경우는 하나의 네비게이션 스택에서 같은 데이터를 참조했기 때문입니다.
  - 탭바 선언된 부분에 데스티네이션을 선언하여 문제를 해결했습니다.
- 단축어 모아보기에 아무것도 출력되지 않던 문제의 경우, 네비게이션 스택 데이터 전달에 이슈가 있었기 때문입니다!
  - 기존 바인딩으로 넘겼던 큐레이션 리스트를 상수로 선언하여 전달하였습니다. (현재는 바인딩 변수 필요 없음)