### PR TITLE
[Feat] 큐레이션 편집에서 단축어 제거 시 단축어의 큐레이션 아이디 제거하는 함수 추가

### DIFF
--- a/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
+++ b/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
@@ -507,7 +507,15 @@ class ShortcutsZipViewModel: ObservableObject {
     
     //MARK: 큐레이션 생성 시 포함된 단축어에 큐레이션 아이디를 저장하는 함수
     
-    func updateShortcutCurationID (shortcutCells: [ShortcutCellModel], curationID: String) {
+    func updateShortcutCurationID (shortcutCells: [ShortcutCellModel], curationID: String, isEdit: Bool, deletedShortcutCells: [ShortcutCellModel]?) {
+        if isEdit {
+            deletedShortcutCells!.forEach { shortcutCell in
+                if var shortcut = fetchShortcutDetail(id: shortcutCell.id) {
+                    shortcut.curationIDs.removeAll(where: { $0 == curationID})
+                    self.setData(model: shortcut)
+                }
+            }
+        }
         shortcutCells.forEach { shortcutCell in
             if var shortcut = fetchShortcutDetail(id: shortcutCell.id) {
                 if !shortcut.curationIDs.contains(curationID) {

--- a/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationInfoView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationInfoView.swift
@@ -19,6 +19,7 @@ struct WriteCurationInfoView: View {
     @Binding var isWriting: Bool
     
     let isEdit: Bool
+    @Binding var deletedShortcutCells: [ShortcutCellModel]
     
     private var isIncomplete: Bool {
         !(isValidTitle && isValidDescription)
@@ -52,11 +53,18 @@ struct WriteCurationInfoView: View {
                 .frame(maxHeight: .infinity)
             
             Button {
+                if isEdit {
+                    curation.shortcuts.forEach { shortcutCell in
+                        deletedShortcutCells.removeAll(where: { $0.id == shortcutCell.id })
+                    }
+                }
                 curation.author = shortcutsZipViewModel.currentUser()
                 shortcutsZipViewModel.setData(model: curation)
                 shortcutsZipViewModel.updateShortcutCurationID(
                     shortcutCells: curation.shortcuts,
-                    curationID: curation.id
+                    curationID: curation.id,
+                    isEdit: isEdit,
+                    deletedShortcutCells: deletedShortcutCells
                 )
                 if let index = shortcutsZipViewModel.userCurations.firstIndex(where: { $0.id == curation.id}) {
                     shortcutsZipViewModel.userCurations[index] = curation

--- a/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationSetView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationSetView.swift
@@ -22,6 +22,7 @@ struct WriteCurationSetView: View {
                                    author: "",
                                    shortcuts: [ShortcutCellModel]())
     @State var isTappedQuestionMark: Bool = false
+    @State var deletedShortcutCells = [ShortcutCellModel]()
     
     let isEdit: Bool
     
@@ -67,7 +68,11 @@ struct WriteCurationSetView: View {
                 }
             }
         }
-        
+        .onAppear() {
+            if isEdit {
+                deletedShortcutCells = curation.shortcuts
+            }
+        }
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
                 Button {
@@ -81,7 +86,8 @@ struct WriteCurationSetView: View {
         .navigationDestination(for: Float.self) { isEdit in
             WriteCurationInfoView(curation: $curation,
                                   isWriting: self.$isWriting,
-                                  isEdit: self.isEdit)
+                                  isEdit: self.isEdit,
+                                  deletedShortcutCells: $deletedShortcutCells)
         }
     }
     


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #316

## 구현/변경 사항
- 큐레이션 편집에서 단축어 제거 시 단축어 정보에서 curation id 지우는 기능 추가

## 스크린샷

https://user-images.githubusercontent.com/41153398/204107571-fa3f81a5-21e8-4517-945f-07a9d2bbd81f.mov

