### PR TITLE
[Feat] 서브타이틀 줄임표 없애기, 자동완성 막기

### DIFF
--- a/HappyAnding/HappyAnding/Views/Components/ValidationCheckTextField.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ValidationCheckTextField.swift
@@ -108,6 +108,8 @@ struct ValidationCheckTextField: View {
     
     var oneLineEditor: some View {
         TextField(placeholder, text: $content)
+            .disableAutocorrection(true)
+            .textInputAutocapitalization(.never)
             .Body2()
             .frame(height: 20)
             .padding(16)

--- a/HappyAnding/HappyAnding/Views/MyPageViews/EditNicknameView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/EditNicknameView.swift
@@ -81,6 +81,8 @@ struct EditNicknameView: View {
     var textField: some View {
         HStack {
             TextField("닉네임 (최대 8글자)", text: $nickname)
+                .disableAutocorrection(true)
+                .textInputAutocapitalization(.never)
                 .Body2()
                 .focused($isFocused)
                 .foregroundColor(.Gray5)

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutHeaderView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutHeaderView.swift
@@ -30,9 +30,12 @@ struct ReadShortcutHeaderView: View {
                 Text("\(shortcut.title)")
                     .Title1()
                     .foregroundColor(Color.Gray5)
+                    .fixedSize(horizontal: false, vertical: true)
+                
                 Text("\(shortcut.subtitle)")
                     .Body1()
                     .foregroundColor(Color.Gray3)
+                    .fixedSize(horizontal: false, vertical: true)
             }
             userInfo
         }

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -235,6 +235,8 @@ extension ReadShortcutView {
                         .foregroundColor(.Gray4)
                 }
                 TextField("댓글을 입력하세요", text: $commentText, axis: .vertical)
+                    .disableAutocorrection(true)
+                    .textInputAutocapitalization(.never)
                     .Body2()
                     .focused($isFocused)
                     .onAppear(perform : UIApplication.shared.hideKeyboard)

--- a/HappyAnding/HappyAnding/Views/SignInViews/WriteNicknameView.swift
+++ b/HappyAnding/HappyAnding/Views/SignInViews/WriteNicknameView.swift
@@ -106,6 +106,8 @@ struct WriteNicknameView: View {
     var textField: some View {
         HStack {
             TextField("닉네임 (최대 8글자)", text: $nickname)
+                .disableAutocorrection(true)
+                .textInputAutocapitalization(.never)
                 .Body2()
                 .focused($isFocused)
                 .foregroundColor(.Gray5)

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTagView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTagView.swift
@@ -192,6 +192,8 @@ struct WriteShortcutTagView: View {
                     
                     if isTextFieldShowing {
                         TextField("", text: $relatedApp)
+                            .disableAutocorrection(true)
+                            .textInputAutocapitalization(.never)
                             .modifier(ClearButton(text: $relatedApp))
                             .focused($isFocused)
                             .onAppear {


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #322
- closes #320 

## 구현/변경 사항
- 서브타이틀 ...로 표기되는 것 수정
- 텍스트필드 자동수정 막기 (자동 수정 및 첫글자 대문자로 바뀌는 것 수정)

## 스크린샷

|iPhone SE|iPhone 14|iPhone 14 Pro Max|
|:---:|:---:|:---:|
|<img src = "https://user-images.githubusercontent.com/68676844/204133365-af6da0bb-9cf2-476e-890e-38528a9ee38f.png" width = 250>|<img src = "https://user-images.githubusercontent.com/68676844/204133018-94fe3e38-c5e2-4157-8bfb-b1496cdc6106.png" width = 250>|<img src = "https://user-images.githubusercontent.com/68676844/204133421-c7d98a0c-5778-47b9-bda1-9968f9cc6948.png" width = 250>

