### PR TITLE
[Fix] 유저 정보가 없을 경우 처리

### DIFF
--- a/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
+++ b/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
@@ -69,6 +69,9 @@ class ShortcutsZipViewModel: ObservableObject {
         fetchCommentAll { comments in
             self.allComments = comments
         }
+        if self.currentUser() == "" {
+            signInStatus = false
+        }
     }
     
     func initUserShortcut(user: User) {
@@ -550,7 +553,7 @@ class ShortcutsZipViewModel: ObservableObject {
                 let currentUser = firebaseAuth.currentUser
                 currentUser?.delete { error in
                     if let error {
-                        print("**\(error.localizedDescription)")
+                        print("\(error.localizedDescription)")
                     } else {
                         withAnimation(.easeInOut) {
                             self.signInStatus = false
@@ -619,23 +622,23 @@ class ShortcutsZipViewModel: ObservableObject {
             .whereField("id", isEqualTo: userID)
             .getDocuments { (querySnapshot, error) in
                 if let error {
-                print("Error getting documents: \(error)")
-            } else {
-                guard let documents = querySnapshot?.documents else { return }
-                let decoder = JSONDecoder()
-                
-                for document in documents {
-                    do {
-                        let data = document.data()
-                        let jsonData = try JSONSerialization.data(withJSONObject: data)
-                        let shortcut = try decoder.decode(User.self, from: jsonData)
-                        completionHandler(shortcut)
-                    } catch let error {
-                        print("error: \(error)")
+                    print("Error getting documents: \(error)")
+                } else {
+                    guard let documents = querySnapshot?.documents else { return }
+                    if documents.isEmpty { self.signInStatus = false }
+                    let decoder = JSONDecoder()
+                    for document in documents {
+                        do {
+                            let data = document.data()
+                            let jsonData = try JSONSerialization.data(withJSONObject: data)
+                            let user = try decoder.decode(User.self, from: jsonData)
+                            completionHandler(user)
+                        } catch let error {
+                            print("error: \(error)")
+                        }
                     }
                 }
             }
-        }
     }
     
     //MARK: user 닉네임 검사함수 - 중복이면 true, 중복되지않으면 false반환

--- a/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
+++ b/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
@@ -69,9 +69,6 @@ class ShortcutsZipViewModel: ObservableObject {
         fetchCommentAll { comments in
             self.allComments = comments
         }
-        if self.currentUser() == "" {
-            signInStatus = false
-        }
     }
     
     func initUserShortcut(user: User) {


### PR DESCRIPTION
- 유저 정보가 없을 경우 로그인 페이지로 연결하도록 처리


<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #313 

## 구현/변경 사항
- 여러 기기에서 사용 시 한 곳에서 탈퇴 시 다른 기기에서 유저 정보가 없는 상태로 앱에 남아있는 경우가 존재했음 
- 유저정보를 받아오는 도중 빈배열을 받아오는 경우 signInStatus를 변경하여 로그인페이지로 연결되도록 변경

## 스크린샷

https://user-images.githubusercontent.com/41153398/204137187-54bc5eee-c646-43c1-b6be-0782ac447295.mov

