### PR TITLE
[Feat] 다운로드한 단축어 셀 업데이트 아이콘 표시

### DIFF
--- a/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
+++ b/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		F94B43632907B19A00987819 /* FirebaseFirestoreCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = F94B43622907B19A00987819 /* FirebaseFirestoreCombine-Community */; };
 		F9724BBF292755E400860F8A /* Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9724BBE292755E400860F8A /* Comment.swift */; };
 		F99569182901DC4D0060AAEF /* Font+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F99569172901DC4D0060AAEF /* Font+Extension.swift */; };
+		F9AC2BBA2935D34C00165820 /* Image+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9AC2BB92935D34C00165820 /* Image+Extension.swift */; };
 		F9CAEF832914855900224B0A /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9CAEF822914855900224B0A /* Date+Extension.swift */; };
 		F9CAEF8429148CDD00224B0A /* ReadAdminCurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E99CA428FFF238009B691F /* ReadAdminCurationView.swift */; };
 		F9F4D36A2906E0B000DC8546 /* Navigationbar+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F4D3692906E0B000DC8546 /* Navigationbar+Extension.swift */; };
@@ -202,6 +203,7 @@
 		F94B432D2907088400987819 /* UserCurationListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserCurationListView.swift; sourceTree = "<group>"; };
 		F9724BBE292755E400860F8A /* Comment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comment.swift; sourceTree = "<group>"; };
 		F99569172901DC4D0060AAEF /* Font+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+Extension.swift"; sourceTree = "<group>"; };
+		F9AC2BB92935D34C00165820 /* Image+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image+Extension.swift"; sourceTree = "<group>"; };
 		F9CAEF822914855900224B0A /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
 		F9F4D3692906E0B000DC8546 /* Navigationbar+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Navigationbar+Extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -406,6 +408,7 @@
 				A0DD085629276608008177BB /* URL+Extension.swift */,
 				8795A16D292AB841004B765F /* View+Extension.swift */,
 				8795A16F292AB945004B765F /* UIScreen+Extension.swift */,
+				F9AC2BB92935D34C00165820 /* Image+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -640,6 +643,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F9AC2BBA2935D34C00165820 /* Image+Extension.swift in Sources */,
 				F90DEA4F29327E4D002140E2 /* NavigationStackModel.swift in Sources */,
 				F9CAEF8429148CDD00224B0A /* ReadAdminCurationView.swift in Sources */,
 				F9131B6B2922D38D00868A0E /* Keyword.swift in Sources */,

--- a/HappyAnding/HappyAnding/Extensions/Image+Extension.swift
+++ b/HappyAnding/HappyAnding/Extensions/Image+Extension.swift
@@ -1,0 +1,17 @@
+//
+//  Image+Extension.swift
+//  HappyAnding
+//
+//  Created by 전지민 on 2022/11/29.
+//
+
+import SwiftUI
+
+extension Image {
+    func setCellIcon() -> some View {
+        self
+            .foregroundColor(.Gray4)
+            .font(.system(size: 24, weight: .medium))
+            .frame(height: 32)
+    }
+}

--- a/HappyAnding/HappyAnding/Views/Components/ListShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ListShortcutView.swift
@@ -61,7 +61,8 @@ struct ListShortcutView: View {
                                     .listRowSeparator(.hidden)
                                 } else {
                                     ShortcutCell(shortcut: shortcut,
-                                                 navigationParentView: data.navigationParentView)
+                                                 navigationParentView: data.navigationParentView,
+                                                 sectionType: data.sectionType)
                                     .listRowInsets(EdgeInsets())
                                     .listRowSeparator(.hidden)
                                 }

--- a/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
@@ -45,6 +45,7 @@ struct ShortcutCell: View {
     var shortcut: Shortcuts?
     var rankNumber: Int = -1
     let navigationParentView: NavigationParentView
+    var sectionType: SectionType?
     
     var body: some View {
         
@@ -125,10 +126,25 @@ struct ShortcutCell: View {
     var downloadInfo: some View {
         
         VStack(alignment: .center, spacing: 0) {
-            Image(systemName: "arrow.down.app.fill")
-                .foregroundColor(.Gray4)
-                .font(.system(size: 24, weight: .medium))
-                .frame(height: 32)
+            if sectionType == SectionType.myDownloadShortcut {
+                if ((shortcutsZipViewModel.userInfo?.downloadedShortcuts.firstIndex(where: {$0.downloadLink == shortcut?.downloadLink[0]})) == nil) {
+                    Image(systemName: "clock.arrow.circlepath")
+                        .foregroundColor(.Gray4)
+                        .font(.system(size: 24, weight: .medium))
+                        .frame(height: 32)
+                }
+                else {
+                    Image(systemName: "arrow.down.app.fill")
+                        .foregroundColor(.Gray4)
+                        .font(.system(size: 24, weight: .medium))
+                        .frame(height: 32)
+                }
+            } else {
+                Image(systemName: "arrow.down.app.fill")
+                    .foregroundColor(.Gray4)
+                    .font(.system(size: 24, weight: .medium))
+                    .frame(height: 32)
+            }
         }
         .padding(.leading, 12)
         .padding(.trailing, 18)

--- a/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
@@ -127,17 +127,19 @@ struct ShortcutCell: View {
         
         VStack(alignment: .center, spacing: 0) {
             if sectionType == SectionType.myDownloadShortcut {
-                if ((shortcutsZipViewModel.userInfo?.downloadedShortcuts.firstIndex(where: {$0.downloadLink == shortcut?.downloadLink[0]})) == nil) {
-                    Image(systemName: "clock.arrow.circlepath")
-                        .foregroundColor(.Gray4)
-                        .font(.system(size: 24, weight: .medium))
-                        .frame(height: 32)
-                }
-                else {
-                    Image(systemName: "arrow.down.app.fill")
-                        .foregroundColor(.Gray4)
-                        .font(.system(size: 24, weight: .medium))
-                        .frame(height: 32)
+                if let index = shortcutsZipViewModel.userInfo?.downloadedShortcuts.firstIndex(where: { $0.id == shortcut?.id}) {
+                    if shortcutsZipViewModel.userInfo?.downloadedShortcuts[index].downloadLink != shortcut?.downloadLink[0] {
+                        Image(systemName: "clock.arrow.circlepath")
+                            .foregroundColor(.Gray4)
+                            .font(.system(size: 24, weight: .medium))
+                            .frame(height: 32)
+                    }
+                    else {
+                        Image(systemName: "arrow.down.app.fill")
+                            .foregroundColor(.Gray4)
+                            .font(.system(size: 24, weight: .medium))
+                            .frame(height: 32)
+                    }
                 }
             } else {
                 Image(systemName: "arrow.down.app.fill")

--- a/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
@@ -130,22 +130,16 @@ struct ShortcutCell: View {
                 if let index = shortcutsZipViewModel.userInfo?.downloadedShortcuts.firstIndex(where: { $0.id == shortcut?.id}) {
                     if shortcutsZipViewModel.userInfo?.downloadedShortcuts[index].downloadLink != shortcut?.downloadLink[0] {
                         Image(systemName: "clock.arrow.circlepath")
-                            .foregroundColor(.Gray4)
-                            .font(.system(size: 24, weight: .medium))
-                            .frame(height: 32)
+                            .setCellIcon()
                     }
                     else {
                         Image(systemName: "arrow.down.app.fill")
-                            .foregroundColor(.Gray4)
-                            .font(.system(size: 24, weight: .medium))
-                            .frame(height: 32)
+                            .setCellIcon()
                     }
                 }
             } else {
                 Image(systemName: "arrow.down.app.fill")
-                    .foregroundColor(.Gray4)
-                    .font(.system(size: 24, weight: .medium))
-                    .frame(height: 32)
+                    .setCellIcon()
             }
         }
         .padding(.leading, 12)


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #327 

## 구현/변경 사항
- ListShortcutView에서 ShortcutCell로 sectionType을 전달하도록 함
- ShortcutCell의 downloadInfo에서 sectionType이 myDownloadShortcut인 경우 유저 정보에 등록된 다운로드 링크와 단축어의 최신 링크를 비교하여 다를 경우 업데이트를 나타내는 아이콘을 띄우로도록 함

## 스크린샷
<img src = "https://user-images.githubusercontent.com/41153398/204142597-71be2f3a-173c-4f2f-926d-bfc0b0043679.png" width=300>

https://user-images.githubusercontent.com/41153398/204142625-f55d00df-785b-4519-b70f-4ec0c07e62bd.mp4


