### PR TITLE
[Fix] 큐레이션 단축어 셀 리스트 업데이트 에러

### DIFF
--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
@@ -45,16 +45,16 @@ struct ReadUserCurationView: View {
                 }
             }
             VStack(spacing: 0){
-                ForEach(Array(self.data.userCuration.shortcuts.enumerated()), id: \.offset) { index, shortcut in
+                ForEach(self.data.userCuration.shortcuts, id: \.self) { shortcut in
                     let data = NavigationReadShortcutType(shortcutID: shortcut.id,
                                                           navigationParentView: self.data.navigationParentView)
                     
                     NavigationLink(value: data) {
                         ShortcutCell(shortcutCell: shortcut,
                                      navigationParentView: self.data.navigationParentView)
-                        .padding(.bottom, index == self.data.userCuration.shortcuts.count - 1 ? 44 : 0)
                     }
                 }
+                Spacer().frame(height: 44)
             }
             
         }

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
@@ -54,8 +54,8 @@ struct ReadUserCurationView: View {
                                      navigationParentView: self.data.navigationParentView)
                     }
                 }
-                Spacer().frame(height: 44)
             }
+            .padding(.bottom, 44)
             
         }
         .onChange(of: isWriting) { _ in


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #315 

## 구현/변경 사항
- 큐레이션 편집에서 단축어 선택 해제 시 ReadCurationView에 정보가 다르게 업데이트 되는 현상 해결
- 기존 array.enumerated()를 이용하여 ForEach 문을 사용하였던 부분을 array로 변경하여 ForEach을 사용
- 기존에 enumerated를 사용한 이유는 마지막 인덱스일 때 padding을 다르게 넣기 위함이었는데 이를 ForEach문이 끝난 후에 넣어주는 것으로 해결

## 스크린샷

https://user-images.githubusercontent.com/41153398/204151895-32d4ced2-7b91-4398-91e3-773c44b07a45.mp4
