### PR TITLE
[Fix] 영어 검색 안되는 이슈 해결

### DIFF
--- a/HappyAnding/HappyAnding/Views/SearchView.swift
+++ b/HappyAnding/HappyAnding/Views/SearchView.swift
@@ -120,9 +120,9 @@ struct SearchView: View {
         shortcutResults.removeAll()
         
         for data in shortcutsZipViewModel.allShortcuts {
-            if data.title.contains(searchText.lowercased()) ||
-                data.requiredApp.contains(searchText.lowercased()) ||
-                data.subtitle.contains(searchText.lowercased())
+            if data.title.lowercased().contains(searchText.lowercased()) ||
+                !data.requiredApp.filter({ $0.lowercased().contains(searchText.lowercased()) }).isEmpty ||
+                data.subtitle.lowercased().contains(searchText.lowercased())
             {
                 shortcutResults.insert(data)
             }


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #330

## 구현/변경 사항
- 검색하는 단어만 소문자로 처리되어 발생한 이슈였습니다!
- 저장되어있는 데이터도 소문자로 변경하여 해당 이슈 해결했습니다.

## 스크린샷

https://user-images.githubusercontent.com/68676844/204160864-528911b7-8125-4b27-8918-e54315464707.mov



