### PR TITLE
[Fix] 단축어 read view 뷰 밀리는 문제 해결

### DIFF
--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -63,7 +63,7 @@ struct ReadShortcutView: View {
                         // MARK: - 단축어 타이틀
                         
                         ReadShortcutHeaderView(shortcut: $data.shortcut.unwrap()!, isMyLike: $isMyLike)
-                            .frame(height: 160)
+                            .frame(minHeight: 160)
                             .padding(.bottom, 33)
                             .background(Color.White)
                         

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -431,22 +431,6 @@ extension ReadShortcutView {
                         } else {
                             if currentTab > 0 {
                                 currentTab -= 1
-                            } else {
-                                
-                                // MARK: Navigation pop 코드
-//                                    print("swipe back")
-//                                    switch data.navigationParentView {
-//                                    case .shortcuts:
-//                                        shortcutNavigation.shortcutPath.removeLast()
-//                                    case .curations:
-//                                        curationNavigation.navigationPath.removeLast()
-//                                    case .myPage:
-//                                        profileNavigation.navigationPath.removeLast()
-//                                    case .writeCuration:
-//                                        writeCurationNavigation.navigationPath.removeLast()
-//                                    case .writeShortcut:
-//                                        writeShortcutNavigation.navigationPath.removeLast()
-//                                    }
                             }
                         }
                     }


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #333

## 구현/변경 사항
- 제목이 길어졌을 때, 뷰가 잘리는 이슈 해결
  - Frame이지정되어있어서 발생한 문제입니다.
  - minHeight으로 바꿔서 해결했습니다
  
## 스크린샷
|iPhone SE|iPhone 14|iPhone 14 Pro Max|
|:---:|:---:|:---:|
|<img src = "https://user-images.githubusercontent.com/68676844/204277338-7d888bc4-da6d-4472-bed4-360b178430b7.png" width = 250>|<img src = "https://user-images.githubusercontent.com/68676844/204277305-69d5d3c7-ef70-4ce3-9fd3-1d68068bd059.png" width = 250>|<img src = "https://user-images.githubusercontent.com/68676844/204277629-7585e4f9-fd06-447f-a682-48093dd4d9b3.png" width = 250>|
