### PR TITLE
[Feat] 다른 사용자 프로필 화면 구현

### DIFF
--- a/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
+++ b/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		4D3DBB88292E67E600DE8160 /* EditNicknameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D3DBB87292E67E500DE8160 /* EditNicknameView.swift */; };
+		4D3DBB962934E31A00DE8160 /* ShowProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D3DBB952934E31A00DE8160 /* ShowProfileView.swift */; };
 		4D61A767291E1EE8000EF531 /* NavigationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D61A766291E1EE8000EF531 /* NavigationViewModel.swift */; };
 		4D778A34290A53BA00C15AC4 /* Application+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D778A33290A53BA00C15AC4 /* Application+Extension.swift */; };
 		4DAD635E292AB61700ABF8C1 /* UpdateShortcutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DAD635D292AB61700ABF8C1 /* UpdateShortcutView.swift */; };
@@ -120,6 +121,7 @@
 		3D41EE06290A458B008BE986 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		3D41EE07290A4C18008BE986 /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
 		4D3DBB87292E67E500DE8160 /* EditNicknameView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditNicknameView.swift; sourceTree = "<group>"; };
+		4D3DBB952934E31A00DE8160 /* ShowProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowProfileView.swift; sourceTree = "<group>"; };
 		4D61A766291E1EE8000EF531 /* NavigationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationViewModel.swift; sourceTree = "<group>"; };
 		4D778A33290A53BA00C15AC4 /* Application+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Application+Extension.swift"; sourceTree = "<group>"; };
 		4DAD635D292AB61700ABF8C1 /* UpdateShortcutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateShortcutView.swift; sourceTree = "<group>"; };
@@ -359,6 +361,7 @@
 				A04ACB3029068688004A85A6 /* ReadShortcutView */,
 				87E99CAE28FFF26A009B691F /* EditShortcutView.swift */,
 				4DAD635D292AB61700ABF8C1 /* UpdateShortcutView.swift */,
+				4D3DBB952934E31A00DE8160 /* ShowProfileView.swift */,
 			);
 			path = ShortcutDetailViews;
 			sourceTree = "<group>";
@@ -658,6 +661,7 @@
 				A0F822AC2910B8F100AF4448 /* ShortcutsZipViewModel.swift in Sources */,
 				87276C382933F6AB00C92F4C /* CustomTextEditor.swift in Sources */,
 				87E99CC429014572009B691F /* Color+Extension.swift in Sources */,
+				4D3DBB962934E31A00DE8160 /* ShowProfileView.swift in Sources */,
 				A0DD085729276608008177BB /* URL+Extension.swift in Sources */,
 				87E99CD929042536009B691F /* SectionType.swift in Sources */,
 				872A7D8F2918393B004A05B8 /* PrivacyPolicyView.swift in Sources */,

--- a/HappyAnding/HappyAnding/Model/NavigationStackModel.swift
+++ b/HappyAnding/HappyAnding/Model/NavigationStackModel.swift
@@ -44,6 +44,10 @@ enum NavigationSearch: Hashable, Equatable {
     case first
 }
 
+enum NavigationProfile: Hashable, Equatable {
+    case first
+}
+
 enum NavigationParentView: Int {
     case shortcuts
     case curations

--- a/HappyAnding/HappyAnding/Model/NavigationStackModel.swift
+++ b/HappyAnding/HappyAnding/Model/NavigationStackModel.swift
@@ -40,11 +40,13 @@ struct NavigationListCurationType: Identifiable, Hashable {
     var curation: [Curation]
 }
 
-enum NavigationSearch: Hashable, Equatable {
-    case first
+struct NavigationProfile: Identifiable, Hashable {
+    var id = UUID().uuidString
+    
+    var userInfo: User?
 }
 
-enum NavigationProfile: Hashable, Equatable {
+enum NavigationSearch: Hashable, Equatable {
     case first
 }
 

--- a/HappyAnding/HappyAnding/Model/User.swift
+++ b/HappyAnding/HappyAnding/Model/User.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct User: Identifiable, Codable {
+struct User: Identifiable, Codable, Hashable {
     var id: String
     var nickname: String
     var likedShortcuts: [String]
@@ -19,7 +19,7 @@ struct User: Identifiable, Codable {
     }
 }
 
-struct DownloadedShortcut: Identifiable, Codable {
+struct DownloadedShortcut: Identifiable, Codable, Hashable {
     var id: String
     var downloadLink: String
 }

--- a/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
@@ -50,9 +50,6 @@ struct ShortcutCell: View {
     var body: some View {
         
         ZStack {
-            
-            Color.Background
-            
             HStack {
                 icon
                 shortcutInfo

--- a/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
@@ -71,7 +71,7 @@ struct ShortcutCell: View {
             .background( background )
             .padding(.horizontal, 20)
         }
-        .padding(.top, 12)
+        .padding(.bottom, 12)
         .background(Color.Background)
         .onAppear() {
             if let shortcut  {

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
@@ -44,6 +44,7 @@ struct ReadUserCurationView: View {
                     .padding(.bottom, 12)
                 }
             }
+            
             VStack(spacing: 0){
                 ForEach(self.data.userCuration.shortcuts, id: \.self) { shortcut in
                     let data = NavigationReadShortcutType(shortcutID: shortcut.id,
@@ -79,13 +80,30 @@ struct ReadUserCurationView: View {
             .environmentObject(writeCurationNavigation)
         }
         .fullScreenCover(isPresented: $isWriting) {
-                    NavigationStack(path: $writeCurationNavigation.navigationPath) {
-                        WriteCurationSetView(isWriting: $isWriting,
-                                             curation: self.data.userCuration,
-                                             isEdit: true)
-                    }
-                    .environmentObject(writeCurationNavigation)
-                }
+            NavigationStack(path: $writeCurationNavigation.navigationPath) {
+                WriteCurationSetView(isWriting: $isWriting,
+                                     curation: self.data.userCuration,
+                                     isEdit: true)
+            }
+            .environmentObject(writeCurationNavigation)
+        }
+        .alert("글 삭제", isPresented: $isTappedDeleteButton) {
+            Button(role: .cancel) {
+                self.isTappedDeleteButton.toggle()
+            } label: {
+                Text("닫기")
+            }
+            
+            Button(role: .destructive) {
+                shortcutsZipViewModel.deleteData(model: self.data.userCuration)
+                shortcutsZipViewModel.curationsMadeByUser = shortcutsZipViewModel.curationsMadeByUser.filter { $0.id != self.data.userCuration.id }
+                presentation.wrappedValue.dismiss()
+            } label: {
+                Text("삭제")
+            }
+        } message: {
+            Text("글을 삭제하시겠습니까?")
+        }
     }
     
     var userInformation: some View {
@@ -110,23 +128,7 @@ struct ReadUserCurationView: View {
                     .frame(height: 48)
                     .foregroundColor(.Gray1)
                     .padding(.horizontal, 16)
-            ).alert(isPresented: $isTappedDeleteButton) {
-                Alert(title: Text("글 삭제")
-                    .foregroundColor(.Gray5),
-                      message: Text("글을 삭제하시겠습니까?")
-                    .foregroundColor(.Gray5),
-                      primaryButton: .default(Text("닫기"),
-                      action: {
-                    self.isTappedDeleteButton.toggle()
-                }),
-                      secondaryButton: .destructive(
-                        Text("삭제")
-                        , action: {
-                            shortcutsZipViewModel.deleteData(model: self.data.userCuration)
-                            shortcutsZipViewModel.curationsMadeByUser = shortcutsZipViewModel.curationsMadeByUser.filter { $0.id != self.data.userCuration.id }
-                            presentation.wrappedValue.dismiss()
-                }))
-            }
+            )
         }
         .onAppear {
             shortcutsZipViewModel.fetchUser(userID: self.data.userCuration.author) { user in

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
@@ -90,17 +90,19 @@ struct ReadUserCurationView: View {
     
     var userInformation: some View {
         ZStack {
-            HStack {
-                Image(systemName: "person.fill")
-                    .frame(width: 28, height: 28)
-                    .foregroundColor(.White)
-                    .background(Color.Gray3)
-                    .clipShape(Circle())
-                
-                Text(authorInformation?.nickname ?? "닉네임")
-                    .Headline()
-                    .foregroundColor(.Gray4)
-                Spacer()
+            NavigationLink(value: NavigationProfile.first) {
+                HStack {
+                    Image(systemName: "person.fill")
+                        .frame(width: 28, height: 28)
+                        .foregroundColor(.White)
+                        .background(Color.Gray3)
+                        .clipShape(Circle())
+                    
+                    Text(authorInformation?.nickname ?? "닉네임")
+                        .Headline()
+                        .foregroundColor(.Gray4)
+                    Spacer()
+                }
             }
             .padding(.horizontal, 30)
             .background(
@@ -178,8 +180,6 @@ extension ReadUserCurationView {
     private var deleteButton: some View {
         Button(role: .destructive, action: {
             isTappedDeleteButton.toggle()
-            // TODO: firebase delete function
-            
         }) {
             Label("삭제", systemImage: "trash.fill")
         }

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
@@ -117,12 +117,13 @@ struct ReadUserCurationView: View {
                             .background(Color.Gray3)
                             .clipShape(Circle())
                         
-                        Text(authorInformation?.nickname ?? "닉네임")
+                        Text(authorInformation?.nickname ?? "탈퇴한 사용자")
                             .Headline()
                             .foregroundColor(.Gray4)
                         Spacer()
                     }
                 }
+                .disabled(authorInformation == nil)
                 .padding(.horizontal, 30)
                 .background(
                     RoundedRectangle(cornerRadius: 12)

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
@@ -108,27 +108,29 @@ struct ReadUserCurationView: View {
     
     var userInformation: some View {
         ZStack {
-            NavigationLink(value: NavigationProfile.first) {
-                HStack {
-                    Image(systemName: "person.fill")
-                        .frame(width: 28, height: 28)
-                        .foregroundColor(.White)
-                        .background(Color.Gray3)
-                        .clipShape(Circle())
-                    
-                    Text(authorInformation?.nickname ?? "닉네임")
-                        .Headline()
-                        .foregroundColor(.Gray4)
-                    Spacer()
+            if let data = NavigationProfile(userInfo: self.authorInformation) {
+                NavigationLink(value: data) {
+                    HStack {
+                        Image(systemName: "person.fill")
+                            .frame(width: 28, height: 28)
+                            .foregroundColor(.White)
+                            .background(Color.Gray3)
+                            .clipShape(Circle())
+                        
+                        Text(authorInformation?.nickname ?? "닉네임")
+                            .Headline()
+                            .foregroundColor(.Gray4)
+                        Spacer()
+                    }
                 }
+                .padding(.horizontal, 30)
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .frame(height: 48)
+                        .foregroundColor(.Gray1)
+                        .padding(.horizontal, 16)
+                )
             }
-            .padding(.horizontal, 30)
-            .background(
-                RoundedRectangle(cornerRadius: 12)
-                    .frame(height: 48)
-                    .foregroundColor(.Gray1)
-                    .padding(.horizontal, 16)
-            )
         }
         .onAppear {
             shortcutsZipViewModel.fetchUser(userID: self.data.userCuration.author) { user in

--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView/CategoryCardView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView/CategoryCardView.swift
@@ -56,9 +56,3 @@ struct CategoryCardView: View {
         }
     }
 }
-
-//struct CategoryCardView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        CategoryCardView()
-//    }
-//}

--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView/CategoryView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView/CategoryView.swift
@@ -41,6 +41,7 @@ struct CategoryView: View {
                 })
             }
             .padding(.leading, 16)
+            
             LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())]) {
                 ForEach(Array(Category.allCases.enumerated()), id: \.offset) { index, value in
                     if index < categoryIndex {
@@ -72,9 +73,3 @@ struct CategoryCellView: View {
             }
     }
 }
-
-//struct CategoryView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        CategoryView()
-//    }
-//}

--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView/DownloadRankView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView/DownloadRankView.swift
@@ -25,8 +25,8 @@ struct DownloadRankView: View {
                 Spacer()
                 
                 NavigationLink(value: NavigationListShortcutType(sectionType: .download,
-                                                          shortcuts: shortcuts,
-                                                          navigationParentView: .shortcuts)) {
+                                                                 shortcuts: shortcuts,
+                                                                 navigationParentView: .shortcuts)) {
                     Text("더보기")
                         .Footnote()
                         .foregroundColor(Color.Gray4)
@@ -34,6 +34,7 @@ struct DownloadRankView: View {
                 }
             }
             .padding(.leading, 16)
+            .padding(.bottom, 12)
             
             ForEach(Array(shortcuts.enumerated()), id:\.offset) { index, shortcut in
                 if index < 3 {

--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView/LovedShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView/LovedShortcutView.swift
@@ -31,6 +31,7 @@ struct LovedShortcutView: View {
                 }
             }
             .padding(.leading, 16)
+            .padding(.bottom, 12)
             
             if let shortcuts {
                 ForEach(Array(shortcuts.enumerated()), id:\.offset) { index, shortcut in

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutHeaderView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutHeaderView.swift
@@ -92,7 +92,7 @@ struct ReadShortcutHeaderView: View {
                             .foregroundColor(.Gray4)
                             .padding(.leading, 16)
                         
-                        Text(userInformation?.nickname ?? "닉네임")
+                        Text(userInformation?.nickname ?? "탈퇴한 사용자")
                             .Body2()
                             .foregroundColor(.Gray4)
                         
@@ -114,6 +114,7 @@ struct ReadShortcutHeaderView: View {
                         
                     }
                 }
+                .disabled(userInformation == nil)
                 .padding(.vertical, 10)
                 .frame(maxWidth: .infinity, maxHeight: 44)
                 .overlay {

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutHeaderView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutHeaderView.swift
@@ -83,33 +83,35 @@ struct ReadShortcutHeaderView: View {
     
     // MARK: - 유저 정보
     var userInfo: some View {
-        HStack(spacing: 8) {
-            
-            Circle()
-                .frame(width: 24, height: 24)
-                .foregroundColor(.Gray4)
-                .padding(.leading, 16)
-            
-            Text(userInformation?.nickname ?? "닉네임")
-                .Body2()
-                .foregroundColor(.Gray4)
-            
-            Spacer()
-                .frame(maxWidth: .infinity)
-            
-            
-            // TODO: 신고기능
-            
-            /*
-            Image(systemName: "light.beacon.max.fill")
-                .Headline()
-                .foregroundColor(.Gray5)
-                .padding(.trailing, 16)
-                .onTapGesture {
-                    print("Tapped!")
-                }
-             */
-            
+        NavigationLink(value: NavigationProfile.first) {
+            HStack(spacing: 8) {
+                
+                Circle()
+                    .frame(width: 24, height: 24)
+                    .foregroundColor(.Gray4)
+                    .padding(.leading, 16)
+                
+                Text(userInformation?.nickname ?? "닉네임")
+                    .Body2()
+                    .foregroundColor(.Gray4)
+                
+                Spacer()
+                    .frame(maxWidth: .infinity)
+                
+                
+                // TODO: 신고기능
+                
+                /*
+                Image(systemName: "light.beacon.max.fill")
+                    .Headline()
+                    .foregroundColor(.Gray5)
+                    .padding(.trailing, 16)
+                    .onTapGesture {
+                        print("Tapped!")
+                    }
+                */
+                
+            }
         }
         .padding(.vertical, 10)
         .frame(maxWidth: .infinity, maxHeight: 44)

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutHeaderView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutHeaderView.swift
@@ -24,7 +24,7 @@ struct ReadShortcutHeaderView: View {
                 Spacer()
                 
                 likeButton
-
+                
             }
             VStack(alignment: .leading, spacing: 4) {
                 Text("\(shortcut.title)")
@@ -64,60 +64,63 @@ struct ReadShortcutHeaderView: View {
     // MARK: 좋아요 버튼
     var likeButton: some View {
         Text("\(isMyLike ? Image(systemName: "heart.fill") : Image(systemName: "heart")) \(shortcut.numberOfLike)")
-
-        .Body2()
-        .padding(10)
-        .foregroundColor(isMyLike ? Color.Text_icon : Color.Gray4)
-        .background(isMyLike ? Color.Primary : Color.Gray1)
-        .cornerRadius(12)
-        .onTapGesture(perform: {
-            isMyLike.toggle()
-            //화면 상의 좋아요 추가, 취소 기능 동작
-            if isMyLike {
-                self.shortcut.numberOfLike += 1
-            } else {
-                self.shortcut.numberOfLike -= 1
-            }
-        })
+            .Body2()
+            .padding(10)
+            .foregroundColor(isMyLike ? Color.Text_icon : Color.Gray4)
+            .background(isMyLike ? Color.Primary : Color.Gray1)
+            .cornerRadius(12)
+            .onTapGesture(perform: {
+                isMyLike.toggle()
+                //화면 상의 좋아요 추가, 취소 기능 동작
+                if isMyLike {
+                    self.shortcut.numberOfLike += 1
+                } else {
+                    self.shortcut.numberOfLike -= 1
+                }
+            })
     }
     
     // MARK: - 유저 정보
     var userInfo: some View {
-        NavigationLink(value: NavigationProfile.first) {
-            HStack(spacing: 8) {
-                
-                Circle()
-                    .frame(width: 24, height: 24)
-                    .foregroundColor(.Gray4)
-                    .padding(.leading, 16)
-                
-                Text(userInformation?.nickname ?? "닉네임")
-                    .Body2()
-                    .foregroundColor(.Gray4)
-                
-                Spacer()
-                    .frame(maxWidth: .infinity)
-                
-                
-                // TODO: 신고기능
-                
-                /*
-                Image(systemName: "light.beacon.max.fill")
-                    .Headline()
-                    .foregroundColor(.Gray5)
-                    .padding(.trailing, 16)
-                    .onTapGesture {
-                        print("Tapped!")
+        ZStack {
+            if let data = NavigationProfile(userInfo: self.userInformation) {
+                NavigationLink(value: data) {
+                    HStack(spacing: 8) {
+                        
+                        Circle()
+                            .frame(width: 24, height: 24)
+                            .foregroundColor(.Gray4)
+                            .padding(.leading, 16)
+                        
+                        Text(userInformation?.nickname ?? "닉네임")
+                            .Body2()
+                            .foregroundColor(.Gray4)
+                        
+                        Spacer()
+                            .frame(maxWidth: .infinity)
+                        
+                        
+                        // TODO: 신고기능
+                        
+                        /*
+                         Image(systemName: "light.beacon.max.fill")
+                         .Headline()
+                         .foregroundColor(.Gray5)
+                         .padding(.trailing, 16)
+                         .onTapGesture {
+                         print("Tapped!")
+                         }
+                         */
+                        
                     }
-                */
-                
+                }
+                .padding(.vertical, 10)
+                .frame(maxWidth: .infinity, maxHeight: 44)
+                .overlay {
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(Color.Gray1, lineWidth: 1)
+                }
             }
-        }
-        .padding(.vertical, 10)
-        .frame(maxWidth: .infinity, maxHeight: 44)
-        .overlay {
-            RoundedRectangle(cornerRadius: 12)
-                .stroke(Color.Gray1, lineWidth: 1)
         }
     }
 }

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ShowProfileView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ShowProfileView.swift
@@ -17,7 +17,6 @@ struct ShowProfileView: View {
     @State var curations: [Curation] = []
     @Namespace var namespace
     @State var currentTab: Int = 0
-    @State var height: CGFloat = 0
     private let tabItems = ["작성한 단축어", "작성한 큐레이션"]
     
     var body: some View {
@@ -112,12 +111,12 @@ extension ShowProfileView {
                     Color.clear.tag(1)
                 }
                 .tabViewStyle(.page(indexDisplayMode: .never))
-                .frame(height: height)
                 
                 switch(currentTab) {
                 case 0:
                     if shortcuts.isEmpty {
                         Text("작성한 단축어가 없습니다.")
+                            .padding(.top, 24)
                             .Body2()
                             .foregroundColor(.Gray4)
                     } else {
@@ -133,20 +132,13 @@ extension ShowProfileView {
                             
                             Spacer()
                         }
-                        .background(
-                            GeometryReader { geometryProxy in
-                                Color.clear
-                                    .preference(key: SizePreferenceKey.self,
-                                                value: geometryProxy.size)
-                            }
-                        )
                     }
                 case 1:
                     if curations.isEmpty {
                         
                         // TODO: 큐레이션에 대한 워딩 변경
-                        
                         Text("작성한 큐레이션이 없습니다.")
+                            .padding(.top, 24)
                             .Body2()
                             .foregroundColor(.Gray4)
                     }
@@ -162,21 +154,11 @@ extension ShowProfileView {
                         
                         Spacer()
                     }
-                    .background(
-                        GeometryReader { geometryProxy in
-                            Color.clear
-                                .preference(key: SizePreferenceKey.self,
-                                            value: geometryProxy.size)
-                        }
-                    )
                 default:
                     EmptyView()
                 }
             }
             .animation(.easeInOut, value: currentTab)
-            .onPreferenceChange(SizePreferenceKey.self) { newSize in
-                self.height = newSize.height
-            }
             .gesture(
                 DragGesture(minimumDistance: 20, coordinateSpace: .global)
                     .onEnded { value in

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ShowProfileView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ShowProfileView.swift
@@ -17,7 +17,7 @@ struct ShowProfileView: View {
     @State var curations: [Curation] = []
     @Namespace var namespace
     @State var currentTab: Int = 0
-    private let tabItems = ["작성한 단축어", "작성한 큐레이션"]
+    private let tabItems = ["작성한 단축어", "작성한 추천 모음집"]
     
     var body: some View {
         ScrollView {
@@ -140,10 +140,8 @@ extension ShowProfileView {
                     }
                 case 1:
                     if curations.isEmpty {
-                        
-                        // TODO: 큐레이션에 대한 워딩 변경
                         VStack{
-                            Text("작성한 큐레이션이 없습니다.")
+                            Text("작성한 추천 모음집이 없습니다.")
                                 .padding(.top, 16)
                                 .Body2()
                                 .foregroundColor(.Gray4)

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ShowProfileView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ShowProfileView.swift
@@ -31,8 +31,8 @@ struct ShowProfileView: View {
                         .offset(y: yOffset > 0 ? -yOffset : 0)
                 }
                 
+                //MARK: 프로필이미지 및 닉네임
                 VStack {
-                    // 프로필 이미지
                     Circle()
                         .fill(Color.Gray4)
                         .frame(width: 72, height: 72)
@@ -44,6 +44,7 @@ struct ShowProfileView: View {
                 .frame(height: 160)
                 .background(Color.White)
                 
+                //MARK: 탭바 및 탭 내부 컨텐츠
                 LazyVStack(pinnedViews: [.sectionHeaders]) {
                     Section(header: tabBarView) {
                         profileContentView
@@ -63,6 +64,8 @@ struct ShowProfileView: View {
 }
 
 extension ShowProfileView {
+    
+    //MARK: 탭바
     var tabBarView: some View {
         HStack(spacing: 20) {
             ForEach(Array(zip(self.tabItems.indices, self.tabItems)), id: \.0) { index, name in
@@ -100,6 +103,7 @@ extension ShowProfileView {
         .buttonStyle(.plain)
     }
     
+    //MARK: 탭 내부 컨텐츠
     var profileContentView: some View {
         VStack {
             ZStack {
@@ -112,26 +116,40 @@ extension ShowProfileView {
                 
                 switch(currentTab) {
                 case 0:
-                    VStack(spacing: 0) {
-                        ForEach(Array(shortcuts.enumerated()), id:\.offset) { index, shortcut in
-                            let data = NavigationReadShortcutType(shortcutID:shortcut.id,
-                                                                  navigationParentView: .shortcuts)
-                            NavigationLink(value: data) {
-                                ShortcutCell(shortcut: shortcut,
-                                             navigationParentView: data.navigationParentView)
+                    if shortcuts.isEmpty {
+                        Text("작성한 단축어가 없습니다.")
+                            .Body2()
+                            .foregroundColor(.Gray4)
+                    } else {
+                        VStack(spacing: 0) {
+                            ForEach(Array(shortcuts.enumerated()), id:\.offset) { index, shortcut in
+                                let data = NavigationReadShortcutType(shortcutID:shortcut.id,
+                                                                      navigationParentView: .shortcuts)
+                                NavigationLink(value: data) {
+                                    ShortcutCell(shortcut: shortcut,
+                                                 navigationParentView: data.navigationParentView)
+                                }
                             }
+                            
+                            Spacer()
                         }
-                        
-                        Spacer()
+                        .background(
+                            GeometryReader { geometryProxy in
+                                Color.clear
+                                    .preference(key: SizePreferenceKey.self,
+                                                value: geometryProxy.size)
+                            }
+                        )
                     }
-                    .background(
-                        GeometryReader { geometryProxy in
-                            Color.clear
-                                .preference(key: SizePreferenceKey.self,
-                                            value: geometryProxy.size)
-                        }
-                    )
                 case 1:
+                    if curations.isEmpty {
+                        
+                        // TODO: 큐레이션에 대한 워딩 변경
+                        
+                        Text("작성한 큐레이션이 없습니다.")
+                            .Body2()
+                            .foregroundColor(.Gray4)
+                    }
                     VStack(spacing: 0) {
                         ForEach(Array(curations.enumerated()), id: \.offset) { index, curation in
                             let data = NavigationReadUserCurationType(userCuration: curation,

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ShowProfileView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ShowProfileView.swift
@@ -110,40 +110,49 @@ extension ShowProfileView {
                     Color.clear.tag(0)
                     Color.clear.tag(1)
                 }
+                .frame(minHeight: UIScreen.screenHeight / 2)
                 .tabViewStyle(.page(indexDisplayMode: .never))
                 
                 switch(currentTab) {
                 case 0:
                     if shortcuts.isEmpty {
-                        Text("작성한 단축어가 없습니다.")
-                            .padding(.top, 24)
-                            .Body2()
-                            .foregroundColor(.Gray4)
-                    } else {
-                        VStack(spacing: 0) {
-                            ForEach(Array(shortcuts.enumerated()), id:\.offset) { index, shortcut in
-                                let data = NavigationReadShortcutType(shortcutID:shortcut.id,
-                                                                      navigationParentView: .shortcuts)
-                                NavigationLink(value: data) {
-                                    ShortcutCell(shortcut: shortcut,
-                                                 navigationParentView: data.navigationParentView)
-                                }
-                            }
-                            
+                        VStack {
+                            Text("작성한 단축어가 없습니다.")
+                                .padding(.top, 16)
+                                .Body2()
+                                .foregroundColor(.Gray4)
                             Spacer()
                         }
+                    }
+                    
+                    VStack(spacing: 0) {
+                        ForEach(shortcuts, id:\.self) { shortcut in
+                            let data = NavigationReadShortcutType(shortcutID:shortcut.id,
+                                                                  navigationParentView: .shortcuts)
+                            NavigationLink(value: data) {
+                                ShortcutCell(shortcut: shortcut,
+                                             navigationParentView: data.navigationParentView)
+                            }
+                        }
+                        
+                        Spacer()
+                            .frame(maxHeight: .infinity)
                     }
                 case 1:
                     if curations.isEmpty {
                         
                         // TODO: 큐레이션에 대한 워딩 변경
-                        Text("작성한 큐레이션이 없습니다.")
-                            .padding(.top, 24)
-                            .Body2()
-                            .foregroundColor(.Gray4)
+                        VStack{
+                            Text("작성한 큐레이션이 없습니다.")
+                                .padding(.top, 16)
+                                .Body2()
+                                .foregroundColor(.Gray4)
+                            Spacer()
+                        }
                     }
+                    
                     VStack(spacing: 0) {
-                        ForEach(Array(curations.enumerated()), id: \.offset) { index, curation in
+                        ForEach(curations, id: \.self) { curation in
                             let data = NavigationReadUserCurationType(userCuration: curation,
                                                                       navigationParentView: .shortcuts)
                             NavigationLink(value: data) {

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ShowProfileView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ShowProfileView.swift
@@ -1,0 +1,179 @@
+//
+//  ShowProfileView.swift
+//  HappyAnding
+//
+//  Created by kimjimin on 2022/11/28.
+//
+
+import SwiftUI
+
+struct ShowProfileView: View {
+    
+    @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
+    
+    @State var shortcuts: [Shortcuts] = []
+    @State var curations: [Curation] = []
+    @Namespace var namespace
+    @State var currentTab: Int = 0
+    @State var height: CGFloat = UIScreen.screenHeight / 2
+    private let contentSize = UIScreen.screenHeight / 2
+    private let tabItems = ["작성한 단축어", "작성한 큐레이션"]
+    
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                GeometryReader { geo in
+                    let yOffset = geo.frame(in: .global).minY
+                    
+                    Color.White
+                        .frame(width: geo.size.width, height: 40 + (yOffset > 0 ? yOffset : 0))
+                        .offset(y: yOffset > 0 ? -yOffset : 0)
+                }
+                
+                VStack {
+                    // 프로필 이미지
+                    Circle()
+                        .fill(Color.Gray4)
+                        .frame(width: 72, height: 72)
+                    Text("닉네임")
+                        .Title1()
+                        .foregroundColor(.Gray5)
+                }
+                .frame(maxWidth: .infinity)
+                .frame(height: 160)
+                .background(Color.White)
+                
+                LazyVStack(pinnedViews: [.sectionHeaders]) {
+                    Section(header: tabBarView) {
+                        profileContentView
+                            .padding(.top, 12)
+                    }
+                }
+            }
+        }
+        .navigationBarBackground { Color.White }
+        .background(Color.Background)
+        .toolbar(.visible, for: .tabBar)
+        .onAppear {
+            
+            //TODO: - author가 작성한 shortcuts, curations만 불러오기
+            
+            shortcuts = shortcutsZipViewModel.allShortcuts
+            curations = shortcutsZipViewModel.fetchCurationByAuthor(author: "")
+        }
+    }
+}
+
+extension ShowProfileView {
+    var tabBarView: some View {
+        HStack(spacing: 20) {
+            ForEach(Array(zip(self.tabItems.indices, self.tabItems)), id: \.0) { index, name in
+                tabBarItem(string: name, tab: index)
+            }
+        }
+        .padding(.horizontal, 16)
+        .frame(height: 36)
+        .background(Color.White)
+    }
+    
+    private func tabBarItem(string: String, tab: Int) -> some View {
+        Button {
+            self.currentTab = tab
+        } label: {
+            VStack {
+                if self.currentTab == tab {
+                    Text(string)
+                        .Headline()
+                        .foregroundColor(.Gray5)
+                    Color.Gray5
+                        .frame(height: 2)
+                        .matchedGeometryEffect(id: "underline", in: namespace, properties: .frame)
+                    
+                } else {
+                    Text(string)
+                        .Body1()
+                        .foregroundColor(.Gray3)
+                    Color.clear
+                        .frame(height: 2)
+                }
+            }
+            .animation(.spring(), value: currentTab)
+        }
+        .buttonStyle(.plain)
+    }
+    
+    var profileContentView: some View {
+        VStack {
+            ZStack {
+                TabView(selection: self.$currentTab) {
+                    Color.clear.tag(0)
+                    Color.clear.tag(1)
+                }
+                .tabViewStyle(.page(indexDisplayMode: .never))
+                .frame(height: height)
+                
+                switch(currentTab) {
+                case 0:
+                    VStack(spacing: 0) {
+                        ForEach(Array(shortcuts.enumerated()), id:\.offset) { index, shortcut in
+                            let data = NavigationReadShortcutType(shortcutID:shortcut.id,
+                                                                  navigationParentView: .shortcuts)
+                            NavigationLink(value: data) {
+                                ShortcutCell(shortcut: shortcut,
+                                             navigationParentView: data.navigationParentView)
+                            }
+                        }
+                        
+                        Spacer()
+                    }
+                    .background(
+                        GeometryReader { geometryProxy in
+                            Color.clear
+                                .preference(key: SizePreferenceKey.self,
+                                            value: geometryProxy.size)
+                        })
+                case 1:
+                    VStack(spacing: 0) {
+                        ForEach(Array(curations.enumerated()), id: \.offset) { index, curation in
+                            let data = NavigationReadUserCurationType(userCuration: curation,
+                                                                      navigationParentView: .shortcuts)
+                            NavigationLink(value: data) {
+                                UserCurationCell(curation: curation,
+                                                 navigationParentView: data.navigationParentView)
+                            }
+                        }
+                        
+                        Spacer()
+                    }
+                    .background(
+                        GeometryReader { geometryProxy in
+                            Color.clear
+                                .preference(key: SizePreferenceKey.self,
+                                            value: geometryProxy.size)
+                        })
+                default:
+                    EmptyView()
+                }
+            }
+            .animation(.easeInOut, value: currentTab)
+            .onPreferenceChange(SizePreferenceKey.self) { newSize in
+                self.height = contentSize > newSize.height ? contentSize : newSize.height
+            }
+            .gesture(
+                DragGesture(minimumDistance: 20, coordinateSpace: .global)
+                    .onEnded { value in
+                        let horizontalAmount = value.translation.width
+                        let verticalAmount = value.translation.height
+                        
+                        if abs(horizontalAmount) > abs(verticalAmount) {
+                            if horizontalAmount < 0 {
+                                currentTab += 1
+                            } else {
+                                currentTab -= 1
+                            }
+                        }
+                    }
+            )
+        }
+    }
+}

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ShowProfileView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ShowProfileView.swift
@@ -11,12 +11,13 @@ struct ShowProfileView: View {
     
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
     
+    @State var data: NavigationProfile
+    
     @State var shortcuts: [Shortcuts] = []
     @State var curations: [Curation] = []
     @Namespace var namespace
     @State var currentTab: Int = 0
-    @State var height: CGFloat = UIScreen.screenHeight / 2
-    private let contentSize = UIScreen.screenHeight / 2
+    @State var height: CGFloat = 0
     private let tabItems = ["작성한 단축어", "작성한 큐레이션"]
     
     var body: some View {
@@ -35,7 +36,7 @@ struct ShowProfileView: View {
                     Circle()
                         .fill(Color.Gray4)
                         .frame(width: 72, height: 72)
-                    Text("닉네임")
+                    Text(data.userInfo?.nickname ?? "user")
                         .Title1()
                         .foregroundColor(.Gray5)
                 }
@@ -55,11 +56,8 @@ struct ShowProfileView: View {
         .background(Color.Background)
         .toolbar(.visible, for: .tabBar)
         .onAppear {
-            
-            //TODO: - author가 작성한 shortcuts, curations만 불러오기
-            
-            shortcuts = shortcutsZipViewModel.allShortcuts
-            curations = shortcutsZipViewModel.fetchCurationByAuthor(author: "")
+            shortcuts = shortcutsZipViewModel.allShortcuts.filter { $0.author == self.data.userInfo?.id }
+            curations = shortcutsZipViewModel.fetchCurationByAuthor(author: data.userInfo?.id ?? "")
         }
     }
 }
@@ -131,7 +129,8 @@ extension ShowProfileView {
                             Color.clear
                                 .preference(key: SizePreferenceKey.self,
                                             value: geometryProxy.size)
-                        })
+                        }
+                    )
                 case 1:
                     VStack(spacing: 0) {
                         ForEach(Array(curations.enumerated()), id: \.offset) { index, curation in
@@ -150,14 +149,15 @@ extension ShowProfileView {
                             Color.clear
                                 .preference(key: SizePreferenceKey.self,
                                             value: geometryProxy.size)
-                        })
+                        }
+                    )
                 default:
                     EmptyView()
                 }
             }
             .animation(.easeInOut, value: currentTab)
             .onPreferenceChange(SizePreferenceKey.self) { newSize in
-                self.height = contentSize > newSize.height ? contentSize : newSize.height
+                self.height = newSize.height
             }
             .gesture(
                 DragGesture(minimumDistance: 20, coordinateSpace: .global)

--- a/HappyAnding/HappyAnding/Views/TabView/ShortcutTabView.swift
+++ b/HappyAnding/HappyAnding/Views/TabView/ShortcutTabView.swift
@@ -64,6 +64,9 @@ struct ShortcutTabView: View {
                             }
                             self.tappedTwice = false
                         })
+                        .navigationDestination(for: NavigationProfile.self) { _ in
+                            ShowProfileView()
+                        }
                         .navigationDestination(for: NavigationSearch.self) { _ in
                             SearchView()
                         }
@@ -77,6 +80,9 @@ struct ShortcutTabView: View {
                             ShortcutsListView(shortcuts: $shortcutsZipViewModel.shortcutsInCategory[category.index],
                                               categoryName: category,
                                               navigationParentView: .shortcuts)
+                        }
+                        .navigationDestination(for: NavigationReadUserCurationType.self) { data in
+                            ReadUserCurationView(data: data)
                         }
                 }
                 .environmentObject(shortcutNavigation)
@@ -99,6 +105,9 @@ struct ShortcutTabView: View {
                             self.tappedTwice = false
                         })
                         .navigationBarBackground ({ Color.Background })
+                        .navigationDestination(for: NavigationProfile.self) { _ in
+                            ShowProfileView()
+                        }
                         .navigationDestination(for: Curation.self) { data in
                             ReadAdminCurationView(curation: data)
                         }
@@ -133,7 +142,9 @@ struct ShortcutTabView: View {
                             self.tappedTwice = false
                         })
                         .navigationBarBackground ({ Color.Background })
-                    
+                        .navigationDestination(for: NavigationProfile.self) { _ in
+                            ShowProfileView()
+                        }
                         .navigationDestination(for: NavigationListShortcutType.self) { data in
                             ListShortcutView(data: data)
                         }

--- a/HappyAnding/HappyAnding/Views/TabView/ShortcutTabView.swift
+++ b/HappyAnding/HappyAnding/Views/TabView/ShortcutTabView.swift
@@ -64,8 +64,8 @@ struct ShortcutTabView: View {
                             }
                             self.tappedTwice = false
                         })
-                        .navigationDestination(for: NavigationProfile.self) { _ in
-                            ShowProfileView()
+                        .navigationDestination(for: NavigationProfile.self) { data in
+                            ShowProfileView(data: data)
                         }
                         .navigationDestination(for: NavigationSearch.self) { _ in
                             SearchView()
@@ -105,8 +105,8 @@ struct ShortcutTabView: View {
                             self.tappedTwice = false
                         })
                         .navigationBarBackground ({ Color.Background })
-                        .navigationDestination(for: NavigationProfile.self) { _ in
-                            ShowProfileView()
+                        .navigationDestination(for: NavigationProfile.self) { data in
+                            ShowProfileView(data: data)
                         }
                         .navigationDestination(for: Curation.self) { data in
                             ReadAdminCurationView(curation: data)
@@ -142,8 +142,8 @@ struct ShortcutTabView: View {
                             self.tappedTwice = false
                         })
                         .navigationBarBackground ({ Color.Background })
-                        .navigationDestination(for: NavigationProfile.self) { _ in
-                            ShowProfileView()
+                        .navigationDestination(for: NavigationProfile.self) { data in
+                            ShowProfileView(data: data)
                         }
                         .navigationDestination(for: NavigationListShortcutType.self) { data in
                             ListShortcutView(data: data)


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #308 

## 구현/변경 사항
- 단축어 상세 화면, 큐레이션 상세 화면에서 닉네임 클릭시 넘어가는 프로필 화면을 구현했습니다.
- CurationCell은 bottom에 패딩이 있고, ShortcutCell은 top에 패딩이 있어서 bottom padding으로 통일했습니다.
- 큐레이션에 관한 워딩은 수정될 예정입니다.
- 등록한 컨텐츠가 없는 경우 임의의 텍스트를 표시했는데 디자인 및 워딩 수정이 필요하다면 말씀해주세요.
- 사용자 정보가 없는 경우 닉네임이 "닉네임"이라고 표시되었는데 이를 "탈퇴한 사용자"로 변경하고 프로필 화면으로 가지 못하게 했는데 더 좋은 방법이 있다면 알려주세요 !!!

## 스크린샷
|light mode|dark mode|등록한 컨텐츠가 없는 경우|
|:---:|:---:|:---:|
|![Simulator Screen Shot - iPhone 14 - 2022-11-30 at 03 57 57](https://user-images.githubusercontent.com/76623853/204622348-04ef552b-9d67-495b-bf35-93078f3e476f.png)|![Simulator Screen Shot - iPhone 14 - 2022-11-30 at 03 57 52](https://user-images.githubusercontent.com/76623853/204622375-3314f516-8ba0-4fc9-ab0d-12324d177fdf.png)|![Simulator Screen Shot - iPhone 14 - 2022-11-30 at 03 58 03](https://user-images.githubusercontent.com/76623853/204622400-36a88bbd-69fb-424b-8ca7-3536bf9ff0e1.png)|
