### PR TITLE
[Feat] user 정보가 없을 때, 로그인 화면으로 이동시키는 기능 구현

### DIFF
--- a/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
+++ b/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
@@ -86,7 +86,7 @@
 		F90DEA5029327E5D002140E2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 87E99C7128F94EA8009B691F /* Assets.xcassets */; };
 		F90DEA5129327E62002140E2 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3D41EE07290A4C18008BE986 /* Launch Screen.storyboard */; };
 		F9131B6B2922D38D00868A0E /* Keyword.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9131B6A2922D38D00868A0E /* Keyword.swift */; };
-		F9136EB6293612310034AAB2 /* LaunchScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9136EB5293612310034AAB2 /* LaunchScreenView.swift */; };
+		F9136EB6293612310034AAB2 /* ShortcutsZipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9136EB5293612310034AAB2 /* ShortcutsZipView.swift */; };
 		F94B432E2907088400987819 /* UserCurationListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F94B432D2907088400987819 /* UserCurationListView.swift */; };
 		F94B435D2907B19A00987819 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = F94B435C2907B19A00987819 /* FirebaseAnalytics */; };
 		F94B435F2907B19A00987819 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = F94B435E2907B19A00987819 /* FirebaseAuth */; };
@@ -205,7 +205,7 @@
 		A3FF01892918F8EF00384211 /* apache.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = apache.txt; sourceTree = "<group>"; };
 		A3FF018D291ACFA500384211 /* WithdrawalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalView.swift; sourceTree = "<group>"; };
 		F9131B6A2922D38D00868A0E /* Keyword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keyword.swift; sourceTree = "<group>"; };
-		F9136EB5293612310034AAB2 /* LaunchScreenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchScreenView.swift; sourceTree = "<group>"; };
+		F9136EB5293612310034AAB2 /* ShortcutsZipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsZipView.swift; sourceTree = "<group>"; };
 		F94B432D2907088400987819 /* UserCurationListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserCurationListView.swift; sourceTree = "<group>"; };
 		F9724BBE292755E400860F8A /* Comment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comment.swift; sourceTree = "<group>"; };
 		F976E82B29368E0D0088BBA1 /* Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
@@ -345,7 +345,7 @@
 				87E606AE291062D300C3DA13 /* SignInViews */,
 				8792479A291BDF820040D5C3 /* SearchView.swift */,
 				3D41EE07290A4C18008BE986 /* Launch Screen.storyboard */,
-				F9136EB5293612310034AAB2 /* LaunchScreenView.swift */,
+				F9136EB5293612310034AAB2 /* ShortcutsZipView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -711,7 +711,7 @@
 				A33F74AE2908D8C800B8D0D0 /* CheckBoxShortcutCell.swift in Sources */,
 				87E606B22910649B00C3DA13 /* SignInWithAppleView.swift in Sources */,
 				87E99CEC29080C30009B691F /* Curation.swift in Sources */,
-				F9136EB6293612310034AAB2 /* LaunchScreenView.swift in Sources */,
+				F9136EB6293612310034AAB2 /* ShortcutsZipView.swift in Sources */,
 				87E99CB128FFF273009B691F /* WriteCurationSetView.swift in Sources */,
 				4D61A767291E1EE8000EF531 /* NavigationViewModel.swift in Sources */,
 				87E99CEE29080D33009B691F /* User.swift in Sources */,

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
@@ -127,7 +127,8 @@ struct ReadUserCurationView: View {
             }
         }
         .onAppear {
-            shortcutsZipViewModel.fetchUser(userID: self.data.userCuration.author) { user in
+            shortcutsZipViewModel.fetchUser(userID: self.data.userCuration.author,
+                                            isCurrentUser: false) { user in
                 authorInformation = user
             }
         }

--- a/HappyAnding/HappyAnding/Views/HappyAndingApp.swift
+++ b/HappyAnding/HappyAnding/Views/HappyAndingApp.swift
@@ -16,6 +16,8 @@ struct HappyAndingApp: App {
     @Environment(\.scenePhase) var scenePhase
     @Environment(\.openURL) private var openURL
     
+    @StateObject var shortcutsZipViewModel = ShortcutsZipViewModel()
+    
     @State var isNeededUpdate = false
     @State var isShowingLaunchScreen = true
     @State var version = Version(latestVersion: "", minimumVersion: "", description: "", title: "")
@@ -57,6 +59,7 @@ struct HappyAndingApp: App {
                 }
             } else {
                 ShortcutsZipView()
+                    .environmentObject(shortcutsZipViewModel)
             }
         }
         .onChange(of: scenePhase) { (newScenePhase) in

--- a/HappyAnding/HappyAnding/Views/LaunchScreenView.swift
+++ b/HappyAnding/HappyAnding/Views/LaunchScreenView.swift
@@ -24,7 +24,7 @@ struct ShortcutsZipView: View {
                     .environmentObject(shorcutsZipViewModel)
                     .onDisappear() {
                         if shorcutsZipViewModel.userInfo == nil {
-                            shorcutsZipViewModel.fetchUser(userID: shorcutsZipViewModel.currentUser()) { user in
+                            shorcutsZipViewModel.fetchUser(userID: shorcutsZipViewModel.currentUser(), isCurrentUser: true) { user in
                                 shorcutsZipViewModel.userInfo = user
                             }
                         }
@@ -33,7 +33,7 @@ struct ShortcutsZipView: View {
                 SignInWithAppleView()
                     .onDisappear() {
                         if shorcutsZipViewModel.userInfo == nil {
-                            shorcutsZipViewModel.fetchUser(userID: shorcutsZipViewModel.currentUser()) { user in
+                            shorcutsZipViewModel.fetchUser(userID: shorcutsZipViewModel.currentUser(), isCurrentUser: true) { user in
                                 shorcutsZipViewModel.userInfo = user
                                 shorcutsZipViewModel.initUserShortcut(user: user)
                                 shorcutsZipViewModel.curationsMadeByUser = shorcutsZipViewModel.fetchCurationByAuthor(author: user.id)

--- a/HappyAnding/HappyAnding/Views/LaunchScreenView.swift
+++ b/HappyAnding/HappyAnding/Views/LaunchScreenView.swift
@@ -8,8 +8,10 @@
 import SwiftUI
 
 struct ShortcutsZipView: View {
+    @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
+    
     @StateObject var userAuth = UserAuth.shared
-    @StateObject var shorcutsZipViewModel = ShortcutsZipViewModel()
+    
     @AppStorage("signInStatus") var signInStatus = false
     @AppStorage("isReauthenticated") var isReauthenticated = false
     
@@ -17,26 +19,26 @@ struct ShortcutsZipView: View {
         if signInStatus {
             ShortcutTabView()
                 .environmentObject(userAuth)
-                .environmentObject(shorcutsZipViewModel)
+                .environmentObject(shortcutsZipViewModel)
         }  else {
             if userAuth.isLoggedIn {
                 WriteNicknameView()
-                    .environmentObject(shorcutsZipViewModel)
+                    .environmentObject(shortcutsZipViewModel)
                     .onDisappear() {
-                        if shorcutsZipViewModel.userInfo == nil {
-                            shorcutsZipViewModel.fetchUser(userID: shorcutsZipViewModel.currentUser(), isCurrentUser: true) { user in
-                                shorcutsZipViewModel.userInfo = user
+                        if shortcutsZipViewModel.userInfo == nil {
+                            shortcutsZipViewModel.fetchUser(userID: shortcutsZipViewModel.currentUser(), isCurrentUser: true) { user in
+                                shortcutsZipViewModel.userInfo = user
                             }
                         }
                     }
             } else {
                 SignInWithAppleView()
                     .onDisappear() {
-                        if shorcutsZipViewModel.userInfo == nil {
-                            shorcutsZipViewModel.fetchUser(userID: shorcutsZipViewModel.currentUser(), isCurrentUser: true) { user in
-                                shorcutsZipViewModel.userInfo = user
-                                shorcutsZipViewModel.initUserShortcut(user: user)
-                                shorcutsZipViewModel.curationsMadeByUser = shorcutsZipViewModel.fetchCurationByAuthor(author: user.id)
+                        if shortcutsZipViewModel.userInfo == nil {
+                            shortcutsZipViewModel.fetchUser(userID: shortcutsZipViewModel.currentUser(), isCurrentUser: true) { user in
+                                shortcutsZipViewModel.userInfo = user
+                                shortcutsZipViewModel.initUserShortcut(user: user)
+                                shortcutsZipViewModel.curationsMadeByUser = shortcutsZipViewModel.fetchCurationByAuthor(author: user.id)
                             }
                         }
                     }

--- a/HappyAnding/HappyAnding/Views/MyPageViews/EditNicknameView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/EditNicknameView.swift
@@ -60,12 +60,14 @@ struct EditNicknameView: View {
         }
         .onAppear {
             nickname = shortcutszipViewModel.userInfo?.nickname ?? ""
-            shortcutszipViewModel.fetchUser(userID: shortcutszipViewModel.currentUser(), completionHandler: { user in
+            shortcutszipViewModel.fetchUser(userID: shortcutszipViewModel.currentUser(),
+                                            isCurrentUser: true) { user in
                 self.user = user
-            })
+            }
         }
         .onDisappear {
-            shortcutszipViewModel.fetchUser(userID: shortcutszipViewModel.currentUser()) { user in
+            shortcutszipViewModel.fetchUser(userID: shortcutszipViewModel.currentUser(),
+                                            isCurrentUser: true) { user in
                 shortcutszipViewModel.userInfo = user
             }
         }

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutHeaderView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutHeaderView.swift
@@ -42,7 +42,8 @@ struct ReadShortcutHeaderView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 16)
         .onAppear() {
-            shortcutsZipViewModel.fetchUser(userID: shortcut.author) { user in
+            shortcutsZipViewModel.fetchUser(userID: shortcut.author,
+                                            isCurrentUser: false) { user in
                 userInformation = user
             }
             

--- a/HappyAnding/HappyAnding/Views/ShortcutsZipView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutsZipView.swift
@@ -19,11 +19,9 @@ struct ShortcutsZipView: View {
         if signInStatus {
             ShortcutTabView()
                 .environmentObject(userAuth)
-                .environmentObject(shortcutsZipViewModel)
         }  else {
             if userAuth.isLoggedIn {
                 WriteNicknameView()
-                    .environmentObject(shortcutsZipViewModel)
                     .onDisappear() {
                         if shortcutsZipViewModel.userInfo == nil {
                             shortcutsZipViewModel.fetchUser(userID: shortcutsZipViewModel.currentUser(), isCurrentUser: true) { user in


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #338 

## 구현/변경 사항
- 로그인 정보가 없을 때, 로그인 페이지로 이동하도록 설정하였습니다.

## 스크린샷

https://user-images.githubusercontent.com/68676844/205080495-d6e52c7b-99f7-43be-b260-dca4b8838a70.mov


## To Reviewer
- fetchUser 할 때, 현재 로그인한 유저인지 확인 후 signInStatus를 변경하였습니다.
- 런치 스크린 화면에서 로그인 페이지로 바로 전환하기 위해서 뷰모델 초기화 위치를 변경하였습니다.
- 로그인없이 둘러보기가 생긴다면, 삭제되어야합니다.