### PR TITLE
WriteShortcutsView UI 수정

### DIFF
--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTagView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTagView.swift
@@ -253,7 +253,11 @@ struct WriteShortcutTagView: View {
         
         var body: some View {
             HStack {
-                Text(item)
+                Button(action: {
+                    //TODO: 탭 되었을 때 수정 로직 추가
+                }, label: {
+                    Text(item)
+                })
                 
                 Button(action: {
                     items.removeAll { $0 == item }

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTitleView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTitleView.swift
@@ -132,26 +132,20 @@ struct WriteShortcutTitleView: View {
                     writeShortcutNavigation.navigationPath = .init()
                     
                 }, label: {
-                    ZStack {
-                        Text("업로드")
-                            .Headline()
-                            .foregroundColor(.Text_Button)
-                            .opacity(0.7)
-                        Text("업로드")
-                            .Headline()
-                            .foregroundColor(.Primary)
-                            .opacity(shortcut.color.isEmpty ||
-                                     shortcut.sfSymbol.isEmpty ||
-                                     shortcut.title.isEmpty ||
-                                     !isNameValid ||
-                                     shortcut.downloadLink.isEmpty ||
-                                     !isLinkValid ||
-                                     shortcut.subtitle.isEmpty ||
-                                     !isOneLineValid ||
-                                     shortcut.description.isEmpty ||
-                                     !isMultiLineValid ||
-                                     shortcut.category.isEmpty ? 0.3 : 1)
-                    }
+                    Text("업로드")
+                        .Headline()
+                        .foregroundColor(.Primary)
+                        .opacity(shortcut.color.isEmpty ||
+                                 shortcut.sfSymbol.isEmpty ||
+                                 shortcut.title.isEmpty ||
+                                 !isNameValid ||
+                                 shortcut.downloadLink.isEmpty ||
+                                 !isLinkValid ||
+                                 shortcut.subtitle.isEmpty ||
+                                 !isOneLineValid ||
+                                 shortcut.description.isEmpty ||
+                                 !isMultiLineValid ||
+                                 shortcut.category.isEmpty ? 0.3 : 1)
                 })
                 .disabled(shortcut.color.isEmpty ||
                           shortcut.sfSymbol.isEmpty ||

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTitleView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTitleView.swift
@@ -232,7 +232,7 @@ struct WriteShortcutTitleView: View {
                                  isMultipleLines: false,
                                  title: "단축어 링크",
                                  placeholder: "단축어 링크를 추가하세요",
-                                 lengthLimit: 100,
+                                 lengthLimit: nil,
                                  isDownloadLinkTextField: true   ,
                                  content: $shortcut.downloadLink[0],
                                  isValid: $isLinkValid
@@ -288,43 +288,36 @@ struct WriteShortcutTitleView: View {
         @Binding var selectedCategories: [String]
         
         var body: some View {
-            ZStack {
-                
-                RoundedRectangle(cornerRadius: 12)
-                    .foregroundColor(.Background)
-                    .frame(height: 52)
+            HStack {
+                Button(action: {
+                    isShowingCategoryModal = true
+                }, label: {
+                    HStack {
+                        if selectedCategories.isEmpty {
+                            Text("카테고리 선택")
+                                .foregroundColor(.Gray2)
+                                .Body2()
+                        } else {
+                            Text(selectedCategories.map { String( Category(rawValue: $0)!.translateName()) }.joined(separator: ", "))
+                                .foregroundColor(.Gray4)
+                                .Body2()
+                                .multilineTextAlignment(.leading)
+                        }
+                        Spacer()
+                        Image(systemName: "chevron.forward")
+                            .foregroundColor(selectedCategories.isEmpty ? .Gray2 : .Gray4)
+                    }
+                    .padding(.all, 16)
                     .overlay(
                         RoundedRectangle(cornerRadius: 12)
                             .strokeBorder(selectedCategories.isEmpty ? Color.Gray2 : Color.Gray4, lineWidth: 1)
                     )
-                HStack {
-                    Button(action: {
-                        isShowingCategoryModal = true
-                    }, label: {
-                        HStack {
-                            if selectedCategories.isEmpty {
-                                Text("카테고리 선택")
-                                    .foregroundColor(.Gray2)
-                                    .Body2()
-                            } else {
-                                ForEach(selectedCategories, id:\.self) { item in
-                                    Text(Category.withLabel(item)!.translateName())
-                                        .foregroundColor(.Gray4)
-                                        .Body2()
-                                }
-                            }
-                            Spacer()
-                            Image(systemName: "chevron.forward")
-                                .foregroundColor(selectedCategories.isEmpty ? .Gray2 : .Gray4)
-                        }
-                    })
-                    .sheet(isPresented: $isShowingCategoryModal) {
-                        CategoryModalView(isShowingCategoryModal: $isShowingCategoryModal, selectedCategories: $selectedCategories)
-                            .presentationDetents([.fraction(0.7)])
-                            .presentationDragIndicator(.visible)
-                    }
+                })
+                .sheet(isPresented: $isShowingCategoryModal) {
+                    CategoryModalView(isShowingCategoryModal: $isShowingCategoryModal, selectedCategories: $selectedCategories)
+                        .presentationDetents([.fraction(0.7)])
+                        .presentationDragIndicator(.visible)
                 }
-                .padding(.horizontal, 16)
             }
             .padding(.horizontal, 16)
             .padding(.bottom, 8)

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTitleView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTitleView.swift
@@ -227,7 +227,7 @@ struct WriteShortcutTitleView: View {
                                  title: "단축어 링크",
                                  placeholder: "단축어 링크를 추가하세요",
                                  lengthLimit: nil,
-                                 isDownloadLinkTextField: true   ,
+                                 isDownloadLinkTextField: true,
                                  content: $shortcut.downloadLink[0],
                                  isValid: $isLinkValid
         )

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTitleView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutTitleView.swift
@@ -292,7 +292,7 @@ struct WriteShortcutTitleView: View {
                                 .foregroundColor(.Gray2)
                                 .Body2()
                         } else {
-                            Text(selectedCategories.map { String( Category(rawValue: $0)!.translateName()) }.joined(separator: ", "))
+                            Text(selectedCategories.map { Category(rawValue: $0)!.translateName() }.joined(separator: ", "))
                                 .foregroundColor(.Gray4)
                                 .Body2()
                                 .multilineTextAlignment(.leading)


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #353

## 구현/변경 사항
- 단축어 링크 텍스트필드의 100자 길이제한을 해제했습니다.
- 카테고리 선택 UI가 글자가 길어지면 깨지던 문제를 해결했습니다.

## 스크린샷

|텍스트필드|카테고리|
|:---:|:---:|
|<img width="352" alt="Screenshot 2022-12-03 at 4 11 33" src="https://user-images.githubusercontent.com/94854258/205368098-813a56e2-404c-4f31-9f8e-5db4b14bc1fe.png">|<img width="345" alt="Screenshot 2022-12-03 at 4 11 49" src="https://user-images.githubusercontent.com/94854258/205368059-f394f89e-dd1f-4465-b697-ff5f23291026.png">|

## 리뷰 시 참고사항
- 해당PR의 코드 변경은 ShareExtension에 사용되는 뷰에도 똑같이 적용될 예정입니다.
- 관련 앱 작성 이후에는 다시 수정할 수 없고 해당 내용을 지운 뒤 만들어야 하는 이슈가 발견되어 추후 수정 예정으로, 현재는 TODO로 표시만 해 두었습니다.
