### PR TITLE
[Feat] 큐레이션의 단축어 정렬 기능 추가

### DIFF
--- a/HappyAnding/HappyAnding/Views/Components/UserCurationCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/UserCurationCell.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 struct UserCurationCell: View {
     
-    let curation: Curation
+    @State var curation: Curation
     let navigationParentView: NavigationParentView
     
     var body: some View {
@@ -71,6 +71,9 @@ struct UserCurationCell: View {
                     .foregroundColor(Color.Gray5)
                     .padding(.bottom, 20)
                     .fixedSize(horizontal: false, vertical: true)
+            }
+            .onAppear() {
+                curation.shortcuts = curation.shortcuts.sorted(by: { $0.title < $1.title})
             }
             .padding(.horizontal, 24)
             .background(Color.Background_list)

--- a/HappyAnding/HappyAnding/Views/Components/UserCurationCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/UserCurationCell.swift
@@ -73,7 +73,7 @@ struct UserCurationCell: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
             .onAppear() {
-                curation.shortcuts = curation.shortcuts.sorted(by: { $0.title < $1.title})
+                curation.shortcuts = curation.shortcuts.sorted { $0.title < $1.title }
             }
             .padding(.horizontal, 24)
             .background(Color.Background_list)

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
@@ -138,7 +138,7 @@ struct ReadUserCurationView: View {
                                             isCurrentUser: false) { user in
                 authorInformation = user
             }
-            data.userCuration.shortcuts = data.userCuration.shortcuts.sorted(by: { $0.title < $1.title})
+            data.userCuration.shortcuts = data.userCuration.shortcuts.sorted { $0.title < $1.title }
         }
     }
 }

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
@@ -138,6 +138,7 @@ struct ReadUserCurationView: View {
                                             isCurrentUser: false) { user in
                 authorInformation = user
             }
+            data.userCuration.shortcuts = data.userCuration.shortcuts.sorted(by: { $0.title < $1.title})
         }
     }
 }

--- a/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationInfoView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationInfoView.swift
@@ -61,6 +61,7 @@ struct WriteCurationInfoView: View {
                             deletedShortcutCells.removeAll(where: { $0.id == shortcutCell.id })
                         }
                     }
+                    curation.shortcuts = curation.shortcuts.sorted(by: { $0.title < $1.title})
                     curation.author = shortcutsZipViewModel.currentUser()
                     shortcutsZipViewModel.setData(model: curation)
                     shortcutsZipViewModel.updateShortcutCurationID(

--- a/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationInfoView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationInfoView.swift
@@ -61,7 +61,7 @@ struct WriteCurationInfoView: View {
                             deletedShortcutCells.removeAll(where: { $0.id == shortcutCell.id })
                         }
                     }
-                    curation.shortcuts = curation.shortcuts.sorted(by: { $0.title < $1.title})
+                    curation.shortcuts = curation.shortcuts.sorted { $0.title < $1.title }
                     curation.author = shortcutsZipViewModel.currentUser()
                     shortcutsZipViewModel.setData(model: curation)
                     shortcutsZipViewModel.updateShortcutCurationID(

--- a/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationSetView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationSetView.swift
@@ -49,7 +49,7 @@ struct WriteCurationSetView: View {
         .navigationTitle(isEdit ? "추천 모음집 편집" : "추천 모음집 작성")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
-            self.shortcutCells = shortcutsZipViewModel.fetchShortcutMakeCuration()
+            self.shortcutCells = shortcutsZipViewModel.fetchShortcutMakeCuration().sorted(by: {$0.title < $1.title})
             if isEdit {
                 deletedShortcutCells = curation.shortcuts
             }

--- a/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationSetView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationSetView.swift
@@ -49,7 +49,7 @@ struct WriteCurationSetView: View {
         .navigationTitle(isEdit ? "추천 모음집 편집" : "추천 모음집 작성")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
-            self.shortcutCells = shortcutsZipViewModel.fetchShortcutMakeCuration().sorted(by: {$0.title < $1.title})
+            self.shortcutCells = shortcutsZipViewModel.fetchShortcutMakeCuration().sorted { $0.title < $1.title }
             if isEdit {
                 deletedShortcutCells = curation.shortcuts
             }


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #357 

## 구현/변경 사항
- 큐레이션 작성 시 선택 가능한 단축어 가나다순 정렬
- 큐레이션 상세 화면에서 보여주는 단축어 가나다순 정렬

## 스크린샷

|iPhone 13|iPhone 13|
|:---:|:---:|
|![IMG_3795](https://user-images.githubusercontent.com/41153398/205436804-76c87d37-331c-4b80-82a7-e0e95cfec843.PNG)|![IMG_3796](https://user-images.githubusercontent.com/41153398/205436811-66734278-bcc2-4ca5-8b04-86d0ee9c1d73.PNG)|
