### PR TITLE
Profile icon 이미지 통일

### DIFF
--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
@@ -111,11 +111,10 @@ struct ReadUserCurationView: View {
             if let data = NavigationProfile(userInfo: self.authorInformation) {
                 NavigationLink(value: data) {
                     HStack {
-                        Image(systemName: "person.fill")
+                        Image(systemName: "person.crop.circle.fill")
+                            .font(.system(size: 28, weight: .medium))
                             .frame(width: 28, height: 28)
-                            .foregroundColor(.White)
-                            .background(Color.Gray3)
-                            .clipShape(Circle())
+                            .foregroundColor(.Gray3)
                         
                         Text(authorInformation?.nickname ?? "탈퇴한 사용자")
                             .Headline()

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
@@ -180,6 +180,8 @@ extension ReadUserCurationView {
             shareCuration()
         }) {
             Label("공유", systemImage: "square.and.arrow.up")
+                .foregroundColor(.Gray4)
+                .fontWeight(.medium)
         }
     }
     

--- a/HappyAnding/HappyAnding/Views/MyPageViews/MyPageView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/MyPageView.swift
@@ -27,14 +27,10 @@ struct MyPageView: View {
                 
                 HStack(spacing: 16) {
                     
-                    //TODO: 사용되는 임시 이미지 지정되면 변경 필요
-                    
-                    Image(systemName: "person.fill")
-                        .font(.title)
+                    Image(systemName: "person.crop.circle.fill")
+                        .font(.system(size: 60, weight: .medium))
                         .frame(width: 60, height: 60)
-                        .foregroundColor(.White)
-                        .background(Color.Gray3)
-                        .clipShape(Circle())
+                        .foregroundColor(.Gray3)
                         .id(333)
                     
                     HStack {

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutCommentView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutCommentView.swift
@@ -72,9 +72,10 @@ struct ReadShortcutCommentView: View {
                     
                     HStack(spacing: 8) {
                         
-                        Circle()
+                        Image(systemName: "person.crop.circle.fill")
+                            .font(.system(size: 24, weight: .medium))
                             .frame(width: 24, height: 24)
-                            .foregroundColor(.Gray4)
+                            .foregroundColor(.Gray3)
                         
                         Text(comment.user_nickname)
                             .Body2()

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutHeaderView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutHeaderView.swift
@@ -88,9 +88,10 @@ struct ReadShortcutHeaderView: View {
                 NavigationLink(value: data) {
                     HStack(spacing: 8) {
                         
-                        Circle()
+                        Image(systemName: "person.crop.circle.fill")
+                            .font(.system(size: 24, weight: .medium))
                             .frame(width: 24, height: 24)
-                            .foregroundColor(.Gray4)
+                            .foregroundColor(.Gray3)
                             .padding(.leading, 16)
                         
                         Text(userInformation?.nickname ?? "탈퇴한 사용자")

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -343,6 +343,8 @@ extension ReadShortcutView {
             shareShortcut()
         }) {
             Label("공유", systemImage: "square.and.arrow.up")
+                .foregroundColor(.Gray4)
+                .fontWeight(.medium)
         }
     }
     

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ShowProfileView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ShowProfileView.swift
@@ -32,9 +32,10 @@ struct ShowProfileView: View {
                 
                 //MARK: 프로필이미지 및 닉네임
                 VStack {
-                    Circle()
-                        .fill(Color.Gray4)
+                    Image(systemName: "person.crop.circle.fill")
+                        .font(.system(size: 72, weight: .medium))
                         .frame(width: 72, height: 72)
+                        .foregroundColor(.Gray3)
                     Text(data.userInfo?.nickname ?? "user")
                         .Title1()
                         .foregroundColor(.Gray5)


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #356

## 구현/변경 사항
- 앱에서 사용되는 모든 profile 이미지의 모양을 person.crop.circle.fill, medium, Gray3 로 통일했습니다.

## 스크린샷
|||||
|:---:|:---:|:---:|:---:|
|![KakaoTalk_Photo_2022-12-03-20-33-54 004](https://user-images.githubusercontent.com/94854258/205438905-a9192b17-66b1-4c33-9ea6-ac0c2595ef38.png)|![KakaoTalk_Photo_2022-12-03-20-33-54 003](https://user-images.githubusercontent.com/94854258/205438940-1b8074c0-a1ca-4d27-b93e-7e3c445e0f2f.png)|![KakaoTalk_Photo_2022-12-03-20-33-54 002](https://user-images.githubusercontent.com/94854258/205438951-4951764c-88b3-4d0f-aaa2-c9b4f3318628.png)|![KakaoTalk_Photo_2022-12-03-20-33-53 001](https://user-images.githubusercontent.com/94854258/205438963-99badea8-07aa-4bc0-9018-f56ce4bec945.png)|

