### PR TITLE
[Feat] Admin curation cell/description UI 오류 수정 및 개행문자 변환

### DIFF
--- a/HappyAnding/HappyAnding/Views/Components/AdminCurationCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/AdminCurationCell.swift
@@ -47,11 +47,11 @@ struct AdminCurationCell: View {
                     .Body2()
                     .foregroundColor(.Text_curation)
                     .lineLimit(2)
+                    .multilineTextAlignment(.leading)
             }
             Spacer()
         }
     }
-    
     
     ///백그라운드 이미지
     var backgroundImage: some View {

--- a/HappyAnding/HappyAnding/Views/Components/AdminCurationCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/AdminCurationCell.swift
@@ -43,7 +43,7 @@ struct AdminCurationCell: View {
                     .Title1()
                     .foregroundColor(.Text_curation)
                     .lineLimit(1)
-                Text(adminCuration.subtitle)
+                Text(adminCuration.subtitle.replacingOccurrences(of: "\\n", with: "\n"))
                     .Body2()
                     .foregroundColor(.Text_curation)
                     .lineLimit(2)

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadAdminCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadAdminCurationView.swift
@@ -89,7 +89,7 @@ struct ReadAdminCurationView: View {
                 Text(curation.title)
                     .Title2()
                     .foregroundColor(.Gray5)
-                Text(curation.subtitle)
+                Text(curation.subtitle.replacingOccurrences(of: "\\n", with: "\n"))
                     .Body2()
                     .foregroundColor(.Gray4)
             }


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #366
- closes #367

## 구현/변경 사항
- AdminCuration의 Subtitle이 한 줄 이상일때 가운데 정렬이 되는 오류를 좌측 정렬로 수정했습니다.
- AdminCuration의 Subtitle에 개행이 필요할 때를 대비해 개행문자를 변환하는 코드를 추가했습니다.

## 스크린샷
![Simulator Screen Shot - iPhone 14 Pro - 2022-12-27 at 14 09 49](https://user-images.githubusercontent.com/94854258/209614463-59935c73-91d7-41cd-aacd-a6dca659a677.png)

