### PR TITLE
[Feat] #371 로그인 없이 둘러보기

### DIFF
--- a/HappyAnding/HappyAnding/Views/Components/MyShortcutCardListView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/MyShortcutCardListView.swift
@@ -86,7 +86,7 @@ struct MyShortcutCardListView: View {
                 Text("로그인하기")
             }
         } message: {
-            Text("단축어 작성은 로그인 후 사용할 수 있는 기능이에요")
+            Text("단축어 작성은 로그인 후 사용할 수 있어요")
         }
         .navigationBarTitleDisplayMode(.automatic)
         .fullScreenCover(isPresented: $isWriting) {

--- a/HappyAnding/HappyAnding/Views/Components/MyShortcutCardListView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/MyShortcutCardListView.swift
@@ -10,8 +10,10 @@ import SwiftUI
 struct MyShortcutCardListView: View {
     
     @StateObject var writeNavigation = WriteShortcutNavigation()
+    @AppStorage("useWithoutSignIn") var useWithoutSignIn: Bool = false
     
     @State var isWriting = false
+    @State private var tryWriteWithoutSignIn: Bool = false
     
     var shortcuts: [Shortcuts]?
     var data: NavigationListShortcutType {
@@ -44,7 +46,11 @@ struct MyShortcutCardListView: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack {
                     Button {
-                        self.isWriting = true
+                        if !useWithoutSignIn {
+                            self.isWriting = true
+                        } else {
+                            self.tryWriteWithoutSignIn = true
+                        }
                     } label: {
                         AddMyShortcutCardView()
                     }
@@ -66,6 +72,21 @@ struct MyShortcutCardListView: View {
                 }
                 .padding(.horizontal, 16)
             }
+        }
+        .alert("로그인을 진행해주세요", isPresented: $tryWriteWithoutSignIn) {
+            Button(role: .cancel) {
+                tryWriteWithoutSignIn = false
+            } label: {
+                Text("취소")
+            }
+            Button {
+                useWithoutSignIn = false
+                tryWriteWithoutSignIn = false
+            } label: {
+                Text("로그인하기")
+            }
+        } message: {
+            Text("단축어 작성은 로그인 후 사용할 수 있는 기능이에요")
         }
         .navigationBarTitleDisplayMode(.automatic)
         .fullScreenCover(isPresented: $isWriting) {

--- a/HappyAnding/HappyAnding/Views/Components/MyShortcutCardListView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/MyShortcutCardListView.swift
@@ -86,7 +86,7 @@ struct MyShortcutCardListView: View {
                 Text("로그인하기")
             }
         } message: {
-            Text("단축어 작성은 로그인 후 사용할 수 있어요")
+            Text("이 기능은 로그인 후 사용할 수 있어요")
         }
         .navigationBarTitleDisplayMode(.automatic)
         .fullScreenCover(isPresented: $isWriting) {

--- a/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
@@ -47,6 +47,9 @@ struct ShortcutCell: View {
     let navigationParentView: NavigationParentView
     var sectionType: SectionType?
     
+    @AppStorage("useWithoutSignIn") var useWithoutSignIn: Bool = false
+    @State private var tryActionWithoutSignIn: Bool = false
+    
     var body: some View {
         
         ZStack {
@@ -56,17 +59,36 @@ struct ShortcutCell: View {
                 Spacer()
                 downloadInfo
                     .onTapGesture {
-                        if let url = URL(string: shortcutCell.downloadLink) {
-                            openURL(url)
-                            if let shortcut = shortcutsZipViewModel.fetchShortcutDetail(id: shortcutCell.id) {
-                                shortcutsZipViewModel.updateNumberOfDownload(shortcut: shortcut, downloadlinkIndex: 0)
+                        if !useWithoutSignIn {
+                            if let url = URL(string: shortcutCell.downloadLink) {
+                                openURL(url)
+                                if let shortcut = shortcutsZipViewModel.fetchShortcutDetail(id: shortcutCell.id) {
+                                    shortcutsZipViewModel.updateNumberOfDownload(shortcut: shortcut, downloadlinkIndex: 0)
+                                }
                             }
+                        } else {
+                            tryActionWithoutSignIn = true
                         }
                     }
             }
             .padding(.vertical, 20)
             .background( background )
             .padding(.horizontal, 20)
+        }
+        .alert("로그인을 진행해주세요", isPresented: $tryActionWithoutSignIn) {
+            Button(role: .cancel) {
+                tryActionWithoutSignIn = false
+            } label: {
+                Text("취소")
+            }
+            Button {
+                useWithoutSignIn = false
+                tryActionWithoutSignIn = false
+            } label: {
+                Text("로그인하기")
+            }
+        } message: {
+            Text("이 기능은 로그인 후 사용할 수 있어요")
         }
         .padding(.bottom, 12)
         .background(Color.Background)

--- a/HappyAnding/HappyAnding/Views/Components/UserCurationListView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/UserCurationListView.swift
@@ -73,7 +73,7 @@ struct UserCurationListView: View {
                 Text("로그인하기")
             }
         } message: {
-            Text("추천 모음집 작성은 로그인 후 사용할 수 있는 기능이에요")
+            Text("추천 모음집 작성은 로그인 후 사용할 수 있어요")
         }
         .background(Color.Background.ignoresSafeArea(.all, edges: .all))
         .fullScreenCover(isPresented: $isWriting) {

--- a/HappyAnding/HappyAnding/Views/Components/UserCurationListView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/UserCurationListView.swift
@@ -73,7 +73,7 @@ struct UserCurationListView: View {
                 Text("로그인하기")
             }
         } message: {
-            Text("추천 모음집 작성은 로그인 후 사용할 수 있어요")
+            Text("이 기능은 로그인 후 사용할 수 있어요")
         }
         .background(Color.Background.ignoresSafeArea(.all, edges: .all))
         .fullScreenCover(isPresented: $isWriting) {

--- a/HappyAnding/HappyAnding/Views/Components/UserCurationListView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/UserCurationListView.swift
@@ -10,9 +10,13 @@ import SwiftUI
 struct UserCurationListView: View {
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
     @StateObject var writeCurationNavigation = WriteCurationNavigation()
+    @AppStorage("useWithoutSignIn") var useWithoutSignIn: Bool = false
+    
     @State var isWriting = false
     @State var data: NavigationListCurationType
     @State var curations = [Curation]()
+    @State private var tryWriteWithoutSignIn: Bool = false
+
     
     var body: some View {
         VStack(spacing: 0) {
@@ -21,7 +25,11 @@ struct UserCurationListView: View {
                 .padding(.horizontal, 16)
             
             Button {
-                self.isWriting = true
+                if !useWithoutSignIn {
+                    self.isWriting = true
+                } else {
+                    self.tryWriteWithoutSignIn = true
+                }
             } label: {
                 
                 HStack(spacing: 7) {
@@ -51,6 +59,21 @@ struct UserCurationListView: View {
                     }
                 }
             }
+        }
+        .alert("로그인을 진행해주세요", isPresented: $tryWriteWithoutSignIn) {
+            Button(role: .cancel) {
+                tryWriteWithoutSignIn = false
+            } label: {
+                Text("취소")
+            }
+            Button {
+                useWithoutSignIn = false
+                tryWriteWithoutSignIn = false
+            } label: {
+                Text("로그인하기")
+            }
+        } message: {
+            Text("추천 모음집 작성은 로그인 후 사용할 수 있는 기능이에요")
         }
         .background(Color.Background.ignoresSafeArea(.all, edges: .all))
         .fullScreenCover(isPresented: $isWriting) {

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ExploreCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ExploreCurationView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct ExploreCurationView: View {
     
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
+    @AppStorage("useWithoutSignIn") var useWithoutSignIn = false
     
     var body: some View {
         ScrollView {
@@ -20,13 +21,15 @@ struct ExploreCurationView: View {
                     .padding(.top, 20)
                     .padding(.bottom, 32)
                 
-                //땡땡니을 위한 모음집
-                CurationListView(data: NavigationListCurationType(type: .personalCuration,
-                                                                  title: "",
-                                                                  isAllUser: false,
-                                                                  navigationParentView: .curations,
-                                                                  curation: shortcutsZipViewModel.personalCurations))
-                .padding(.bottom, 32)
+                //사용자를 위한 모음집
+                if !useWithoutSignIn {
+                    CurationListView(data: NavigationListCurationType(type: .personalCuration,
+                                                                      title: "",
+                                                                      isAllUser: false,
+                                                                      navigationParentView: .curations,
+                                                                      curation: shortcutsZipViewModel.personalCurations))
+                    .padding(.bottom, 32)
+                }
                 
                 //추천 유저 큐레이션
                 CurationListView(data: NavigationListCurationType(type: .userCuration,

--- a/HappyAnding/HappyAnding/Views/MyPageViews/MyPageView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/MyPageView.swift
@@ -10,7 +10,8 @@ import SwiftUI
 struct MyPageView: View {
     
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
-    
+    @AppStorage("useWithoutSignIn") var useWithoutSignIn: Bool = false
+
     enum NavigationSettingView: Hashable, Equatable {
         case first
     }
@@ -34,14 +35,16 @@ struct MyPageView: View {
                         .id(333)
                     
                     HStack {
-                        Text(shortcutsZipViewModel.userInfo?.nickname ?? "User")
+                        Text(shortcutsZipViewModel.userInfo?.nickname ?? "사용자")
                             .Title1()
                             .foregroundColor(.Gray5)
                         
-                        NavigationLink(value: NavigationNicknameView.first) {
-                            Image(systemName: "square.and.pencil")
-                                .Title2()
-                                .foregroundColor(.Gray4)
+                        if !useWithoutSignIn {
+                            NavigationLink(value: NavigationNicknameView.first) {
+                                Image(systemName: "square.and.pencil")
+                                    .Title2()
+                                    .foregroundColor(.Gray4)
+                            }
                         }
                     }
                     Spacer()

--- a/HappyAnding/HappyAnding/Views/MyPageViews/SettingView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/SettingView.swift
@@ -13,6 +13,7 @@ import FirebaseAuth
 struct SettingView: View {
     
     @AppStorage("signInStatus") var signInStatus = false
+    @AppStorage("useWithoutSignIn") var useWithoutSignIn = false
     @EnvironmentObject var userAuth: UserAuth
     @ObservedObject var webViewModel = WebViewModel()
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
@@ -89,33 +90,42 @@ struct SettingView: View {
                 }
             }
             
-            
-            // MARK: - 로그아웃 버튼
-            Button {
-                self.isTappedLogOutButton.toggle()
-            } label: {
-                SettingCell(title: "로그아웃")
-            }
-            .alert("로그아웃", isPresented: $isTappedLogOutButton) {
-                Button(role: .cancel) {
-                    
+            //로그인없이 둘러보기 여부에 따라 보여지는 버튼 다르게 표시
+            if useWithoutSignIn {
+                //MARK: - 로그인없이 둘러보기 시 로그인 버튼
+                Button {
+                    useWithoutSignIn = false
                 } label: {
-                    Text("닫기")
+                    SettingCell(title: "로그인")
                 }
                 
-                Button(role: .destructive) {
-                    logOut()
+            } else {
+                // MARK: - 로그아웃 버튼
+                Button {
+                    self.isTappedLogOutButton.toggle()
                 } label: {
-                    Text("로그아웃")
+                    SettingCell(title: "로그아웃")
                 }
-            } message: {
-                Text("로그아웃 하시겠습니까?")
-            }
-            
-            
-            // MARK: - 회원탈퇴 버튼
-            NavigationLink(value: NavigationWithdrawal.first) {
-                SettingCell(title: "탈퇴하기")
+                .alert("로그아웃", isPresented: $isTappedLogOutButton) {
+                    Button(role: .cancel) {
+                        
+                    } label: {
+                        Text("닫기")
+                    }
+                    
+                    Button(role: .destructive) {
+                        logOut()
+                    } label: {
+                        Text("로그아웃")
+                    }
+                } message: {
+                    Text("로그아웃 하시겠습니까?")
+                }
+                
+                // MARK: - 회원탈퇴 버튼
+                NavigationLink(value: NavigationWithdrawal.first) {
+                    SettingCell(title: "탈퇴하기")
+                }
             }
             
             Spacer()

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutCommentView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutCommentView.swift
@@ -16,6 +16,8 @@ struct ReadShortcutCommentView: View {
     @State var isTappedDeleteButton = false
     @State var deletedComment: Comment = Comment(user_nickname: "", user_id: "", date: "", depth: 0, contents: "")
     @FocusState var isFocused: Bool
+    @AppStorage("useWithoutSignIn") var useWithoutSignIn: Bool = false
+    
     let shortcutID: String
     
     var body: some View {
@@ -93,15 +95,17 @@ struct ReadShortcutCommentView: View {
                     
                     // MARK: Button
                     HStack(spacing: 16) {
-                        Button {
-                            nestedCommentInfoText = comment.user_nickname
-                            addedComment.bundle_id = comment.bundle_id
-                            addedComment.depth = 1
-                            isFocused = true
-                        } label: {
-                            Text("답글")
-                                .Footnote()
-                                .foregroundColor(.Gray4)
+                        if !useWithoutSignIn {
+                            Button {
+                                nestedCommentInfoText = comment.user_nickname
+                                addedComment.bundle_id = comment.bundle_id
+                                addedComment.depth = 1
+                                isFocused = true
+                            } label: {
+                                Text("답글")
+                                    .Footnote()
+                                    .foregroundColor(.Gray4)
+                            }
                         }
                         
                         if let user = shortcutsZipViewModel.userInfo {

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutHeaderView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutHeaderView.swift
@@ -15,6 +15,9 @@ struct ReadShortcutHeaderView: View {
     @Binding var isMyLike: Bool
     @State var userInformation: User? = nil
     
+    @AppStorage("useWithoutSignIn") var useWithoutSignIn: Bool = false
+    @State private var tryActionWithoutSignIn: Bool = false
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             HStack {
@@ -39,6 +42,21 @@ struct ReadShortcutHeaderView: View {
             }
             userInfo
         }
+        .alert("로그인을 진행해주세요", isPresented: $tryActionWithoutSignIn) {
+            Button(role: .cancel) {
+                tryActionWithoutSignIn = false
+            } label: {
+                Text("취소")
+            }
+            Button {
+                useWithoutSignIn = false
+                tryActionWithoutSignIn = false
+            } label: {
+                Text("로그인하기")
+            }
+        } message: {
+            Text("이 기능은 로그인 후 사용할 수 있어요")
+        }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 16)
         .onAppear() {
@@ -46,7 +64,6 @@ struct ReadShortcutHeaderView: View {
                                             isCurrentUser: false) { user in
                 userInformation = user
             }
-            
         }
     }
     
@@ -71,12 +88,16 @@ struct ReadShortcutHeaderView: View {
             .background(isMyLike ? Color.Primary : Color.Gray1)
             .cornerRadius(12)
             .onTapGesture {
-                isMyLike.toggle()
-                //화면 상의 좋아요 추가, 취소 기능 동작
-                if isMyLike {
-                    self.shortcut.numberOfLike += 1
+                if !useWithoutSignIn {
+                    isMyLike.toggle()
+                    //화면 상의 좋아요 추가, 취소 기능 동작
+                    if isMyLike {
+                        self.shortcut.numberOfLike += 1
+                    } else {
+                        self.shortcut.numberOfLike -= 1
+                    }
                 } else {
-                    self.shortcut.numberOfLike -= 1
+                    tryActionWithoutSignIn = true
                 }
             }
     }

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -254,7 +254,7 @@ extension ReadShortcutView {
                     Image(systemName: "arrow.turn.down.right")
                         .foregroundColor(.Gray4)
                 }
-                TextField(useWithoutSignIn ? "로그인 후 댓글을 작성할 수 있습니다" : "댓글을 입력하세요", text: $commentText, axis: .vertical)
+                TextField(useWithoutSignIn ? "로그인 후 댓글을 작성할 수 있어요" : "댓글을 입력하세요", text: $commentText, axis: .vertical)
                     .disabled(useWithoutSignIn == true)
                     .disableAutocorrection(true)
                     .textInputAutocapitalization(.never)

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -42,6 +42,9 @@ struct ReadShortcutView: View {
     @State var isClickCorrection = false                //댓글 수정버튼 클릭했는지?
     @State var isCancledCorrection = false              //댓글 수정 중 텍스트필드를 제외한 부분을 터치했는지?
     
+    @AppStorage("useWithoutSignIn") var useWithoutSignIn: Bool = false
+    @State private var tryActionWithoutSignIn: Bool = false
+    
     private let tabItems = ["기본 정보", "버전 정보", "댓글"]
     
     var body: some View {
@@ -80,6 +83,21 @@ struct ReadShortcutView: View {
                     }
                 }
             }
+            .alert("로그인을 진행해주세요", isPresented: $tryActionWithoutSignIn) {
+                Button(role: .cancel) {
+                    tryActionWithoutSignIn = false
+                } label: {
+                    Text("취소")
+                }
+                Button {
+                    useWithoutSignIn = false
+                    tryActionWithoutSignIn = false
+                } label: {
+                    Text("로그인하기")
+                }
+            } message: {
+                Text("이 기능은 로그인 후 사용할 수 있어요")
+            }
             .scrollDisabled(isClickCorrection)
             .navigationBarBackground ({ Color.White })
             .background(Color.Background)
@@ -93,14 +111,18 @@ struct ReadShortcutView: View {
                         if !isFocused {
                             if let shortcut = data.shortcut {
                                 Button {
-                                    if let url = URL(string: shortcut.downloadLink[0]) {
-                                        if (shortcutsZipViewModel.userInfo?.downloadedShortcuts.firstIndex(where: { $0.id == data.shortcutID })) == nil {
-                                            data.shortcut?.numberOfDownload += 1
+                                    if !useWithoutSignIn {
+                                        if let url = URL(string: shortcut.downloadLink[0]) {
+                                            if (shortcutsZipViewModel.userInfo?.downloadedShortcuts.firstIndex(where: { $0.id == data.shortcutID })) == nil {
+                                                data.shortcut?.numberOfDownload += 1
+                                            }
+                                            isClickDownload = true
+                                            openURL(url)
                                         }
-                                        isClickDownload = true
-                                        openURL(url)
+                                        shortcutsZipViewModel.updateNumberOfDownload(shortcut: shortcut, downloadlinkIndex: 0)
+                                    } else {
+                                        self.tryActionWithoutSignIn = true
                                     }
-                                    shortcutsZipViewModel.updateNumberOfDownload(shortcut: shortcut, downloadlinkIndex: 0)
                                 } label: {
                                     Text("다운로드 | \(Image(systemName: "arrow.down.app.fill")) \(shortcut.numberOfDownload)")
                                         .Body1()
@@ -232,7 +254,8 @@ extension ReadShortcutView {
                     Image(systemName: "arrow.turn.down.right")
                         .foregroundColor(.Gray4)
                 }
-                TextField("댓글을 입력하세요", text: $commentText, axis: .vertical)
+                TextField(useWithoutSignIn ? "로그인 후 댓글을 작성할 수 있습니다" : "댓글을 입력하세요", text: $commentText, axis: .vertical)
+                    .disabled(useWithoutSignIn == true)
                     .disableAutocorrection(true)
                     .textInputAutocapitalization(.never)
                     .Body2()

--- a/HappyAnding/HappyAnding/Views/ShortcutsZipView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutsZipView.swift
@@ -23,9 +23,6 @@ struct ShortcutsZipView: View {
         }  else {
             if useWithoutSignIn {
                 ShortcutTabView()
-                    .onAppear() {
-                        print(userAuth)
-                    }
 //                    .environmentObject(userAuth)
             } else {
                 if userAuth.isLoggedIn {

--- a/HappyAnding/HappyAnding/Views/ShortcutsZipView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutsZipView.swift
@@ -14,32 +14,41 @@ struct ShortcutsZipView: View {
     
     @AppStorage("signInStatus") var signInStatus = false
     @AppStorage("isReauthenticated") var isReauthenticated = false
+    @AppStorage("useWithoutSignIn") var useWithoutSignIn: Bool = false
     
     var body: some View {
         if signInStatus {
             ShortcutTabView()
                 .environmentObject(userAuth)
         }  else {
-            if userAuth.isLoggedIn {
-                WriteNicknameView()
-                    .onDisappear() {
-                        if shortcutsZipViewModel.userInfo == nil {
-                            shortcutsZipViewModel.fetchUser(userID: shortcutsZipViewModel.currentUser(), isCurrentUser: true) { user in
-                                shortcutsZipViewModel.userInfo = user
-                            }
-                        }
+            if useWithoutSignIn {
+                ShortcutTabView()
+                    .onAppear() {
+                        print(userAuth)
                     }
+//                    .environmentObject(userAuth)
             } else {
-                SignInWithAppleView()
-                    .onDisappear() {
-                        if shortcutsZipViewModel.userInfo == nil {
-                            shortcutsZipViewModel.fetchUser(userID: shortcutsZipViewModel.currentUser(), isCurrentUser: true) { user in
-                                shortcutsZipViewModel.userInfo = user
-                                shortcutsZipViewModel.initUserShortcut(user: user)
-                                shortcutsZipViewModel.curationsMadeByUser = shortcutsZipViewModel.fetchCurationByAuthor(author: user.id)
+                if userAuth.isLoggedIn {
+                    WriteNicknameView()
+                        .onDisappear() {
+                            if shortcutsZipViewModel.userInfo == nil {
+                                shortcutsZipViewModel.fetchUser(userID: shortcutsZipViewModel.currentUser(), isCurrentUser: true) { user in
+                                    shortcutsZipViewModel.userInfo = user
+                                }
                             }
                         }
-                    }
+                } else {
+                    SignInWithAppleView()
+                        .onDisappear() {
+                            if shortcutsZipViewModel.userInfo == nil {
+                                shortcutsZipViewModel.fetchUser(userID: shortcutsZipViewModel.currentUser(), isCurrentUser: true) { user in
+                                    shortcutsZipViewModel.userInfo = user
+                                    shortcutsZipViewModel.initUserShortcut(user: user)
+                                    shortcutsZipViewModel.curationsMadeByUser = shortcutsZipViewModel.fetchCurationByAuthor(author: user.id)
+                                }
+                            }
+                        }
+                }
             }
         }
     }

--- a/HappyAnding/HappyAnding/Views/SignInViews/SignInWithAppleView.swift
+++ b/HappyAnding/HappyAnding/Views/SignInViews/SignInWithAppleView.swift
@@ -14,6 +14,8 @@ struct SignInWithAppleView: View {
         
     @State private var appleLoginCoordinator: AppleAuthCoordinator?
     
+    @AppStorage("useWithoutSignIn") var useWithoutSignIn = false
+    
     var body: some View {
         
         VStack {
@@ -33,9 +35,6 @@ struct SignInWithAppleView: View {
             
             Spacer()
             
-            
-            // TODO: HiFi design 수정 시 색상 및 폰트 변경
-            
             Button(action: {
                 appleLogin()
             }, label: {
@@ -48,8 +47,17 @@ struct SignInWithAppleView: View {
                     Text("\(Image(systemName: "applelogo")) Apple로 로그인")
                         .foregroundColor(.White)
                 }
-                .padding(.bottom, 37)
+                .padding(.bottom, 8)
             })
+            
+            Button(action: {
+                useWithoutSignIn = true
+            }, label: {
+                Text("로그인 없이 둘러보기")
+                    .Body2()
+                    .foregroundColor(.Gray5)
+            })
+            .padding(.bottom, 12)
         }
         .background(Color.Background)
     }


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #371

## 구현/변경 사항
- 로그인 화면에 '로그인 없이 둘러보기' 버튼 추가
- 비로그인 상태에서 제거, 비활성화, Alert을 표시하는 기능들
    - ReadShoercutsView의 좋아요, 다운로드, 이전 버전 다운로드 버튼 클릭 시 로그인 필요 Alert 추가
    - ReadShoercutsView의 답글 버튼 제거, 댓글 달기 워딩 변경 및 비활성화
    - 추천모음집 탭의 사용자를 위한 추천 모음집 항목 제거
    - 프로필 탭의 닉네임을 '사용자' 로 변경 및 닉네임 수정 버튼 제거
    - 프로필 탭의 단축어 작성, 추천 모음집 작성 버튼 클릭 시 로그인 필요 Alert 추가
    - 프로필 탭 설정 화면의 로그아웃, 탈퇴하기 버튼 대신 로그인 버튼 표시
- Alert의 '로그인하기' 버튼 클릭 시 로그인 화면 표시

## 스크린샷
모두 로그인 없이 둘러보기 시 표시되는 화면입니다.
로그인 상태의 화면은 이전과 달라진 항목이 없습니다.
|로그인 화면|로그인 Alert|프로필 화면|설정 화면|댓글 화면|
|:---:|:---:|:---:|:---:|:---:|
|![Simulator Screen Shot - iPhone 14 Pro - 2023-01-08 at 00 58 38](https://user-images.githubusercontent.com/94854258/211159622-bd025a2d-97ba-46f0-985c-7c80e36352be.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-01-08 at 00 58 47](https://user-images.githubusercontent.com/94854258/211159629-cb88c6db-5b28-4d6f-bfe7-543a9cb1e54e.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-01-08 at 00 59 02](https://user-images.githubusercontent.com/94854258/211159646-8ad47fad-8a5b-4f23-9002-a4f4e5166cce.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-01-08 at 00 59 08](https://user-images.githubusercontent.com/94854258/211159652-7ae2e151-0c04-49fd-91d1-126196044f8b.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-01-08 at 01 01 43](https://user-images.githubusercontent.com/94854258/211159670-182509cf-7346-4227-82fc-9da143459226.png)|

## 구현 방법
```Swift
@AppStorage("useWithoutSignIn") var useWithoutSignIn: Bool
```
AppStorage에 'useWithoutSignIn' 값을 추가해 로그인 없이 앱을 사용하는 상황을 관리했습니다.
기본값은 `false`로 설정되어 있고 
로그인 화면에서 '로그인 없이 둘러보기' 버튼을 눌렀을 때 `true`로 변경되고 앱을 둘러볼 수 있습니다.
alert 또는 설정 화면에서 '로그인하기' 버튼을 눌렀을 때 다시 `false`로 변경되고 로그인 화면을 표시합니다.
비로그인 상태에서 제한되는 기능이 있는 View에서 해당 AppStorage를 이용해 기능을 제한했습니다.

## 코드리뷰 시 참고해주세요

### Alert
- 현재 같은 Alert이 여러 곳에서 사용되고 있어서 하나로 관리하는 것이 필요해 보입니다.
- 익스텐션을 만들어 Alert을 사용하는 방법이 생각나는데, 이 방법이 좋을지 혹은 더 좋은 방법이 있는지 궁금합니다!
- Alert의 경우 추후 커스텀하자는 이야기도 나왔던 것으로 기억해서 지금 위의 방식대로 개선해놓을지, 커스텀 할 때 한 번에 변경할지도 의견 주시면 줗을 것 같습니다.

### 로그인 화면 Modal
- 현재 ReadShortcutView에서 뜨는 Alert의 '로그인하기' 를 클릭하고 로그인을 진행하면 원래 있던 단축어 상세 페이지가 아닌 탭의 최상단으로 이동합니다.
- 이 부분을 그대로 유지할지, 해당 상황에서 로그인 시 원래 페이지로 돌아오게 할지 논의가 필요합니다.
- 최선의 방법은 해당 View에 로그인 기능만 Modal로 띄워서 구현하는 것이라고 생각하는데, 이 방법으로 구현하기 위해서는 로그인 담당하셨던 분의 도움이 필요할 것 같습니다...

### 디자인과 워딩
- 로그인 화면의 '로그인 없이 둘러보기' 버튼의 폰트, 색상, 패딩은 현재 확정된 디자인이 아닙니다. 디자인 확정 시 변경될 수 있습니다.
- 로그인 없이 둘러보기 상태일 때 나타나는 새로운 워딩들이 있습니다. 테스트 시 함께 검토해 주세요.
    - 로그인 없이 둘러보기
    - 로그인 후 댓글을 작성할 수 있어요
    - 로그인을 진행해주세요
    - 이 기능은 로그인 후 사용할 수 있어요

### 기능 제거 / 비활성화 / Alert 기준
- 사용자가 로그인 없이 둘러보기 상황에서도 App의 기능을 파악할 수 있는가? 를 기준으로 했습니다.
- 변경할 부분 있으면 의견 남겨 주세요!
- **제거한 기능**: 버튼이 보이지 않아도 해당 기능이 있다는 것을 파악할 수 있는 것 / 컨텐츠를 표시할 수 없는 것
    - 답글 달기
    - 사용자 맞춤 추천 모음집
    - 닉네임 변경
    - 로그아웃/탈퇴하기
- **비활성화한 기능**: 버튼이 보여야 기능을 알 수 있지만 label로 사용자에게 설명할 수 있는 것
    - 댓글 달기 textField
- **Alert을 띄우는 기능**: 버튼이 보여야 기능을 알 수 있는 것
    - 단축어 작성
    - 추천 모음집 작성
    - 단축어 다운로드 (이전 버전 다운로드)
    - 단축어 좋아요

