### PR TITLE
[Fix] 단축어, 큐레이션 변경사항 반영 문제 해결

### DIFF
--- a/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
+++ b/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		F9724BBF292755E400860F8A /* Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9724BBE292755E400860F8A /* Comment.swift */; };
 		F976E82C29368E0D0088BBA1 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = F976E82B29368E0D0088BBA1 /* Version.swift */; };
 		F976E85129395B350088BBA1 /* ShareExtensionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F976E85029395B350088BBA1 /* ShareExtensionViewModel.swift */; };
+		F989217E296C6AD400C21912 /* UserCurationDataCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F989217D296C6AD400C21912 /* UserCurationDataCell.swift */; };
 		F99569182901DC4D0060AAEF /* Font+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F99569172901DC4D0060AAEF /* Font+Extension.swift */; };
 		F9AC2BB62935201C00165820 /* CheckUpdateVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9AC2BB52935201C00165820 /* CheckUpdateVersion.swift */; };
 		F9AC2BBA2935D34C00165820 /* Image+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9AC2BB92935D34C00165820 /* Image+Extension.swift */; };
@@ -272,6 +273,7 @@
 		F9724BBE292755E400860F8A /* Comment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comment.swift; sourceTree = "<group>"; };
 		F976E82B29368E0D0088BBA1 /* Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
 		F976E85029395B350088BBA1 /* ShareExtensionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareExtensionViewModel.swift; sourceTree = "<group>"; };
+		F989217D296C6AD400C21912 /* UserCurationDataCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserCurationDataCell.swift; sourceTree = "<group>"; };
 		F99569172901DC4D0060AAEF /* Font+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+Extension.swift"; sourceTree = "<group>"; };
 		F9AC2BB52935201C00165820 /* CheckUpdateVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckUpdateVersion.swift; sourceTree = "<group>"; };
 		F9AC2BB92935D34C00165820 /* Image+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image+Extension.swift"; sourceTree = "<group>"; };
@@ -523,6 +525,7 @@
 				A3B263692909DFD200829DE1 /* CurationListView.swift */,
 				87276C372933F6AB00C92F4C /* CustomTextEditor.swift */,
 				87CFD8482939187200F97B86 /* NicknameTextField.swift */,
+				F989217D296C6AD400C21912 /* UserCurationDataCell.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -826,6 +829,7 @@
 				F94B432E2907088400987819 /* UserCurationListView.swift in Sources */,
 				A04ACB34290686C7004A85A6 /* ReadShortcutContentView.swift in Sources */,
 				A3FF0183291648A300384211 /* MailView.swift in Sources */,
+				F989217E296C6AD400C21912 /* UserCurationDataCell.swift in Sources */,
 				87E99CAF28FFF26A009B691F /* EditShortcutView.swift in Sources */,
 				A0F822AC2910B8F100AF4448 /* ShortcutsZipViewModel.swift in Sources */,
 				87276C382933F6AB00C92F4C /* CustomTextEditor.swift in Sources */,

--- a/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
+++ b/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
@@ -1112,7 +1112,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.happyanding.HappyAnding;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1154,7 +1154,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.happyanding.HappyAnding;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
+++ b/HappyAnding/HappyAnding/ViewModel/ShortcutsZipViewModel.swift
@@ -72,6 +72,7 @@ class ShortcutsZipViewModel: ObservableObject {
     }
     
     func refreshPersonalCurations() {
+        self.personalCurations.removeAll()
         let personalCurationIDs = Set(self.shortcutsUserDownloaded.flatMap({ $0.curationIDs }))
         for curationID in personalCurationIDs {
             if let curation = self.userCurations.first(where: { $0.id == curationID }) {
@@ -430,7 +431,7 @@ class ShortcutsZipViewModel: ObservableObject {
                 }
             }
         }
-        
+//        self.refreshPersonalCurations()
     }
     
     //MARK: 좋아요 수를 업데이트하는 함수

--- a/HappyAnding/HappyAnding/Views/Components/CurationListView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/CurationListView.swift
@@ -16,16 +16,13 @@ struct CurationListView: View {
         VStack(spacing: 0) {
             listHeader
             
-            ForEach(Array(data.curation.enumerated()), id: \.offset) { index, curation in
-                if index < 2 {
-                    
-                    let data = NavigationReadUserCurationType(userCuration: curation,
-                                                              navigationParentView: self.data.navigationParentView)
-                    NavigationLink(value: data) {
-                        UserCurationCell(curation: curation,
-                                         navigationParentView: self.data.navigationParentView,
-                                         lineLimit: 2)
-                    }
+            ForEach(data.curation.prefix(2), id: \.self) { curation in
+                let data = NavigationReadUserCurationType(userCuration: curation,
+                                                          navigationParentView: self.data.navigationParentView)
+                NavigationLink(value: data) {
+                    UserCurationCell(curation: curation,
+                                     navigationParentView: self.data.navigationParentView,
+                                     lineLimit: 2)
                 }
             }
         }

--- a/HappyAnding/HappyAnding/Views/Components/ListShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ListShortcutView.swift
@@ -14,7 +14,6 @@ struct ListShortcutView: View {
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
     
     @State var data: NavigationListShortcutType
-    @State var shortcutsArray: [Shortcuts] = []
     @State private var isLastItem = false
     
     var body: some View {
@@ -45,21 +44,71 @@ struct ListShortcutView: View {
                                 .listRowSeparator(.hidden)
                                 .listRowInsets(EdgeInsets())
                         }
-                        
                         //TODO: 무한 스크롤을 위한 업데이트 함수 필요
-                        ForEach(Array(shortcuts.enumerated()), id: \.offset) { index, shortcut in
-                            let navigationData = NavigationReadShortcutType(shortcut: shortcut,
-                                                                            shortcutID: shortcut.id,
-                                                                            navigationParentView: self.data.navigationParentView)
-                            
-                            NavigationLink(value: navigationData) {
-                                if data.sectionType == .download && index < 100 {
+                        switch data.sectionType {
+                        case .download:
+                            ForEach(shortcutsZipViewModel.sortedShortcutsByDownload.prefix(100), id: \.self) { shortcut in
+                                let navigationData = NavigationReadShortcutType(shortcut: shortcut,
+                                                                                shortcutID: shortcut.id,
+                                                                                navigationParentView: self.data.navigationParentView)
+                                
+                                NavigationLink(value: navigationData) {
                                     ShortcutCell(shortcut: shortcut,
-                                                 rankNumber: index + 1,
+                                                 rankNumber: 1,
                                                  navigationParentView: data.navigationParentView)
                                     .listRowInsets(EdgeInsets())
                                     .listRowSeparator(.hidden)
-                                } else {
+                                }
+                            }
+                        case .popular:
+                            ForEach(shortcutsZipViewModel.sortedShortcutsByLike, id: \.self) { shortcut in
+                                let navigationData = NavigationReadShortcutType(shortcut: shortcut,
+                                                                                shortcutID: shortcut.id,
+                                                                                navigationParentView: self.data.navigationParentView)
+
+                                NavigationLink(value: navigationData) {
+                                    ShortcutCell(shortcut: shortcut,
+                                                 navigationParentView: data.navigationParentView,
+                                                 sectionType: data.sectionType)
+                                    .listRowInsets(EdgeInsets())
+                                    .listRowSeparator(.hidden)
+                                }
+                            }
+                        case .myDownloadShortcut:
+                            ForEach(shortcutsZipViewModel.shortcutsUserDownloaded, id: \.self) { shortcut in
+                                let navigationData = NavigationReadShortcutType(shortcut: shortcut,
+                                                                                shortcutID: shortcut.id,
+                                                                                navigationParentView: self.data.navigationParentView)
+
+                                NavigationLink(value: navigationData) {
+                                    ShortcutCell(shortcut: shortcut,
+                                                 navigationParentView: data.navigationParentView,
+                                                 sectionType: data.sectionType)
+                                    .listRowInsets(EdgeInsets())
+                                    .listRowSeparator(.hidden)
+                                }
+                            }
+                        case .myLovingShortcut:
+                            ForEach(shortcutsZipViewModel.shortcutsUserLiked, id: \.self) { shortcut in
+                                let navigationData = NavigationReadShortcutType(shortcut: shortcut,
+                                                                                shortcutID: shortcut.id,
+                                                                                navigationParentView: self.data.navigationParentView)
+
+                                NavigationLink(value: navigationData) {
+                                    ShortcutCell(shortcut: shortcut,
+                                                 navigationParentView: data.navigationParentView,
+                                                 sectionType: data.sectionType)
+                                    .listRowInsets(EdgeInsets())
+                                    .listRowSeparator(.hidden)
+                                }
+                            }
+                        case .myShortcut:
+                            ForEach(shortcutsZipViewModel.shortcutsMadeByUser, id: \.self) { shortcut in
+                                let navigationData = NavigationReadShortcutType(shortcut: shortcut,
+                                                                                shortcutID: shortcut.id,
+                                                                                navigationParentView: self.data.navigationParentView)
+
+                                NavigationLink(value: navigationData) {
                                     ShortcutCell(shortcut: shortcut,
                                                  navigationParentView: data.navigationParentView,
                                                  sectionType: data.sectionType)

--- a/HappyAnding/HappyAnding/Views/Components/UserCurationDataCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/UserCurationDataCell.swift
@@ -1,17 +1,18 @@
 //
-//  UserCurationCell.swift
+//  UserCurationDataCell.swift
 //  HappyAnding
 //
-//  Created by 이지원 on 2022/10/20.
+//  Created by 전지민 on 2023/01/10.
 //
 
 import SwiftUI
 
 //MARK: - UserCurationCell 구현 시작
 
-struct UserCurationCell: View {
+struct UserCurationDataCell: View {
     
-    @State var curation: Curation
+    @Binding var data: NavigationReadUserCurationType
+    
     let navigationParentView: NavigationParentView
     var lineLimit: Int?
     
@@ -23,7 +24,7 @@ struct UserCurationCell: View {
                 
                 //MARK: - 단축어 아이콘 배열
                 HStack {
-                    ForEach(curation.shortcuts.prefix(4), id: \.self) { shortcut in
+                    ForEach(data.userCuration.shortcuts.prefix(4), id: \.self) { shortcut in
                         ZStack {
                             Rectangle()
                                 .fill(Color.fetchGradient(
@@ -38,7 +39,7 @@ struct UserCurationCell: View {
                     }
                     
                     //단축어가 4개 이상인 경우에만 그리는 아이콘
-                    if curation.shortcuts.count > 4 {
+                    if data.userCuration.shortcuts.count > 4 {
                         ZStack(alignment: .center) {
                             Rectangle()
                                 .fill(Color.Gray2)
@@ -46,7 +47,7 @@ struct UserCurationCell: View {
                                 .frame(width: 36, height: 36)
                             HStack(spacing: 0) {
                                 Image(systemName: "plus")
-                                Text("\(curation.shortcuts.count-4)")
+                                Text("\(data.userCuration.shortcuts.count-4)")
                             }
                             .foregroundColor(.Gray5)
                             .Footnote()
@@ -58,11 +59,11 @@ struct UserCurationCell: View {
                 
                 //MARK: - curation title, subtitle
                 
-                Text(curation.title)
+                Text(data.userCuration.title)
                     .Headline()
                     .foregroundColor(Color.Gray5)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                Text(curation.subtitle)
+                Text(data.userCuration.subtitle)
                     .Body2()
                     .multilineTextAlignment(.leading)
                     .lineLimit(lineLimit)
@@ -71,7 +72,7 @@ struct UserCurationCell: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
             .onAppear() {
-                curation.shortcuts = curation.shortcuts.sorted { $0.title < $1.title }
+                data.userCuration.shortcuts = data.userCuration.shortcuts.sorted { $0.title < $1.title }
             }
             .padding(.horizontal, 24)
             .background(Color.Background_list)
@@ -86,15 +87,3 @@ struct UserCurationCell: View {
         .padding(.bottom, 12)
     }
 }
-
-//struct UserCurationCell_Previews: PreviewProvider {
-//    static var previews: some View {
-//        VStack {
-//            UserCurationCell(
-//                title: "워라벨 지키기. 단축어와 함께",
-//                subtitle: "nil",
-//                shortcuts: Shortcut.fetchData(number: 5)
-//            )
-//        }
-//    }
-//}

--- a/HappyAnding/HappyAnding/Views/Components/UserCurationListView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/UserCurationListView.swift
@@ -38,12 +38,12 @@ struct UserCurationListView: View {
                 .padding(.horizontal, 16)
             }
             
-            ForEach(Array(curations.enumerated()), id: \.offset) { index, curation in
+            var count = 0
+            ForEach(curations.prefix(2), id: \.self) { curation in
                 
                 let data = NavigationReadUserCurationType(userCuration: curation,
                                                           navigationParentView: self.data.navigationParentView)
-                //TODO: 데이터 변경 필요
-                if index < 2 {
+                if count < 2 {
                     NavigationLink(value: data) {
                         UserCurationCell(curation: curation,
                                          navigationParentView: self.data.navigationParentView,

--- a/HappyAnding/HappyAnding/Views/Components/UserCurationListView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/UserCurationListView.swift
@@ -38,17 +38,14 @@ struct UserCurationListView: View {
                 .padding(.horizontal, 16)
             }
             
-            var count = 0
             ForEach(curations.prefix(2), id: \.self) { curation in
                 
                 let data = NavigationReadUserCurationType(userCuration: curation,
                                                           navigationParentView: self.data.navigationParentView)
-                if count < 2 {
-                    NavigationLink(value: data) {
-                        UserCurationCell(curation: curation,
-                                         navigationParentView: self.data.navigationParentView,
-                                         lineLimit: 2)
-                    }
+                NavigationLink(value: data) {
+                    UserCurationCell(curation: curation,
+                                     navigationParentView: self.data.navigationParentView,
+                                     lineLimit: 2)
                 }
             }
         }

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ExploreCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ExploreCurationView.swift
@@ -36,14 +36,14 @@ struct ExploreCurationView: View {
                                                                   curation: shortcutsZipViewModel.userCurations))
             }
             .padding(.bottom, 32)
+            .onChange(of: shortcutsZipViewModel.userCurations) { _ in
+                shortcutsZipViewModel.refreshPersonalCurations()
+            }
         }
         .navigationBarTitle(Text("추천 모음집 둘러보기"))
         .navigationBarTitleDisplayMode(.large)
         .scrollIndicators(.hidden)
         .background(Color.Background)
-        .onAppear {
-            shortcutsZipViewModel.refreshPersonalCurations()
-        }
     }
 }
 

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ListCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ListCurationView.swift
@@ -37,23 +37,59 @@ struct ListCurationView: View {
         } else {
             ScrollView {
                 LazyVStack(spacing: 0) {
-                    
-                    ForEach(Array(data.curation.enumerated()), id: \.offset) { index, curation in
-                        
-                        let data = NavigationReadUserCurationType(userCuration: curation,
-                                                                  navigationParentView: self.data.navigationParentView)
-                        
-                        NavigationLink(value: data) {
-                            UserCurationCell(curation: curation,
-                                             navigationParentView: self.data.navigationParentView,
-                                             lineLimit: 2)
-                            .listRowInsets(EdgeInsets())
-                            .listRowSeparator(.hidden)
-                            .listRowBackground(Color.Background)
-                            .padding(.top, index == 0 ? 20 : 0 )
-                            .padding(.bottom, index == self.data.curation.count - 1 ? 32 : 0)
+                    Rectangle()
+                        .fill(Color.Background)
+                        .frame(height: 20)
+                    switch data.type {
+                    case .personalCuration:
+                        ForEach(shortcutsZipViewModel.personalCurations, id: \.self) { curation in
+                            
+                            let data = NavigationReadUserCurationType(userCuration: curation,
+                                                                      navigationParentView: self.data.navigationParentView)
+                            
+                            NavigationLink(value: data) {
+                                UserCurationCell(curation: curation,
+                                                 navigationParentView: self.data.navigationParentView,
+                                                 lineLimit: 2)
+                                .listRowInsets(EdgeInsets())
+                                .listRowSeparator(.hidden)
+                                .listRowBackground(Color.Background)
+                            }
+                        }
+                    case .userCuration:
+                        ForEach(shortcutsZipViewModel.userCurations, id: \.self) { curation in
+                            
+                            let data = NavigationReadUserCurationType(userCuration: curation,
+                                                                      navigationParentView: self.data.navigationParentView)
+                            
+                            NavigationLink(value: data) {
+                                UserCurationCell(curation: curation,
+                                                 navigationParentView: self.data.navigationParentView,
+                                                 lineLimit: 2)
+                                .listRowInsets(EdgeInsets())
+                                .listRowSeparator(.hidden)
+                                .listRowBackground(Color.Background)
+                            }
+                        }
+                    case .myCuration:
+                        ForEach(shortcutsZipViewModel.curationsMadeByUser, id: \.self) { curation in
+                            
+                            let data = NavigationReadUserCurationType(userCuration: curation,
+                                                                      navigationParentView: self.data.navigationParentView)
+                            
+                            NavigationLink(value: data) {
+                                UserCurationCell(curation: curation,
+                                                 navigationParentView: self.data.navigationParentView,
+                                                 lineLimit: 2)
+                                .listRowInsets(EdgeInsets())
+                                .listRowSeparator(.hidden)
+                                .listRowBackground(Color.Background)
+                            }
                         }
                     }
+                    Rectangle()
+                        .fill(Color.Background)
+                        .frame(height: 32)
                 }
             }
             .scrollIndicators(.hidden)

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
@@ -39,8 +39,7 @@ struct ReadUserCurationView: View {
                         .padding(.top, 103)
                         .padding(.bottom, 22)
                     
-                    UserCurationCell(curation: data.userCuration,
-                                     navigationParentView: data.navigationParentView)
+                    UserCurationDataCell(data: $data, navigationParentView: data.navigationParentView)
                 }
             }
             .background(Color.white)
@@ -59,6 +58,13 @@ struct ReadUserCurationView: View {
             }
             .padding(.bottom, 44)
             
+        }
+        .refreshable {
+            print("refresh")
+            if let updatedCuration = shortcutsZipViewModel.fetchCurationDetail(curationID: data.userCuration.id) {
+                data.userCuration = updatedCuration
+                print(updatedCuration)
+            }
         }
         .onChange(of: isWriting) { _ in
             if !isWriting {

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
@@ -60,10 +60,8 @@ struct ReadUserCurationView: View {
             
         }
         .refreshable {
-            print("refresh")
             if let updatedCuration = shortcutsZipViewModel.fetchCurationDetail(curationID: data.userCuration.id) {
                 data.userCuration = updatedCuration
-                print(updatedCuration)
             }
         }
         .onChange(of: isWriting) { _ in

--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ShortcutsListView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ShortcutsListView.swift
@@ -24,7 +24,7 @@ struct ShortcutsListView: View {
             scrollHeader
             
             LazyVStack(spacing: 0) {
-                ForEach(Array(shortcuts.enumerated()), id: \.offset) { index, shortcut in
+                ForEach(shortcuts, id: \.self) { shortcut in
                     let data = NavigationReadShortcutType(shortcut: shortcut,
                                                           shortcutID: shortcut.id,
                                                           navigationParentView: self.navigationParentView)


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #361 
- closes #359 

## 구현/변경 사항
- 기존 ForEach문에서 enumerated를 사용한 구문을 index가 필요한 부분 외에 제거함
- NavigationStackModel에서는 State사용이 불가능하여 데이터 변경사항을 화면에서 감지할 수 없어서 발생한 문제들로 refreshable동작을 추가하거나 뷰모델의 데이터로 연결하여 해결함

## 동영상
https://user-images.githubusercontent.com/41153398/213147078-e5835e04-3662-4da5-844b-ff3de9872de9.mov



##To Reviewer
다른 부분들은 바로 반영이되도록 수정되었는데 ReadCurationView에서만 당겨서 새로고침을 하도록 되어있는 상태입니다. 다른 부분들과 통일성 있게 맞추는 것이 좋을까요?
