### PR TITLE
[Fix] ShortcutCell, CurationCell의 줄바꿈 문제 해결

### DIFF
--- a/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
+++ b/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		A3FF01882918581E00384211 /* LicenseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3FF01872918581E00384211 /* LicenseView.swift */; };
 		A3FF018A2918F8EF00384211 /* apache.txt in Resources */ = {isa = PBXBuildFile; fileRef = A3FF01892918F8EF00384211 /* apache.txt */; };
 		A3FF018E291ACFA500384211 /* WithdrawalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3FF018D291ACFA500384211 /* WithdrawalView.swift */; };
+		A3FF4F832979C09000FA9EEE /* LineBreaking+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3FF4F822979C09000FA9EEE /* LineBreaking+Extension.swift */; };
 		F90DEA4F29327E4D002140E2 /* NavigationStackModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8764C0D6291F85DF00E1593B /* NavigationStackModel.swift */; };
 		F90DEA5029327E5D002140E2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 87E99C7128F94EA8009B691F /* Assets.xcassets */; };
 		F90DEA5129327E62002140E2 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3D41EE07290A4C18008BE986 /* Launch Screen.storyboard */; };
@@ -266,6 +267,7 @@
 		A3FF01872918581E00384211 /* LicenseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicenseView.swift; sourceTree = "<group>"; };
 		A3FF01892918F8EF00384211 /* apache.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = apache.txt; sourceTree = "<group>"; };
 		A3FF018D291ACFA500384211 /* WithdrawalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalView.swift; sourceTree = "<group>"; };
+		A3FF4F822979C09000FA9EEE /* LineBreaking+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LineBreaking+Extension.swift"; sourceTree = "<group>"; };
 		F9131B6A2922D38D00868A0E /* Keyword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keyword.swift; sourceTree = "<group>"; };
 		F9136EB5293612310034AAB2 /* ShortcutsZipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsZipView.swift; sourceTree = "<group>"; };
 		F94B432D2907088400987819 /* UserCurationListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserCurationListView.swift; sourceTree = "<group>"; };
@@ -502,6 +504,7 @@
 				8795A16F292AB945004B765F /* UIScreen+Extension.swift */,
 				F9AC2BB92935D34C00165820 /* Image+Extension.swift */,
 				A3439AFA2939B0E80043E273 /* UserDefaults+Extension.swift */,
+				A3FF4F822979C09000FA9EEE /* LineBreaking+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -899,6 +902,7 @@
 				87E99CCB290145C4009B691F /* UserCurationCell.swift in Sources */,
 				F9724BBF292755E400860F8A /* Comment.swift in Sources */,
 				87E99CA328FFF22E009B691F /* ExploreCurationView.swift in Sources */,
+				A3FF4F832979C09000FA9EEE /* LineBreaking+Extension.swift in Sources */,
 				A0F822B729164D2300AF4448 /* ShortcutsListView.swift in Sources */,
 				4D3DBB88292E67E600DE8160 /* EditNicknameView.swift in Sources */,
 				87E99CE82907C6E6009B691F /* Shortcuts.swift in Sources */,

--- a/HappyAnding/HappyAnding/Extensions/LineBreaking+Extension.swift
+++ b/HappyAnding/HappyAnding/Extensions/LineBreaking+Extension.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 extension String {
-    var LineBreaking: String { self + "           " }
+    var lineBreaking: String { self + "           " }
 }

--- a/HappyAnding/HappyAnding/Extensions/LineBreaking+Extension.swift
+++ b/HappyAnding/HappyAnding/Extensions/LineBreaking+Extension.swift
@@ -1,0 +1,12 @@
+//
+//  LineBreaking+Extension.swift
+//  HappyAnding
+//
+//  Created by HanGyeongjun on 2023/01/20.
+//
+
+import Foundation
+
+extension String {
+    var LineBreaking: String { self + "           " }
+}

--- a/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
@@ -111,7 +111,7 @@ struct ShortcutCell: View {
                 .Headline()
                 .foregroundColor(.Gray5)
                 .lineLimit(1)
-            Text(shortcutCell.subtitle.LineBreaking)
+            Text(shortcutCell.subtitle.lineBreaking)
                 .Footnote()
                 .foregroundColor(.Gray3)
                 .multilineTextAlignment(.leading)

--- a/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
@@ -111,7 +111,7 @@ struct ShortcutCell: View {
                 .Headline()
                 .foregroundColor(.Gray5)
                 .lineLimit(1)
-            Text(shortcutCell.subtitle + "        ")
+            Text(shortcutCell.subtitle.LineBreaking)
                 .Footnote()
                 .foregroundColor(.Gray3)
                 .multilineTextAlignment(.leading)

--- a/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
@@ -111,7 +111,7 @@ struct ShortcutCell: View {
                 .Headline()
                 .foregroundColor(.Gray5)
                 .lineLimit(1)
-            Text(shortcutCell.subtitle)
+            Text(shortcutCell.subtitle + "        ")
                 .Footnote()
                 .foregroundColor(.Gray3)
                 .multilineTextAlignment(.leading)

--- a/HappyAnding/HappyAnding/Views/Components/UserCurationCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/UserCurationCell.swift
@@ -65,7 +65,7 @@ struct UserCurationCell: View {
                     .Headline()
                     .foregroundColor(Color.Gray5)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                Text(curation.subtitle.LineBreaking)
+                Text(curation.subtitle.lineBreaking)
                     .Body2()
                     .multilineTextAlignment(.leading)
                     .lineLimit(lineLimit)

--- a/HappyAnding/HappyAnding/Views/Components/UserCurationCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/UserCurationCell.swift
@@ -65,7 +65,7 @@ struct UserCurationCell: View {
                     .Headline()
                     .foregroundColor(Color.Gray5)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                Text(curation.subtitle + "        ")
+                Text(curation.subtitle.LineBreaking)
                     .Body2()
                     .multilineTextAlignment(.leading)
                     .lineLimit(lineLimit)

--- a/HappyAnding/HappyAnding/Views/Components/UserCurationCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/UserCurationCell.swift
@@ -64,7 +64,7 @@ struct UserCurationCell: View {
                     .Headline()
                     .foregroundColor(Color.Gray5)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                Text(shortcutsZipViewModel.userCurations[index].subtitle)
+                Text(shortcutsZipViewModel.userCurations[index].subtitle.lineBreaking)
                     .Body2()
                     .multilineTextAlignment(.leading)
                     .lineLimit(lineLimit)

--- a/HappyAnding/HappyAnding/Views/Components/UserCurationCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/UserCurationCell.swift
@@ -65,7 +65,7 @@ struct UserCurationCell: View {
                     .Headline()
                     .foregroundColor(Color.Gray5)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                Text(curation.subtitle)
+                Text(curation.subtitle + "        ")
                     .Body2()
                     .multilineTextAlignment(.leading)
                     .lineLimit(lineLimit)


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #323

## 구현/변경 사항
- ShortcutsCell의 Subtitle이 충분한 공간이 있음에도 빨리 줄바꿈되는 문제를 해결했습니다.
- UserCurationCell의 Subtitle에도 기기에 따라 같은 문제가 있을 수 있어 미리 같은 방법으로 처리해두었습니다.

## 원인
- Apple의 줄바꿈 방식 때문에 특정 경우에서 충분한 공간이 있음에도 줄바꿈이 되는 경우가 발생합니다.
- UIkit의 UILabel에서는 다음과 같은 방법으로 해당 설정을 해제할 수 있지만 SwiftUI에서는 지원하지 않습니다.
    - `label.lineBreakStrategy = NSParagraphStyle.LineBreakStrategy()`
- 참조 : https://stackoverflow.com/questions/72685881/swiftui-text-doesnt-fit-full-width-while-having-multiple-lines

## 해결 방법
- text 뒤에 후행 공백을 충분히 넣으면 해결됩니다.
- 후행 공백을 넣는 `LineBreaking+Extension`을 만들어 적용했습니다.

## 스크린샷

|해결 이전|해결 이후|
|:---:|:---:|
|![Simulator Screen Shot - iPhone 14 Pro - 2023-01-20 at 03 01 46](https://user-images.githubusercontent.com/94854258/213526298-d455f97e-10f5-45c7-8781-aa4538350dc5.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-01-20 at 03 03 01](https://user-images.githubusercontent.com/94854258/213526344-0502883b-8be3-481c-a2a1-3ef7fdcf76c1.png)|
