### PR TITLE
[Fix] 앱이 백그라운드에 없을 때, 비어있는 모달이 출력되는 문제

### DIFF
--- a/HappyAnding/HappyAnding/Views/TabView/ShortcutTabView.swift
+++ b/HappyAnding/HappyAnding/Views/TabView/ShortcutTabView.swift
@@ -172,17 +172,6 @@ struct ShortcutTabView: View {
                 }
                 .tag(3)
             }
-            .sheet(isPresented: self.$isShortcutDeeplink) {
-                let data = NavigationReadShortcutType(shortcutID: self.tempShortcutId,
-                                                      navigationParentView: .myPage)
-                ReadShortcutView(data: data)
-            }
-            .sheet(isPresented: self.$isCurationDeeplink) {
-                if let curation = shortcutsZipViewModel.fetchCurationDetail(curationID: tempCurationId) {
-                    let data = NavigationReadUserCurationType(userCuration: curation, navigationParentView: .myPage)
-                    ReadUserCurationView(data: data)
-                }
-            }
             .onChange(of: phase) { newPhase in
                 switch newPhase {
                 case .background: isShortcutDeeplink = false; isCurationDeeplink = false
@@ -212,6 +201,10 @@ struct ShortcutTabView: View {
         
         tempShortcutId  = shortcutIDfromURL
         isShortcutDeeplink = true
+        
+        let data = NavigationReadShortcutType(shortcutID: self.tempShortcutId,
+                                              navigationParentView: .myPage)
+        navigateLink(data: data)
     }
     
     private func fetchCurationIdFromUrl(urlString: String) {
@@ -228,10 +221,28 @@ struct ShortcutTabView: View {
         
         guard let curationIDfromURL = dictionaryData["curationID"] else { return }
         
-        print("curationIDfromURL = \(curationIDfromURL)")
-        
         tempCurationId  = curationIDfromURL
         isCurationDeeplink = true
+        
+        if let curation = shortcutsZipViewModel.fetchCurationDetail(curationID: tempCurationId) {
+            let data = NavigationReadUserCurationType(userCuration: curation,
+                                                      navigationParentView: .myPage)
+            navigateLink(data: data)
+        }
+    }
+    
+    private func navigateLink<T: Hashable> (data: T) {
+        
+        switch selectedTab {
+        case 1:
+            shortcutNavigation.navigationPath.append(data)
+        case 2:
+            curationNavigation.navigationPath.append(data)
+        case 3:
+            profileNavigation.navigationPath.append(data)
+        default:
+            break
+        }
     }
 }
 


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #363

## 구현/변경 사항
- sheet의 고질적인 문제여서 Navigation으로 변경하여 문제를 해결하였습니다.

## 스크린샷

https://user-images.githubusercontent.com/68676844/214092052-24fd879f-2a1d-411f-bdad-68b2d99f612e.mov

## To Reviewer
- Navigation Path를 통해 구현했기 때문에, 만약 링크를 여러번 클릭하게 된다면, 그만큼 뷰가 쌓이게 됩니다! (이해가 어려우시다면, 스크린샷 추가하겠습니다)

## Trouble shooting

### 이슈가 일어난 이유
- sheet에서 State를 사용하는 경우, 첫 화면에서 빈 화면이 나타나는 이슈가 존재한다. (iOS 14부터 존재하는 이슈로 확인됨)
  - [참조](https://developer.apple.com/forums/thread/659660)에 따르면 State 변수가 예측하기 힘든 상황에서는 데이터가 제대로 작동하지 않는다고 한다. (정확한 문서나 답변은 찾지 못했다)
  - 이를 해결하기 위해서 Sheet에 전달하는 데이터는 State가 아닌 Binding으로 전달해야한다.
  - 현재 뷰가 State로 선언되어있으며, Binding으로 변경하기 애매한 상황이다. (Read Shortcuts View, Read Curation View) 모두 작업을 진행해야함 + 참조하는 페이지가 많아서
  - 이에 팀원들과 논의 후 Navigation으로 진행하거나, Binding으로 선언한 새로운 뷰를 선언하여 작업을 진행할 예정이다. (현재는 Navigation으로 변경한 상태임)

### 어떤 Navigation Path에 추가해야하는가?
- 현재 탭뷰를 사용하고 있어서, 3개의 Navigation Path를 선언해서 사용하고 있다. 
- 그래서 무작정 첫번째 Navigation Path에 Append 할 경우, 큐레이션 탭에서 백그라운드를 둔 채 링크를 클릭하면, 제대로 동작하지 않는다.
- 현재 사용자가 있는 탭이 App Storage에 저장되어있다는 점에서 착안하여 switch 문을 통해 path를 append할 수 있도록하여 문제를 해결하였다.

### 같은 코드의 중복
- 단축어 글에 대한 정보를 공유할 수도 있고, 큐레이션 데이터를 공유할 수도 있다.
- 이에 데이터 형태만 다른 두 개의 함수를 사용해야했다.
- 제네릭을 통해 구현하였으며, switch 문을 사용하기 위해 T의 제약조건을 Hashable로 두었다.

### switch @unknown 키워드
- 탭이 충분히 추가될 가능성이 있기 때문에, unknown 키워드를 사용하고자 했다.
- 하지만 case가 정의된 것이 아니라, 정수형태를 사용했기 때문에 정의하지 못했다.
- 이를 위해 따로 case를 만들어야할지는 고민이 된다.
