### PR TITLE
[Fix] 댓글입력 창 레이아웃 오류 해결

### DIFF
--- a/HappyAnding/HappyAnding/TextLiteral.swift
+++ b/HappyAnding/HappyAnding/TextLiteral.swift
@@ -103,6 +103,7 @@ enum TextLiteral {
     static let readShortcutViewCommentTabTitle: String = "댓글"
     static let readShortcutViewDeletionTitle: String = "단축어 삭제"
     static let readShortcutViewDeletionMessage: String = "단축어를 삭제하시겠어요?"
+    static let readShortcutViewDeleteFixesTitle: String = "수정사항 삭제"
     static let readShortcutViewDeleteFixes: String = "수정사항을 삭제하시겠어요?"
     static let readShortcutViewKeepFixes: String = "계속 작성"
     static let readShortcutViewCommentDescriptionBeforeLogin: String = "로그인 후 댓글을 작성할 수 있어요"

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -232,11 +232,12 @@ extension ReadShortcutView {
                         .foregroundColor(.gray4)
                 }
                 TextField(useWithoutSignIn ? TextLiteral.readShortcutViewCommentDescriptionBeforeLogin : TextLiteral.readShortcutViewCommentDescription, text: $commentText, axis: .vertical)
+                    .keyboardType(.twitter)
                     .disabled(useWithoutSignIn)
                     .disableAutocorrection(true)
                     .textInputAutocapitalization(.never)
                     .Body2()
-                    .lineLimit((comment.depth == 1) && (!isClickCorrection) ? 2 : 4)
+                    .lineLimit(comment.depth == 1 ? 2 : 4)
                     .focused($isFocused)
                     .onAppear(perform : UIApplication.shared.hideKeyboard)
                     .onTapGesture {/*터치영역구분을위한부분*/}

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -184,13 +184,8 @@ struct ReadShortcutView: View {
                 Text(TextLiteral.readShortcutViewDeletionMessage)
             }
             .fullScreenCover(isPresented: $isEdit) {
-                NavigationStack(path: $writeNavigation.navigationPath) {
-                    if let shortcut = data.shortcut {
-                        WriteShortcutView(isWriting: $isEdit,
-                                          shortcut: shortcut,
-                                          isEdit: true)
-                    }
-                }
+                NavigationRouter(content: writeShortcutView,
+                                 path: $writeNavigation.navigationPath)
                 .environmentObject(writeNavigation)
             }
             .fullScreenCover(isPresented: $isUpdating) {

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -43,33 +43,49 @@ struct ReadShortcutView: View {
     @AppStorage("useWithoutSignIn") var useWithoutSignIn: Bool = false
     @FocusState private var isFocused: Bool
     @Namespace var namespace
+    @Namespace var topID
+    @Namespace var bottomID
     
     private let tabItems = [TextLiteral.readShortcutViewBasicTabTitle, TextLiteral.readShortcutViewVersionTabTitle, TextLiteral.readShortcutViewCommentTabTitle]
     
     var body: some View {
         ZStack {
-            ScrollView {
-                VStack(spacing: 0) {
-                    if data.shortcut != nil {
-                        StickyHeader(height: 40)
-                        
-                        // MARK: - 단축어 타이틀
-                        
-                        ReadShortcutHeaderView(shortcut: $data.shortcut.unwrap()!, isMyLike: $isMyLike)
-                            .frame(minHeight: 160)
-                            .padding(.bottom, 33)
-                            .background(Color.shortcutsZipWhite)
-                        
-                        
-                        // MARK: - 탭뷰 (기본 정보, 버전 정보, 댓글)
-                        
-                        LazyVStack(pinnedViews: [.sectionHeaders]) {
-                            Section(header: tabBarView
+            ScrollViewReader { proxy in
+                ScrollView {
+                    VStack(spacing: 0) {
+                        if data.shortcut != nil {
+                            StickyHeader(height: 40).id(topID)
+                            
+                            // MARK: - 단축어 타이틀
+                            
+                            ReadShortcutHeaderView(shortcut: $data.shortcut.unwrap()!, isMyLike: $isMyLike)
+                                .frame(minHeight: 160)
+                                .padding(.bottom, 33)
                                 .background(Color.shortcutsZipWhite)
-                            ) {
-                                detailInformationView
-                                    .padding(.top, 4)
-                                    .padding(.horizontal, 16)
+                            
+                            
+                            // MARK: - 탭뷰 (기본 정보, 버전 정보, 댓글)
+                            
+                            LazyVStack(pinnedViews: [.sectionHeaders]) {
+                                Section(header: tabBarView
+                                    .background(Color.shortcutsZipWhite)
+                                ) {
+                                    detailInformationView
+                                        .padding(.top, 4)
+                                        .padding(.horizontal, 16)
+                                }
+                            }
+                            
+                            HStack{}.id(bottomID)
+                        }
+                    }
+                }
+                .onAppear() {
+                    NotificationCenter.default.addObserver(forName: UIResponder.keyboardDidShowNotification, object: nil, queue: .main) {
+                        notification in
+                        withAnimation {
+                            if currentTab == 2 {
+                                proxy.scrollTo(bottomID)
                             }
                         }
                     }
@@ -162,8 +178,8 @@ struct ReadShortcutView: View {
                 NavigationStack(path: $writeNavigation.navigationPath) {
                     if let shortcut = data.shortcut {
                         WriteShortcutView(isWriting: $isEdit,
-                                               shortcut: shortcut,
-                                               isEdit: true)
+                                          shortcut: shortcut,
+                                          isEdit: true)
                     }
                 }
                 .environmentObject(writeNavigation)
@@ -178,13 +194,13 @@ struct ReadShortcutView: View {
                     .opacity(0.4)
                     .safeAreaInset(edge: .bottom, spacing: 0) {
                         textField
-                        .ignoresSafeArea(.keyboard)
-                        .focused($isFocused, equals: true)
-                        .task {
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                                isFocused = true
+                            .ignoresSafeArea(.keyboard)
+                            .focused($isFocused, equals: true)
+                            .task {
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                                    isFocused = true
+                                }
                             }
-                        }
                     }
                     .onAppear() {
                         commentText = comment.contents

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -84,11 +84,20 @@ struct ReadShortcutView: View {
                     NotificationCenter.default.addObserver(forName: UIResponder.keyboardDidShowNotification, object: nil, queue: .main) {
                         notification in
                         withAnimation {
-                            if currentTab == 2 {
+                            if currentTab == 2 && !isClickCorrection && comment.depth == 0 {
                                 proxy.scrollTo(bottomID)
                             }
                         }
                     }
+                    NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillHideNotification, object: nil, queue: .main) {
+                        notification in
+                        withAnimation {
+                            if currentTab == 2 && comment.depth == 0 && comments.comments.count == 1 {
+                                proxy.scrollTo(topID)
+                            }
+                        }
+                    }
+
                 }
             }
             .scrollDisabled(isClickCorrection)
@@ -209,7 +218,7 @@ struct ReadShortcutView: View {
                         isFocused.toggle()
                         isCancledCorrection.toggle()
                     }
-                    .alert(TextLiteral.readShortcutViewDeletionTitle, isPresented: $isCancledCorrection) {
+                    .alert(TextLiteral.readShortcutViewDeleteFixesTitle, isPresented: $isCancledCorrection) {
                         Button(role: .cancel) {
                             isFocused.toggle()
                         } label: {

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -232,10 +232,11 @@ extension ReadShortcutView {
                         .foregroundColor(.gray4)
                 }
                 TextField(useWithoutSignIn ? TextLiteral.readShortcutViewCommentDescriptionBeforeLogin : TextLiteral.readShortcutViewCommentDescription, text: $commentText, axis: .vertical)
-                    .disabled(useWithoutSignIn == true)
+                    .disabled(useWithoutSignIn)
                     .disableAutocorrection(true)
                     .textInputAutocapitalization(.never)
                     .Body2()
+                    .lineLimit((comment.depth == 1) && (!isClickCorrection) ? 2 : 4)
                     .focused($isFocused)
                     .onAppear(perform : UIApplication.shared.hideKeyboard)
                     .onTapGesture {/*터치영역구분을위한부분*/}


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #383 

## 구현/변경 사항
- 댓글 입력 시 줄바으로 인해 댓글입력창이 무제한으로 늘어나는 이슈를 해결했습니다.
- 댓글을 입력할때는 4줄까지, 답글을 입력할때는 2줄까지 텍스트필드가 늘어나도록 했습니다.
- 줄바꿈은 계속 가능하며, 텍스트필드 스크롤 또한 가능합니다.

## 추가 기능
- 3회 이상의 줄바꿈을 제한하는 기능도 생각해 봤지만 의미가 있을지, 어떻게 막을지에 대한 고민이 생겨서 구현하지 않았습니다.
- 위의 기능이나 다른 기능들 추가가 필요하다고 생각되면 추가하겠습니다!

