### PR TITLE
[Fix] 좋아요 숫자 오류 해결

### DIFF
--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutHeaderView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutHeaderView.swift
@@ -49,8 +49,8 @@ struct ReadShortcutHeaderView: View {
             shortcutsZipViewModel.fetchUser(userID: shortcut.author,
                                             isCurrentUser: false) { user in
                 userInformation = user
-                numberOfLike = shortcut.numberOfLike
             }
+            numberOfLike = shortcut.numberOfLike
         }
         .onDisappear { self.shortcut.numberOfLike = numberOfLike }
     }


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #398 

## 구현/변경 사항
- 탈퇴한 회원이 작성한 단축어 글의 좋아요 숫자가 제대로 보이지 않는 문제 해결

- 탈퇴한 회원의 경우 유저 정보가 존재하지 않아 값이 반환되는 클로저가 실행되지 않았고, 기존에는 처음 좋아요 숫자를 가져오는 동작을 해당 클로저 안에서 실행하여 발생한 문제 -> 좋아요 숫자를 가져오는 위치를 클로저 밖으로 변경하여 해결

## 스크린샷

| | |
|:---:|:---:|
|![Simulator Screen Shot - iPhone 13 - 2023-02-20 at 21 29 20](https://user-images.githubusercontent.com/41153398/220108353-b0a8fdf5-0331-4953-a82e-4fdce9f221b0.png)|![Simulator Screen Shot - iPhone 13 - 2023-02-20 at 21 29 31](https://user-images.githubusercontent.com/41153398/220108377-4539283e-3045-41bb-8069-7c219eaeebb2.png)|