### PR TITLE
[Feat] 카테고리를 표현하는 레이아웃 변경

### DIFF
--- a/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
+++ b/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		4D3DBB962934E31A00DE8160 /* ShowProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D3DBB952934E31A00DE8160 /* ShowProfileView.swift */; };
 		4D402E7B2979342800D9A825 /* RecentRegisteredView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D402E7A2979342800D9A825 /* RecentRegisteredView.swift */; };
 		4D61A767291E1EE8000EF531 /* NavigationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D61A766291E1EE8000EF531 /* NavigationViewModel.swift */; };
+		4D6A9EFF29A36E9C00D02522 /* WrappingHStack in Frameworks */ = {isa = PBXBuildFile; productRef = 4D6A9EFE29A36E9C00D02522 /* WrappingHStack */; };
 		4D778A34290A53BA00C15AC4 /* Application+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D778A33290A53BA00C15AC4 /* Application+Extension.swift */; };
 		4D7D16072986BBD7008B3332 /* TextLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D7D16062986BBD7008B3332 /* TextLiteral.swift */; };
 		4D7D16082986BBDE008B3332 /* TextLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D7D16062986BBD7008B3332 /* TextLiteral.swift */; };
@@ -292,6 +293,7 @@
 				F94B43632907B19A00987819 /* FirebaseFirestoreCombine-Community in Frameworks */,
 				F94B435F2907B19A00987819 /* FirebaseAuth in Frameworks */,
 				F94B43612907B19A00987819 /* FirebaseFirestore in Frameworks */,
+				4D6A9EFF29A36E9C00D02522 /* WrappingHStack in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -660,6 +662,7 @@
 				F94B435E2907B19A00987819 /* FirebaseAuth */,
 				F94B43602907B19A00987819 /* FirebaseFirestore */,
 				F94B43622907B19A00987819 /* FirebaseFirestoreCombine-Community */,
+				4D6A9EFE29A36E9C00D02522 /* WrappingHStack */,
 			);
 			productName = HappyAnding;
 			productReference = 87E99C6A28F94EA6009B691F /* HappyAnding.app */;
@@ -762,6 +765,7 @@
 			mainGroup = 87E99C6128F94EA6009B691F;
 			packageReferences = (
 				F94B435B2907B19A00987819 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				4D6A9EFD29A36E9C00D02522 /* XCRemoteSwiftPackageReference "WrappingHStack" */,
 			);
 			productRefGroup = 87E99C6B28F94EA6009B691F /* Products */;
 			projectDirPath = "";
@@ -1360,6 +1364,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		4D6A9EFD29A36E9C00D02522 /* XCRemoteSwiftPackageReference "WrappingHStack" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/dkk/WrappingHStack";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
 		F94B435B2907B19A00987819 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
@@ -1371,6 +1383,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		4D6A9EFE29A36E9C00D02522 /* WrappingHStack */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4D6A9EFD29A36E9C00D02522 /* XCRemoteSwiftPackageReference "WrappingHStack" */;
+			productName = WrappingHStack;
+		};
 		A3FC4746292A61550058BF26 /* FirebaseAnalytics */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = F94B435B2907B19A00987819 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;

--- a/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
+++ b/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		4D402E7B2979342800D9A825 /* RecentRegisteredView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D402E7A2979342800D9A825 /* RecentRegisteredView.swift */; };
 		4D61A767291E1EE8000EF531 /* NavigationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D61A766291E1EE8000EF531 /* NavigationViewModel.swift */; };
 		4D6A9EFF29A36E9C00D02522 /* WrappingHStack in Frameworks */ = {isa = PBXBuildFile; productRef = 4D6A9EFE29A36E9C00D02522 /* WrappingHStack */; };
+		4D6A9F0129A3A92F00D02522 /* wrappinghstack+license.txt in Resources */ = {isa = PBXBuildFile; fileRef = 4D6A9F0029A3A92E00D02522 /* wrappinghstack+license.txt */; };
 		4D778A34290A53BA00C15AC4 /* Application+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D778A33290A53BA00C15AC4 /* Application+Extension.swift */; };
 		4D7D16072986BBD7008B3332 /* TextLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D7D16062986BBD7008B3332 /* TextLiteral.swift */; };
 		4D7D16082986BBDE008B3332 /* TextLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D7D16062986BBD7008B3332 /* TextLiteral.swift */; };
@@ -180,6 +181,7 @@
 		4D3DBB952934E31A00DE8160 /* ShowProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowProfileView.swift; sourceTree = "<group>"; };
 		4D402E7A2979342800D9A825 /* RecentRegisteredView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentRegisteredView.swift; sourceTree = "<group>"; };
 		4D61A766291E1EE8000EF531 /* NavigationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationViewModel.swift; sourceTree = "<group>"; };
+		4D6A9F0029A3A92E00D02522 /* wrappinghstack+license.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "wrappinghstack+license.txt"; sourceTree = "<group>"; };
 		4D778A33290A53BA00C15AC4 /* Application+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Application+Extension.swift"; sourceTree = "<group>"; };
 		4D7D16062986BBD7008B3332 /* TextLiteral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TextLiteral.swift; path = HappyAnding/TextLiteral.swift; sourceTree = SOURCE_ROOT; };
 		4DAD635D292AB61700ABF8C1 /* UpdateShortcutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateShortcutView.swift; sourceTree = "<group>"; };
@@ -627,6 +629,7 @@
 				A3FF01852918552E00384211 /* AboutTeamView.swift */,
 				A3FF01872918581E00384211 /* LicenseView.swift */,
 				A3FF01892918F8EF00384211 /* apache.txt */,
+				4D6A9F0029A3A92E00D02522 /* wrappinghstack+license.txt */,
 				A3FF018D291ACFA500384211 /* WithdrawalView.swift */,
 			);
 			path = SettingViews;
@@ -784,6 +787,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4D6A9F0129A3A92F00D02522 /* wrappinghstack+license.txt in Resources */,
 				F90DEA5129327E62002140E2 /* Launch Screen.storyboard in Resources */,
 				F90DEA5029327E5D002140E2 /* Assets.xcassets in Resources */,
 				A3439B05293B48C20043E273 /* GoogleService-Info.plist in Resources */,

--- a/HappyAnding/HappyAnding/Views/MyPageViews/SettingViews/LicenseView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/SettingViews/LicenseView.swift
@@ -11,8 +11,8 @@ struct LicenseView: View {
     
     var body: some View {
         ScrollView {
-            LicenseCell(title: "[Firebase](https://github.com/firebase)", text: "License\nThe contents of this repository are licensed under the Apache License, version 2.0.\nYour use of Firebase is governed by the Terms of Service for Firebase Services.")
-            LicenseCell(title: "Apache License 2.0", text: readTextFile("apache.txt"))
+            LicenseCell(title: "[Firebase](https://github.com/firebase)", text: readTextFile("apache.txt"))
+            LicenseCell(title: "[Wrapping HStack](https://github.com/dkk/WrappingHStack)", text: readTextFile("wrappinghstack+license.txt"))
         }
         .background(Color.shortcutsZipBackground)
     }

--- a/HappyAnding/HappyAnding/Views/MyPageViews/SettingViews/wrappinghstack+license.txt
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/SettingViews/wrappinghstack+license.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Daniel Klöck
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutContentView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutContentView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import WrappingHStack
 
 struct ReadShortcutContentView: View {
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
@@ -45,21 +46,20 @@ struct ReadShortcutContentView: View {
                     .Body2()
                     .foregroundColor(Color.gray4)
                 
-                HStack(spacing: 8) {
-                    ForEach(content, id: \.self) { item in
-                        if Category.allCases.contains(where: { $0.rawValue == item }) {
-                            Text(Category(rawValue: item)?.translateName() ?? "")
-                                .Body2()
-                                .foregroundColor(Color.gray5)
-                        } else {
-                            Text(item)
-                                .Body2()
-                                .foregroundColor(Color.gray5)
-                        }
-                        if item != content.last {
-                            Text("|")
-                                .foregroundColor(Color.gray2)
-                        }
+                WrappingHStack(content, id: \.self, alignment: .leading, spacing: .constant(8), lineSpacing: 8) { item in
+                    if Category.allCases.contains(where: { $0.rawValue == item }) {
+                        Text(Category(rawValue: item)?.translateName() ?? "")
+                            .Body2()
+                            .padding(.trailing, 8)
+                            .foregroundColor(Color.gray5)
+                    } else {
+                        Text(item)
+                            .Body2()
+                            .padding(.trailing, 8)
+                            .foregroundColor(Color.gray5)
+                    }
+                    if item != content.last {
+                        Divider()
                     }
                 }
             }

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutContentView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutContentView.swift
@@ -15,36 +15,52 @@ struct ReadShortcutContentView: View {
     let profileImage: String = "person.crop.circle"
     
     var body: some View {
-            VStack(alignment: .leading, spacing: 24) {
-                ReusableTextView(title: TextLiteral.readShortcutContentViewDescription, contents: shortcut.description, contentsArray: nil)
-                
-                categoryView
-                
-                if !shortcut.requiredApp.isEmpty {
-                    ReusableTextView(title: TextLiteral.readShortcutContentViewRequiredApps, contents: nil, contentsArray: shortcut.requiredApp)
-                }
-                
-                if !shortcut.shortcutRequirements.isEmpty {
-                    ReusableTextView(title: TextLiteral.readShortcutContentViewRequirements, contents: shortcut.shortcutRequirements, contentsArray: nil)
-                }
-                Spacer()
-                    .frame(maxHeight: .infinity)
+        VStack(alignment: .leading, spacing: 24) {
+            ReusableTextView(title: TextLiteral.readShortcutContentViewDescription, contents: shortcut.description, contentsArray: nil)
+            
+            SplitList(title: TextLiteral.readShortcutContentViewCategory, content: shortcut.category)
+            
+            if !shortcut.requiredApp.isEmpty {
+                SplitList(title: TextLiteral.readShortcutContentViewRequiredApps, content: shortcut.requiredApp)
             }
-            .padding(.top, 16)
-            .frame(maxWidth: .infinity, alignment: .leading)
+            
+            if !shortcut.shortcutRequirements.isEmpty {
+                ReusableTextView(title: TextLiteral.readShortcutContentViewRequirements, contents: shortcut.shortcutRequirements, contentsArray: nil)
+            }
+            
+            Spacer()
+                .frame(maxHeight: .infinity)
+        }
+        .padding(.top, 16)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
     
-    var categoryView: some View {
-        VStack(alignment: .leading) {
-            Text(TextLiteral.readShortcutContentViewCategory)
-                .Body2()
-                .foregroundColor(.gray4)
-            
-            HStack(spacing: 8) {
-                ForEach(shortcut.category, id: \.self) { categoryName in
-                    Text(Category(rawValue: categoryName)?.translateName() ?? "")
-                        .Body2()
-                        .foregroundColor(.gray5)
+    private struct SplitList: View {
+        let title: String
+        let content: [String]
+        
+        var body: some View {
+            VStack(alignment: .leading) {
+                Text(title)
+                    .Body2()
+                    .foregroundColor(Color.gray4)
+                
+                HStack(spacing: 8) {
+                    ForEach(content, id: \.self) { item in
+                        if Category.allCases.contains(where: { $0.rawValue == item }) {
+                            Text(Category(rawValue: item)?.translateName() ?? "")
+                                .Body2()
+                                .foregroundColor(Color.gray5)
+                        } else {
+                            Text(item)
+                                .Body2()
+                                .foregroundColor(Color.gray5)
+                        }
+                        if item != content.last {
+                            Text("|")
+                                .foregroundColor(Color.gray2)
+                        }
+                    }
                 }
             }
         }
@@ -92,4 +108,3 @@ private struct ReusableTextView: View {
         .frame(height: self.heigth)
     }
 }
-

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutContentView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutContentView.swift
@@ -42,7 +42,7 @@ struct ReadShortcutContentView: View {
             
             HStack(spacing: 8) {
                 ForEach(shortcut.category, id: \.self) { categoryName in
-                    Text(Category(rawValue: categoryName)!.translateName())
+                    Text(Category(rawValue: categoryName)?.translateName() ?? "")
                         .Body2()
                         .foregroundColor(.gray5)
                 }


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #386 

## 구현/변경 사항
- ReadShortcutContentView에서 '카테고리'와 '단축어 사용에 필요한 앱' 레이아웃을 변경 및 통일했습니다.
- 컨텐츠의 길이에 맞춰 변화하는 여러줄의 hstack을 표현하기 위해 오픈소스를 사용했습니다. (사용된 패키지 - https://github.com/dkk/WrappingHStack) 이후에 제 코드로 수정해보겠습니다 ~!
- MIT license 파일 추가했습니다.

## 스크린샷

|iPhone SE|iPhone 14|iPhone 14 Pro Max|
|:---:|:---:|:---:|
|![Simulator Screen Shot - iPhone SE (3rd generation) - 2023-02-20 at 22 54 23](https://user-images.githubusercontent.com/76623853/220126644-95ef77ce-c720-4a1a-98bf-d11c72258383.png)|![Simulator Screen Shot - iPhone 14 - 2023-02-20 at 18 23 47](https://user-images.githubusercontent.com/76623853/220126510-4cc25ed5-719f-4adc-b176-229ce6053818.png)|![Simulator Screen Shot - iPhone 14 Pro Max - 2023-02-20 at 22 55 51](https://user-images.githubusercontent.com/76623853/220127024-28174ee3-e87a-4c6d-9864-d829a0c96a8d.png)|
