### PR TITLE
[Feat] 버전정보 처리방법 변경

### DIFF
--- a/HappyAnding/HappyAnding/Views/MyPageViews/SettingView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/SettingView.swift
@@ -38,29 +38,27 @@ struct SettingView: View {
             
             /*
              // TODO: 알림 기능
-            Text("알림 설정")
-                .padding(.top, 16)
-                .padding(.bottom, 12)
-            
-            //TODO: 화면 연결 필요
-            NavigationLink(destination: EmptyView()) {
-                SettingCell(title: "알림 및 소리")
-            }
-            */
+             Text("알림 설정")
+             .padding(.top, 16)
+             .padding(.bottom, 12)
+             
+             //TODO: 화면 연결 필요
+             NavigationLink(destination: EmptyView()) {
+             SettingCell(title: "알림 및 소리")
+             }
+             */
             
             // MARK: - 버전 정보
-            SettingCell(title: TextLiteral.settingViewVersion, version: TextLiteral.settingViewVersionNumber)
+            SettingCell(title: TextLiteral.settingViewVersion, version: getAppVersion())
             
             
             // MARK: - 오픈소스 라이선스
-            
             NavigationLink(value: NavigationLisence.first) {
                 SettingCell(title: TextLiteral.settingViewOpensourceLicense)
             }
             
             
             // MARK: - 개인정보처리방침 모달뷰
-            
             Button {
                 self.isTappedPrivacyButton.toggle()
             } label: {
@@ -70,12 +68,11 @@ struct SettingView: View {
             
             // MARK: - 개발팀에 관하여 버튼
             //TODO: Halogen의 꿈. 추후 스프린트 시 완성되면 적용 예정
-//            NavigationLink(destination: AboutTeamView()) {
-//                SettingCell(title: "개발팀에 관하여")
-//            }
+            //            NavigationLink(destination: AboutTeamView()) {
+            //                SettingCell(title: "개발팀에 관하여")
+            //            }
             
             // MARK: - 개발자에게 연락하기 버튼
-            
             Button(action : {
                 if MFMailComposeViewController.canSendMail() {
                     self.isShowingMailView.toggle()
@@ -84,14 +81,12 @@ struct SettingView: View {
                 if MFMailComposeViewController.canSendMail() {
                     SettingCell(title: TextLiteral.settingViewContact)
                 }
-                //못 보내는 기기일 때 뜨는 것. 아예 지워도 될 것 같긴 한데 어떻게할까요. 못 보내는 기기의 기준이 확실치 않아서 일단 이렇게 둠.
                 else {
                     SettingCell(title: TextLiteral.settingViewContactMessage)
                         .multilineTextAlignment(.leading)
                 }
             }
             
-            //로그인없이 둘러보기 여부에 따라 보여지는 버튼 다르게 표시
             if useWithoutSignIn {
                 //MARK: - 로그인없이 둘러보기 시 로그인 버튼
                 Button {
@@ -128,21 +123,19 @@ struct SettingView: View {
                     SettingCell(title: TextLiteral.settingViewWithdrawal)
                 }
             }
-            
             Spacer()
         }
         .sheet(isPresented: $isShowingMailView) {
             MailView(isShowing: self.$isShowingMailView, result: self.$result)
         }
-        
         .sheet(isPresented: self.$isTappedPrivacyButton) {
             ZStack {
                 PrivacyPolicyView(viewModel: webViewModel,
                                   isTappedPrivacyButton: $isTappedPrivacyButton,
                                   url: TextLiteral.settingViewPrivacyPolicyURL)
-                    .environmentObject(webViewModel)
-                    .presentationDetents([.large])
-                    .presentationDragIndicator(.visible)
+                .environmentObject(webViewModel)
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
                 if webViewModel.isLoading {
                     ProgressView()
                 }
@@ -175,6 +168,15 @@ struct SettingView: View {
             print(error.localizedDescription)
         }
     }
+    
+    private func getAppVersion() -> String {
+        if let info: [String: Any] = Bundle.main.infoDictionary,
+           let appVersion: String
+            = info["CFBundleShortVersionString"] as? String {
+            return appVersion
+        }
+        return "nil"
+    }
 }
 struct SettingCell: View {
     var title: String
@@ -190,7 +192,6 @@ struct SettingCell: View {
         .padding(.horizontal, 12)
         .padding(.vertical, 16)
     }
-    
 }
 
 struct SettingView_Previews: PreviewProvider {

--- a/HappyAnding/HappyAnding/Views/MyPageViews/SettingView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/SettingView.swift
@@ -55,9 +55,8 @@ struct SettingView: View {
             
             
             // MARK: - 오픈소스 라이선스
-            NavigationLink(value: NavigationLisence.first) {
-                SettingCell(title: TextLiteral.settingViewOpensourceLicense)
-            }
+            SettingCell(title: TextLiteral.settingViewOpensourceLicense)
+                .navigationLinkRouter(data: NavigationLisence.first)
             
             
             // MARK: - 개인정보처리방침 모달뷰

--- a/HappyAnding/HappyAnding/Views/MyPageViews/SettingView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/SettingView.swift
@@ -49,7 +49,9 @@ struct SettingView: View {
              */
             
             // MARK: - 버전 정보
-            SettingCell(title: TextLiteral.settingViewVersion, version: getAppVersion())
+            if !getAppVersion().isEmpty {
+                SettingCell(title: TextLiteral.settingViewVersion, version: getAppVersion())
+            }
             
             
             // MARK: - 오픈소스 라이선스
@@ -170,12 +172,9 @@ struct SettingView: View {
     }
     
     private func getAppVersion() -> String {
-        if let info: [String: Any] = Bundle.main.infoDictionary,
-           let appVersion: String
-            = info["CFBundleShortVersionString"] as? String {
-            return appVersion
-        }
-        return "nil"
+        guard let info = Bundle.main.infoDictionary,
+              let appVersion = info["CFBundleShortVersionString"] as? String else { return "" }
+        return appVersion
     }
 }
 struct SettingCell: View {


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #403

## 구현/변경 사항
- 기존에는 수동으로 관리되던 SettingView의 버전 정보를 Bundle에서 가져와서 보여주는 방빅으로 변경했습니다.
- SettingView에 `getAppVersion` 함수에서 Bundle에 있는 app Version을 가져와 표시합니다.
- 디자인적인 변경사항은 없습니다.
- 코드리뷰 후 추가적인 변경사항
    - 오류로 인해 버전정보를 가져오지 못할 경우 버전정보 항목을 보이지 않게 처리했습니다.