### PR TITLE
[Fix] 단축어 버전 정보 화면의 레이아웃 오류 해결

### DIFF
--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutVersionView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutVersionView.swift
@@ -19,20 +19,19 @@ struct ReadShortcutVersionView: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-        if shortcut.updateDescription.count == 1 {
-            Text(TextLiteral.readShortcutVersionViewNoUpdates)
-                .Body2()
-                .foregroundColor(.gray4)
-                .padding(.top, 16)
-            
-            Spacer()
-                .frame(maxHeight: .infinity)
-            
-        } else {
-            Text(TextLiteral.readShortcutVersionViewUpdateContent)
+            if shortcut.updateDescription.count == 1 {
+                Text(TextLiteral.readShortcutVersionViewNoUpdates)
                     .Body2()
                     .foregroundColor(.gray4)
-            
+                    .padding(.top, 16)
+                
+                Spacer()
+                    .frame(maxHeight: .infinity)
+                
+            } else {
+                Text(TextLiteral.readShortcutVersionViewUpdateContent)
+                    .Body2()
+                    .foregroundColor(.gray4)
                 ForEach(Array(zip(shortcut.updateDescription, shortcut.updateDescription.indices)), id: \.0) { data, index in
                     VStack(alignment: .leading, spacing: 12) {
                         HStack {
@@ -75,7 +74,6 @@ struct ReadShortcutVersionView: View {
                     }
                 }
                 Spacer()
-                    .frame(maxHeight: .infinity)
             }
         }
         .padding(.top, 16)


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #417

## 구현/변경 사항
- ReadShortcutVersionView에서 버전 정보 텍스트가 한 줄을 넘어갈 경우 잘리는 레이아웃 오류를 해결했습니다.

## 원인
- 버전 정보를 보여주는 셀 아래 Spacer의 속성인 `frame(maxHeight: .infiinity)가 원인이었습니다.
- 해당 Spacer는 정보가 위쪽에 배치될 수 있도록 하는 역할을 수행하는데, 여기에 최대높이가 .infinity로 설정되면서 해당 이슈가 나타났습니다.
- Spacer의 최대 높이 설정으로 인해 버전 정보 셀의 설명 텍스트의 높이가 최소한으로 줄어버려(1줄만 표시될 수 있도록) 2줄인 경우에는 표시가 온전하게 되지 않은 것으로 보입니다.
- 그런데 아무런 frame 속성이 붙지 않은 Spacer도 자신의 높이를 최대로 세팅하는 것으로 알고 있는데, 왜 .infinity 속성을 붙여 주었을 때만 해당 이슈가 나타나는지는 파악하지 못했습니다.

## 스크린샷

|개선 전|개선 후|
|:---:|:---:|
|![image](https://user-images.githubusercontent.com/94854258/222900457-4ae7d2a3-2b9f-4e5a-befc-f962988208f7.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-03-04 at 21 11 44](https://user-images.githubusercontent.com/94854258/222900477-e1e4b63f-bccd-419f-bb41-ae6a52acaec0.png)|


