### PR TITLE
[Fix] #426 - 네비게이션 오류 해결

### DIFF
--- a/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
+++ b/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
@@ -1193,7 +1193,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.happyanding.HappyAnding;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = ShortcutsZipProfile_Dev_20230301;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = ShortcutsZipProfile_Dev_20230308;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -1345,7 +1345,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.happyanding.HappyAnding.ShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = ShortcutsZipShareExtProfile_Dev_20230301;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = ShortcutsZipShareExtProfile_Dev_20230308;
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";

--- a/HappyAnding/HappyAnding/Extensions/View/View+Navigation.swift
+++ b/HappyAnding/HappyAnding/Extensions/View/View+Navigation.swift
@@ -46,11 +46,34 @@ extension View {
         }
     }
     
+    @ViewBuilder
+    func navigationLinkRouter<T: Hashable>(data: T, isPresented: Binding<Bool>) -> some View {
+        if #available(iOS 16.1, *) {
+            NavigationLink(value: data) {
+                self
+            }
+        } else {
+            NavigationLink(destination: getDestination(data: data, isPresented: isPresented)) {
+                self
+            }
+        }
+    }
+    
     
     /**
      Naivagion View의 Destination 확인을 위해 필요한 View Builder입니다.
      새로운 뷰가 추가되면, Stack에서 사용하는 데이터 타입과 목적지를 넣어주세요
      */
+    @ViewBuilder
+    func getDestination<T: Hashable>(data: T, isPresented: Binding<Bool>) -> some View {
+        switch data {
+        case is WriteCurationInfoType:
+            WriteCurationInfoView(data: data as! WriteCurationInfoType, isWriting: isPresented)
+        default:
+            EmptyView()
+        }
+    }
+    
     @ViewBuilder
     func getDestination<T: Hashable>(data: T) -> some View {
         switch data {

--- a/HappyAnding/HappyAnding/Model/NavigationStackModel.swift
+++ b/HappyAnding/HappyAnding/Model/NavigationStackModel.swift
@@ -55,6 +55,15 @@ struct NavigationListCategoryShortcutType: Identifiable, Hashable {
     var navigationParentView: NavigationParentView
 }
 
+struct WriteCurationInfoType: Identifiable, Hashable {
+    
+    var id = UUID().uuidString
+    
+    var curation: Curation
+    var deletedShortcutCells: [ShortcutCellModel]
+    var isEdit: Bool
+}
+
 enum NavigationSearch: Hashable, Equatable {
     case first
 }

--- a/HappyAnding/HappyAnding/Views/Components/UserCurationListView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/UserCurationListView.swift
@@ -71,13 +71,18 @@ struct UserCurationListView: View {
         .fullScreenCover(isPresented: $isWriting) {
             NavigationRouter(content: writeCurationView,
                              path: $writeCurationNavigation.navigationPath)
+            .environmentObject(writeCurationNavigation)
         }
     }
     
     @ViewBuilder
     private func writeCurationView() -> some View {
-        WriteCurationSetView(isWriting: $isWriting, isEdit: false)
-            .environmentObject(writeCurationNavigation)
+        WriteCurationSetView(isWriting: $isWriting
+                             , isEdit: false
+        )
+        .navigationDestination(for: WriteCurationInfoType.self) { data in
+            WriteCurationInfoView(data: data, isWriting: $isWriting)
+        }
     }
 }
 

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
@@ -117,12 +117,16 @@ struct ReadUserCurationView: View {
             }
         }
     }
-    
+     
     @ViewBuilder
     private func editView() -> some View {
         WriteCurationSetView(isWriting: $isWriting,
-                             curation: shortcutsZipViewModel.userCurations[index],
-                             isEdit: true)
+                             curation: shortcutsZipViewModel.userCurations[index]
+                             ,isEdit: true
+        )
+        .navigationDestination(for: WriteCurationInfoType.self) { data in
+            WriteCurationInfoView(data: data, isWriting: $isWriting)
+        }
     }
 }
 

--- a/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationInfoView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationInfoView.swift
@@ -12,9 +12,8 @@ struct WriteCurationInfoView: View {
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
     @EnvironmentObject var writeCurationNavigation: WriteCurationNavigation
     
-    @Binding var curation: Curation
+    @State var data: WriteCurationInfoType
     @Binding var isWriting: Bool
-    @Binding var deletedShortcutCells: [ShortcutCellModel]
     
     @State var isValidTitle = false
     @State var isValidDescription = false
@@ -22,8 +21,6 @@ struct WriteCurationInfoView: View {
     private var isIncomplete: Bool {
         !(isValidTitle && isValidDescription)
     }
-    
-    let isEdit: Bool
     
     var body: some View {
         VStack(spacing: 24) {
@@ -35,7 +32,7 @@ struct WriteCurationInfoView: View {
                                      placeholder: TextLiteral.writeCurationInfoViewNamePlaceholder,
                                      lengthLimit: 20,
                                      isDownloadLinkTextField: false,
-                                     content: $curation.title,
+                                     content: $data.curation.title,
                                      isValid: $isValidTitle)
             .padding(.top, 12)
             
@@ -46,8 +43,8 @@ struct WriteCurationInfoView: View {
                                      lengthLimit: 40,
                                      isDownloadLinkTextField: false,
                                      inputHeight: 72,
-                                     content: Binding(get: {curation.subtitle},
-                                                      set: {curation.subtitle = $0}),
+                                     content: Binding(get: {data.curation.subtitle},
+                                                      set: {data.curation.subtitle = $0}),
                                      isValid: $isValidDescription)
             
             Spacer()
@@ -57,10 +54,12 @@ struct WriteCurationInfoView: View {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button {
                     
-                    shortcutsZipViewModel.addCuration(curation: curation, isEdit: isEdit, deletedShortcutCells: deletedShortcutCells)
+                    shortcutsZipViewModel.addCuration(curation: data.curation, isEdit: data.isEdit, deletedShortcutCells: data.deletedShortcutCells)
                     
                     self.isWriting.toggle()
-                    writeCurationNavigation.navigationPath = .init()
+                    if #available(iOS 16.1, *) {
+                        writeCurationNavigation.navigationPath = .init()
+                    }
                 } label: {
                     Text(TextLiteral.upload)
                         .shortcutsZipHeadline()
@@ -70,7 +69,7 @@ struct WriteCurationInfoView: View {
             }
         }
         .background(Color.shortcutsZipBackground)
-        .navigationBarTitle(isEdit ? TextLiteral.writeCurationInfoViewEdit : TextLiteral.wrietCurationInfoViewPost)
+        .navigationBarTitle(data.isEdit ? TextLiteral.writeCurationInfoViewEdit : TextLiteral.wrietCurationInfoViewPost)
         .onAppear(perform : UIApplication.shared.hideKeyboard)
     }
 }

--- a/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationSetView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationSetView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct WriteCurationSetView: View {
     
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
+    @EnvironmentObject var writeCurationNavigation: WriteCurationNavigation
     
     @Binding var isWriting: Bool
     
@@ -67,17 +68,11 @@ struct WriteCurationSetView: View {
             
             ToolbarItem(placement: .navigationBarTrailing) {
                 Text(TextLiteral.next)
+                    .navigationLinkRouter(data: WriteCurationInfoType(curation: curation, deletedShortcutCells: deletedShortcutCells, isEdit: isEdit), isPresented: $isWriting)
                     .shortcutsZipHeadline()
                     .foregroundColor(curation.shortcuts.isEmpty ? .shortcutsZipPrimary.opacity(0.3) : .shortcutsZipPrimary)
-                    .navigationLinkRouter(data: Float(0.0))
                     .disabled(curation.shortcuts.isEmpty)
             }
-        }
-        .navigationDestination(for: Float.self) { isEdit in
-            WriteCurationInfoView(curation: $curation,
-                                  isWriting: self.$isWriting,
-                                  deletedShortcutCells: $deletedShortcutCells,
-                                  isEdit: self.isEdit)
         }
     }
     
@@ -131,7 +126,6 @@ struct WriteCurationSetView: View {
 
 struct WriteCurationSetView_Previews: PreviewProvider {
     static var previews: some View {
-        WriteCurationSetView(isWriting: .constant(false),
-                             isEdit: false)
+        WriteCurationSetView(isWriting: .constant(false), isEdit: false)
     }
 }


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #426

## 문제가 일어난 이유와 해결 방법
- iOS 16.1부터 추천 모음집 작성 시 앱이 꺼졌던 이유는 Navigation Stack Path 모델을 전달해주지 않았기 때문이었습니다.
- Navigation Path 초기화의 경우 iOS 16.1부터 작동하도록 수정했습니다.
- iOS 16.0애서 추천 모음집 작성 시 빈 화면이 나왔던 이유는 Navigation Router에 해당 Data 정보가 없었기 때문입니다.
- 현재 추천모음집이 Full Screen Cover로 presented라는 바인딩 변수가 필요합니다. 하지만 저희 프로젝트의 경우 Navigation Router를 통해 데이터를 한 번에 관리하고 있어서 함수를 오버로딩 하여 문제를 해결했습니다.
- 이와 같이 데이터가 누락되는 문제를 해결하기 위해서는 Navigation Data 전체를 다루는 열거형으로 정의하는 것이 좋을 것 같습니다

## 구현/변경 사항
- 추천 모음집 작성시 앱이 종료되는 문제 (iOS 16.1부터)해결
- 추천 모음집 작성시 빈 페이지가 나오는 문제 (iOS 16) 해결

## 스크린샷, iOS 16.0 (Navigation View)

https://user-images.githubusercontent.com/68676844/224933852-146b6e75-9610-4700-8d64-cd690624ce60.mov

## 스크린샷2, iOS 16.1 * (Navigation Stack) 

https://user-images.githubusercontent.com/68676844/224934035-bd0a7207-edde-4faa-b18a-2d0d77220be7.mov

