### PR TITLE
[Feat] 닉네임 수정 버튼 위치 변경 등의 UI 변경사항 (Apple Feedback)

### DIFF
--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ListCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ListCurationView.swift
@@ -28,7 +28,7 @@ struct ListCurationView: View {
     var body: some View {
         let titleString = data.type == .personalCuration ? (shortcutsZipViewModel.userInfo?.nickname ?? "") : ""
         if data.curation.count == 0 {
-            Text("아직 \(titleString)\(data.type.rawValue)이(가) 없어요")
+            Text("아직 \(titleString)\(data.type.rawValue)\(titleString.contains("단축어") ? "가" : "이") 없어요")
                 .shortcutsZipBody2()
                 .foregroundColor(Color.gray4)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/HappyAnding/HappyAnding/Views/MyPageViews/MyPageView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/MyPageView.swift
@@ -33,18 +33,10 @@ struct MyPageView: View {
                             .id(333)
                     }
                     
-                    HStack {
-                        Text(shortcutsZipViewModel.userInfo?.nickname ?? TextLiteral.defaultUser)
-                            .shortcutsZipTitle1()
-                            .foregroundColor(.gray5)
-                        
-                        if !useWithoutSignIn {
-                            Image(systemName: "square.and.pencil")
-                                .mediumIcon()
-                                .foregroundColor(.gray4)
-                                .navigationLinkRouter(data: NavigationNicknameView.first)
-                        }
-                    }
+                    Text(shortcutsZipViewModel.userInfo?.nickname ?? TextLiteral.defaultUser)
+                        .shortcutsZipTitle1()
+                        .foregroundColor(.gray5)
+                    
                     Spacer()
                 }
                 .frame(maxWidth: .infinity)

--- a/HappyAnding/HappyAnding/Views/MyPageViews/SettingView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/SettingView.swift
@@ -20,6 +20,7 @@ struct SettingView: View {
     @AppStorage("useWithoutSignIn") var useWithoutSignIn = false
     
     @State var result: Result<MFMailComposeResult, Error>? = nil
+    @State var isTappedEditNicknameButton = false
     @State var isTappedUserGradeButton = false
     @State var isShowingMailView = false
     @State var isTappedLogOutButton = false
@@ -27,111 +28,131 @@ struct SettingView: View {
     @State var isTappedPrivacyButton = false
     
     var body: some View {
-        VStack(alignment: .leading) {
+        ScrollView() {
             
             // MARK: - 버전 정보
             if !getAppVersion().isEmpty {
                 SettingCell(title: TextLiteral.settingViewVersion, version: getAppVersion())
             }
             
-            divider
-            
-            //MARK: - 단축어 작성 등급
-            Button {
-                isTappedUserGradeButton = true
-            } label: {
-                FunctionCell(title: TextLiteral.shortcutGradeTitle, tag: TextLiteral.announcementTag)
-            }
-            
-            /*
-             // TODO: 알림 기능
-             Text("알림 설정")
-             .padding(.top, 16)
-             .padding(.bottom, 12)
-             
-             //TODO: 화면 연결 필요
-             NavigationLink(destination: EmptyView()) {
-             SettingCell(title: "알림 및 소리")
-             }
-             */
-            
-            divider
-            
-            // MARK: - 오픈소스 라이선스
-            SettingCell(title: TextLiteral.settingViewOpensourceLicense)
-                .navigationLinkRouter(data: NavigationLisence.first)
-            
-            
-            // MARK: - 개인정보처리방침 모달뷰
-            Button {
-                self.isTappedPrivacyButton.toggle()
-            } label: {
-                SettingCell(title: TextLiteral.settingViewPrivacyPolicy)
-            }
-            
-            
-            // MARK: - 개발팀에 관하여 버튼
-            //TODO: Halogen의 꿈. 추후 스프린트 시 완성되면 적용 예정
-            //            NavigationLink(destination: AboutTeamView()) {
-            //                SettingCell(title: "개발팀에 관하여")
-            //            }
-            
-            
-            // MARK: - 개발자에게 연락하기 버튼
-            Button(action : {
-                if MFMailComposeViewController.canSendMail() {
-                    self.isShowingMailView.toggle()
-                }
-            }) {
-                if MFMailComposeViewController.canSendMail() {
-                    SettingCell(title: TextLiteral.settingViewContact)
-                }
-                else {
-                    SettingCell(title: TextLiteral.settingViewContactMessage)
-                        .multilineTextAlignment(.leading)
-                }
-            }
-            
-            divider
-            
-            if useWithoutSignIn {
-                //MARK: - 로그인없이 둘러보기 시 로그인 버튼
+            if !useWithoutSignIn {
+                divider
+                
                 Button {
-                    useWithoutSignIn = false
+                    isTappedEditNicknameButton = true
                 } label: {
-                    SettingCell(title: TextLiteral.settingViewLogin)
+                    SettingCell(title: "닉네임 수정")
                 }
-            } else {
-                // MARK: - 로그아웃 버튼
+                
+                /*
+                 // TODO: 알림 기능
+                 Text("알림 설정")
+                 .padding(.top, 16)
+                 .padding(.bottom, 12)
+                 
+                 //TODO: 화면 연결 필요
+                 NavigationLink(destination: EmptyView()) {
+                 SettingCell(title: "알림 및 소리")
+                 }
+                 */
+            }
+            
+            divider
+            
+            Group {
+                //MARK: - 단축어 작성 등급
                 Button {
-                    self.isTappedLogOutButton.toggle()
+                    isTappedUserGradeButton = true
                 } label: {
-                    SettingCell(title: TextLiteral.settingViewLogout)
+                    FunctionCell(title: TextLiteral.shortcutGradeTitle, tag: TextLiteral.announcementTag)
                 }
-                .alert(TextLiteral.settingViewLogout, isPresented: $isTappedLogOutButton) {
-                    Button(role: .cancel) {
-                        
+            }
+            
+            divider
+            
+            Group {
+                // MARK: - 오픈소스 라이선스
+                SettingCell(title: TextLiteral.settingViewOpensourceLicense)
+                    .navigationLinkRouter(data: NavigationLisence.first)
+                
+                
+                // MARK: - 개인정보처리방침 모달뷰
+                Button {
+                    self.isTappedPrivacyButton.toggle()
+                } label: {
+                    SettingCell(title: TextLiteral.settingViewPrivacyPolicy)
+                }
+                
+                
+                // MARK: - 개발팀에 관하여 버튼
+                //TODO: Halogen의 꿈. 추후 스프린트 시 완성되면 적용 예정
+                //            NavigationLink(destination: AboutTeamView()) {
+                //                SettingCell(title: "개발팀에 관하여")
+                //            }
+                
+                
+                // MARK: - 개발자에게 연락하기 버튼
+                Button(action : {
+                    if MFMailComposeViewController.canSendMail() {
+                        self.isShowingMailView.toggle()
+                    }
+                }) {
+                    if MFMailComposeViewController.canSendMail() {
+                        SettingCell(title: TextLiteral.settingViewContact)
+                    }
+                    else {
+                        SettingCell(title: TextLiteral.settingViewContactMessage)
+                            .multilineTextAlignment(.leading)
+                    }
+                }
+            }
+            
+            divider
+            
+            Group {
+                if useWithoutSignIn {
+                    //MARK: - 로그인없이 둘러보기 시 로그인 버튼
+                    Button {
+                        useWithoutSignIn = false
                     } label: {
-                        Text(TextLiteral.cancel)
+                        SettingCell(title: TextLiteral.settingViewLogin)
+                    }
+                } else {
+                    // MARK: - 로그아웃 버튼
+                    Button {
+                        self.isTappedLogOutButton.toggle()
+                    } label: {
+                        SettingCell(title: TextLiteral.settingViewLogout)
+                    }
+                    .alert(TextLiteral.settingViewLogout, isPresented: $isTappedLogOutButton) {
+                        Button(role: .cancel) {
+                            
+                        } label: {
+                            Text(TextLiteral.cancel)
+                        }
+                        
+                        Button(role: .destructive) {
+                            logOut()
+                        } label: {
+                            Text(TextLiteral.settingViewLogout)
+                        }
+                    } message: {
+                        Text(TextLiteral.settingViewLogoutMessage)
                     }
                     
-                    Button(role: .destructive) {
-                        logOut()
-                    } label: {
-                        Text(TextLiteral.settingViewLogout)
-                    }
-                } message: {
-                    Text(TextLiteral.settingViewLogoutMessage)
+                    // MARK: - 회원탈퇴 버튼
+                    SettingCell(title: TextLiteral.settingViewWithdrawal)
+                        .navigationLinkRouter(data: NavigationWithdrawal.first)
                 }
-                
-                
-                // MARK: - 회원탈퇴 버튼
-                SettingCell(title: TextLiteral.settingViewWithdrawal)
-                    .navigationLinkRouter(data: NavigationWithdrawal.first)
             }
+            
             Spacer()
         }
-        
+        .sheet(isPresented: $isTappedEditNicknameButton) {
+            EditNicknameView()
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
+        }
         .sheet(isPresented: $isTappedUserGradeButton) {
             AboutShortcutGradeView()
                 .presentationDetents([.large])


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #423 

## 구현/변경 사항
- Apple로부터 디자인 피드백을 받은 사항을 반영했습니다.
- 프로필 탭 닉네임의 오른쪽에 위치해 있던 닉네임 수정 버튼을 설정 페이지 안쪽으로 이동시켰습니다.
    - 사용자가 설정히는 항목이기 때문에 위치는 버전 정보 바로 아래, 최상단으로 설정했습니다.
    - 항목이 늘어남에 따라 VStack에서 ScrollView로 변경해 화면보다 항목이 길어질 경우를 대비했습니다.
    - 현재 해당 ScrollView 내부에 컴포넌트가 10개 이상 사용됨에 따라 컴파일 에러가 발생했습니다. 같은 종류의 컴포넌트들을 Group으로 묶어 해결했는데, 더 좋은 방법이 있다면 제안해주시면 감사하겠습니다!
- 닉네임 수정 뷰가 나타나는 방식을 Navigation에서 Modal로 변경했습니다.
    - 이에 따라 NavigationRouter에서 EditNicknameView 관련 코드를 삭제해도 무방할 것 같은데 괜찮을까요?
- 작성한 단축어 또는 추천 모음집이 없을 때 나타나는 텍스트의 조사를 '이(가)'에서 나타나는 텍스트에 맞게 자연스럽게 나타날 수 있도록 수정했습니다. 다음과 같이 표시됩니다.
    - 아직 내가 작성한 추천 모음집이(가) 없어요 -> 아직 내가 작성한 추천 모음집이 없어요
    - 텍스트 안에 '단축어' 가 있으면 '가' 를, 없으면(추천 모음집) '이' 를 붙입니다.
    - 현재 해당 뷰에 들어가는 텍스트가 단추축어, 추천 모음집 둘 중  하나로 끝나기 때문에 이렇게 처리해도 문제가 되지 않을 것으로 생각했습니다.
    - 이런 식으로 조사를 처리하는 경우가 추후 앱에서 많이 사용될 것 같다면, 텍스트의 마지막 종성을 인식해 자동으로 조사를 붙이는 extension을 만들어 봐도 재미있을 것 같습니다!

## 스크린샷

|프로필 탭 변경|설정 페이지 변경|텍스트 변경|
|:---:|:---:|:---:|
|![Simulator Screen Shot - iPhone 14 Pro - 2023-03-15 at 19 48 18](https://user-images.githubusercontent.com/94854258/225286963-3e1e857a-2161-4b74-a0c0-7836cd798a79.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-03-15 at 19 48 24](https://user-images.githubusercontent.com/94854258/225287047-0c7f4d61-f6f2-436c-bca8-611f2255775b.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-03-15 at 19 48 34](https://user-images.githubusercontent.com/94854258/225287163-1680daa6-72be-4783-a366-8d9c8dd3d5c3.png)|
