### PR TITLE
[Feat] #431 - 검색화면 자동 키보드 기능

### DIFF
--- a/HappyAnding/HappyAnding/Views/SearchView.swift
+++ b/HappyAnding/HappyAnding/Views/SearchView.swift
@@ -13,6 +13,8 @@ struct SearchView: View {
     @Environment(\.dismissSearch) private var dismissSearch
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
     
+    @FocusState private var isFocused: Bool
+    
     @State var keywords: Keyword = Keyword(keyword: [String]())
     @State var isSearched: Bool = false
     @State var searchText: String = ""
@@ -20,6 +22,9 @@ struct SearchView: View {
     
     var body: some View {
         VStack {
+            
+            searchTextfield
+            
             if !isSearched {
                 recommendKeyword
                 Spacer()
@@ -48,7 +53,6 @@ struct SearchView: View {
         .onAppear() {
             self.keywords = shortcutsZipViewModel.keywords
         }
-        .searchable(text: $searchText, prompt: TextLiteral.searchViewPrompt)
         .onSubmit(of: .search, runSearch)
         .onChange(of: searchText) { _ in
             didChangedSearchText()
@@ -68,11 +72,35 @@ struct SearchView: View {
         isSearched = true
     }
     
+    var searchTextfield: some View {
+        HStack {
+            Image(systemName: "magnifyingglass")
+                .foregroundColor(.gray5)
+            TextField(TextLiteral.searchViewPrompt, text: $searchText)
+                .shortcutsZipBody1()
+                .accentColor(.gray5)
+                .disableAutocorrection(true)
+                .onChange(of: searchText) { _ in
+                    // TODO: 수정 필요
+                    didChangedSearchText()
+                }
+                .focused($isFocused)
+                .task {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                        isFocused = true
+                    }
+                }
+        }
+        .padding(11)
+        .background(Color.gray1)
+        .cornerRadius(12)
+        .padding(EdgeInsets(top: 12, leading: 16, bottom: 20, trailing: 16))
+    }
+    
     var recommendKeyword: some View {
         VStack(alignment: .leading) {
             Text(TextLiteral.searchViewRecommendedKeyword)
                 .padding(.leading, 16)
-                .padding(.top, 12)
                 .shortcutsZipHeadline()
             
             ScrollView(.horizontal) {


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #431 

## 구현/변경 사항
- 검색화면 검색창을 searchable에서 커스텀 검색창으로 변경함
- FocusState를 사용하여 키보드 올라오도록 설정
- 커스텀 검색창으로 변경하며 피그마 기준으로 디자인을 적용하여 약간의 차이가 존재합니다.
- 취소버튼이 추가되었습니다. -> 키보드 내리는 용도
- FocusState자체로는 값이 변경되는 것을 감지할 수 없어 취소버튼이 나타나고 사라질 때 애니메이션을 주기위한 isKeyboardFocused 변수가 하나 더 사용되었습니다.

- searchable을 활용할 수 있는지 좀 더 찾아봤는데 아직까지는 활용이 불가능한 것 같습니다.

## 스크린샷

|기존|
|:---:|
|<img src="https://user-images.githubusercontent.com/41153398/232040789-03504837-ee67-461e-b0d4-74bab47fa716.png" width=300>|

- 변경 후

https://user-images.githubusercontent.com/41153398/232045297-d64ed76c-a90e-4896-b541-02f01c1c1601.mp4


### To Reviewer
- 저희 원래 그냥 화면 터치했을 때 키보드 내려가는 기능이 없었나요..?
