### PR TITLE
[Feat] #425 ShowProfileView에서의 badge 회전 추가 (Apple Feedback)

### DIFF
--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ShowProfileView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ShowProfileView.swift
@@ -17,6 +17,8 @@ struct ShowProfileView: View {
     @State var curations: [Curation] = []
     @State var currentTab: Int = 0
     
+    @State private var animationAmount = 0.0
+    
     @Namespace var namespace
     
     private let tabItems = [TextLiteral.showProfileViewShortcutTabTitle, TextLiteral.showProfileViewCurationTabTitle]
@@ -29,13 +31,22 @@ struct ShowProfileView: View {
                 
                 //MARK: 프로필이미지 및 닉네임
                 VStack(spacing: 8) {
-                    ZStack(alignment: .center) {
-                        Circle()
-                            .frame(width: 72, height: 72)
-                            .foregroundColor(.gray1)
-                        shortcutsZipViewModel.fetchShortcutGradeImage(isBig: true, shortcutGrade: shortcutsZipViewModel.checkShortcutGrade(userID: data.userInfo?.id ?? ""))
-                            .font(.system(size: 72, weight: .medium))
-                            .foregroundColor(.gray3)
+                    Button {
+                        withAnimation(.interpolatingSpring(stiffness: 10, damping: 3)) {
+                            self.animationAmount += 360
+                        }
+                    } label: {
+                        ZStack(alignment: .center) {
+                            Circle()
+                                .frame(width: 72, height: 72)
+                                .foregroundColor(.gray1)
+                            shortcutsZipViewModel.fetchShortcutGradeImage(isBig: true, shortcutGrade: shortcutsZipViewModel.checkShortcutGrade(userID: data.userInfo?.id ?? ""))
+                                .font(.system(size: 72, weight: .medium))
+                                .foregroundColor(.gray3)
+                                .rotation3DEffect(
+                                    .degrees(animationAmount), axis: (x: 0.0, y: 1.0, z: 0.0))
+                        }
+                        .clipShape(Circle())
                     }
                     Text(data.userInfo?.nickname ?? TextLiteral.defaultUser)
                         .shortcutsZipTitle1()
@@ -60,6 +71,9 @@ struct ShowProfileView: View {
         .onAppear {
             shortcuts = shortcutsZipViewModel.allShortcuts.filter { $0.author == self.data.userInfo?.id }
             curations = shortcutsZipViewModel.fetchCurationByAuthor(author: data.userInfo?.id ?? "")
+            withAnimation(.interpolatingSpring(stiffness: 10, damping: 3)) {
+                self.animationAmount += 360
+            }
         }
     }
 }

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ShowProfileView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ShowProfileView.swift
@@ -41,12 +41,9 @@ struct ShowProfileView: View {
                                 .frame(width: 72, height: 72)
                                 .foregroundColor(.gray1)
                             shortcutsZipViewModel.fetchShortcutGradeImage(isBig: true, shortcutGrade: shortcutsZipViewModel.checkShortcutGrade(userID: data.userInfo?.id ?? ""))
-                                .font(.system(size: 72, weight: .medium))
-                                .foregroundColor(.gray3)
                                 .rotation3DEffect(
                                     .degrees(animationAmount), axis: (x: 0.0, y: 1.0, z: 0.0))
                         }
-                        .clipShape(Circle())
                     }
                     Text(data.userInfo?.nickname ?? TextLiteral.defaultUser)
                         .shortcutsZipTitle1()


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #425

## 구현/변경 사항
- ShowProfileView에서 유저의 badge를 터치했을 때의 인터렉션을 추가했습니다. 오른쪽 방향으로 한 바퀴 badge가 회전합니다.
- 회전 반동은 AboutShortcutGradeView와 같은 정도로 주었습니다.
- View가 onAppear 될 때도 오른쪽으로 한 바퀴 회전합니다.

## 스크린샷

|iPhone SE|iPhone 14|
|:---:|:---:|
| https://user-images.githubusercontent.com/94854258/236709833-5c41f1bc-1661-410f-a7bb-42b9fc5c0b93.mp4 | https://user-images.githubusercontent.com/94854258/236709843-807583d1-fb75-4bee-a330-31f86aa4950e.mp4 |

