### PR TITLE
[bug] ShortcutTabView의 Red 배경색 제거

### DIFF
--- a/HappyAnding/HappyAnding/Views/TabView/ShortcutTabView.swift
+++ b/HappyAnding/HappyAnding/Views/TabView/ShortcutTabView.swift
@@ -112,7 +112,6 @@ struct ShortcutTabView: View {
                 fetchCurationIdFromUrl(urlString: url.absoluteString)
             }
         }
-        .background(Color.red)
     }
     
     


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #441

## 구현/변경 사항
- 앱 로그인 시 간헐적으로 Red 컬러의 배경이 화면 전체에 보이는 버그를 해결했습니다.
- ShortcutTabView의 background 속성을 제거함으로 해결했습니다.

