### PR TITLE
[Feat] 작성자 닉네임 셀 디자인 통일

### DIFF
--- a/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
+++ b/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
@@ -137,6 +137,7 @@
 		F976E82C29368E0D0088BBA1 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = F976E82B29368E0D0088BBA1 /* Version.swift */; };
 		F976E85129395B350088BBA1 /* ShareExtensionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F976E85029395B350088BBA1 /* ShareExtensionViewModel.swift */; };
 		F99569182901DC4D0060AAEF /* UIFont+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F99569172901DC4D0060AAEF /* UIFont+Extension.swift */; };
+		F9A86DA62A0B54ED00405E12 /* UserNameCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9A86DA52A0B54ED00405E12 /* UserNameCell.swift */; };
 		F9AC2BB62935201C00165820 /* CheckUpdateVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9AC2BB52935201C00165820 /* CheckUpdateVersion.swift */; };
 		F9BA11D329A389EA00176807 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = F9BA11D229A389EA00176807 /* GoogleService-Info.plist */; };
 		F9BA11D429A389EA00176807 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = F9BA11D229A389EA00176807 /* GoogleService-Info.plist */; };
@@ -298,6 +299,7 @@
 		F976E82B29368E0D0088BBA1 /* Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
 		F976E85029395B350088BBA1 /* ShareExtensionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareExtensionViewModel.swift; sourceTree = "<group>"; };
 		F99569172901DC4D0060AAEF /* UIFont+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extension.swift"; sourceTree = "<group>"; };
+		F9A86DA52A0B54ED00405E12 /* UserNameCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNameCell.swift; sourceTree = "<group>"; };
 		F9AC2BB52935201C00165820 /* CheckUpdateVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckUpdateVersion.swift; sourceTree = "<group>"; };
 		F9AC2BB92935D34C00165820 /* Image+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image+View.swift"; sourceTree = "<group>"; };
 		F9BA11D229A389EA00176807 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -573,6 +575,7 @@
 				F96D45BC29816578000C2441 /* StickyHeader.swift */,
 				F91A72C22999160E00CA135A /* Alerter.swift */,
 				F91F09DE29AE0B5E00E04FA0 /* GradeAlertView.swift */,
+				F9A86DA52A0B54ED00405E12 /* UserNameCell.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -906,6 +909,7 @@
 				4D778A34290A53BA00C15AC4 /* UIApplication+Keyboard.swift in Sources */,
 				A3766B232904330300708F83 /* ReadUserCurationView.swift in Sources */,
 				87E606B0291062F900C3DA13 /* AppleAuthCoordinator.swift in Sources */,
+				F9A86DA62A0B54ED00405E12 /* UserNameCell.swift in Sources */,
 				8795A170292AB945004B765F /* UIScreen+Size.swift in Sources */,
 				A04ACB0A29041CD8004A85A6 /* DownloadRankView.swift in Sources */,
 				4DAD6370292BCB1000ABF8C1 /* CategoryCardView.swift in Sources */,

--- a/HappyAnding/HappyAnding/Views/Components/UserNameCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/UserNameCell.swift
@@ -28,6 +28,7 @@ struct UserNameCell: View {
         HStack {
             gradeImage
                 .font(.system(size: 24, weight: .medium))
+                .frame(width: 24, height: 24)
                 .foregroundColor(.gray3)
             
             Text(userInformation?.nickname ?? TextLiteral.withdrawnUser)
@@ -48,7 +49,6 @@ struct UserNameCell: View {
         .background(
             RoundedRectangle(cornerRadius: 12)
                 .foregroundColor(.gray1)
-                .frame(height: 48)
         )
         .navigationLinkRouter(data: NavigationProfile(userInfo: self.userInformation))
         .disabled(self.userInformation == nil)

--- a/HappyAnding/HappyAnding/Views/Components/UserNameCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/UserNameCell.swift
@@ -34,19 +34,21 @@ struct UserNameCell: View {
                 .shortcutsZipBody2()
                 .foregroundColor(.gray4)
             
+            Spacer()
+            
             if userInformation?.nickname != nil {
                 Image(systemName: "chevron.right")
                     .shortcutsZipFootnote()
                     .foregroundColor(.gray4)
             }
             
-            Spacer()
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 10)
         .background(
             RoundedRectangle(cornerRadius: 12)
                 .foregroundColor(.gray1)
+                .frame(height: 48)
         )
         .navigationLinkRouter(data: NavigationProfile(userInfo: self.userInformation))
         .disabled(self.userInformation == nil)

--- a/HappyAnding/HappyAnding/Views/Components/UserNameCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/UserNameCell.swift
@@ -1,0 +1,60 @@
+//
+//  UserNameCell.swift
+//  HappyAnding
+//
+//  Created by 전지민 on 2023/05/10.
+//
+
+import SwiftUI
+
+/**
+ 작성자 셀을 재사용하기 위한 뷰입니다.
+ 
+ 사용자 정보를 전달해주세요. 클릭시 사용자 프로필 뷰로 이동합니다.
+ 
+ - parameters:
+ - userInformation : 뷰모델에서 fetchUser 로 불러온 결과값 User를 전달해주세요
+ - gradeImage : 뷰모델에서 fetchShortcutGradeImage로 불러온 결과값 Image를 전달해주세요
+ 
+ - description:
+ - 해당 뷰는 넓이가 부모 프레임에 꽉차도록 만들어졌습니다. 여백이 필요한 경우 부모프레임 또는 해당 뷰를 불러온 후 설정해주세요.
+
+ */
+struct UserNameCell: View {
+    var userInformation: User?
+    var gradeImage: Image?
+    
+    var body: some View {
+        HStack {
+            gradeImage
+                .font(.system(size: 24, weight: .medium))
+                .foregroundColor(.gray3)
+            
+            Text(userInformation?.nickname ?? TextLiteral.withdrawnUser)
+                .shortcutsZipBody2()
+                .foregroundColor(.gray4)
+            
+            if userInformation?.nickname != nil {
+                Image(systemName: "chevron.right")
+                    .shortcutsZipFootnote()
+                    .foregroundColor(.gray4)
+            }
+            
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .foregroundColor(.gray1)
+        )
+        .navigationLinkRouter(data: NavigationProfile(userInfo: self.userInformation))
+        .disabled(self.userInformation == nil)
+    }
+}
+
+struct UserNameCell_Previews: PreviewProvider {
+    static var previews: some View {
+        UserNameCell()
+    }
+}

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
@@ -113,15 +113,6 @@ struct ReadUserCurationView: View {
                 )
                 .navigationLinkRouter(data: data)
             }
-            .disabled(authorInformation == nil)
-            .padding(.horizontal, 30)
-            .background(
-                RoundedRectangle(cornerRadius: 12)
-                    .frame(height: 48)
-                    .foregroundColor(.gray1)
-                    .padding(.horizontal, 16)
-            )
-            .navigationLinkRouter(data: NavigationProfile(userInfo: self.authorInformation))
         }
         .onAppear {
             shortcutsZipViewModel.fetchUser(userID: self.data.userCuration.author,

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
@@ -84,17 +84,34 @@ struct ReadUserCurationView: View {
     
     var userInformation: some View {
         ZStack {
-            HStack {
-                shortcutsZipViewModel.fetchShortcutGradeImage(isBig: false, shortcutGrade: shortcutsZipViewModel.checkShortcutGrade(userID: authorInformation?.id ?? "!"))
-                    .font(.system(size: 24, weight: .medium))
-                    .frame(width: 24, height: 24)
-                    .foregroundColor(.gray3)
-                
-                Text(authorInformation?.nickname ?? TextLiteral.withdrawnUser)
-                    .shortcutsZipHeadline()
-                    .foregroundColor(.gray4)
-                
-                Spacer()
+            if let data = NavigationProfile(userInfo: self.authorInformation) {
+                HStack {
+                    shortcutsZipViewModel.fetchShortcutGradeImage(isBig: false, shortcutGrade: shortcutsZipViewModel.checkShortcutGrade(userID: authorInformation?.id ?? "!"))
+                        .font(.system(size: 24, weight: .medium))
+                        .frame(width: 24, height: 24)
+                        .foregroundColor(.gray3)
+                    
+                    Text(authorInformation?.nickname ?? TextLiteral.withdrawnUser)
+                        .shortcutsZipBody2()
+                        .foregroundColor(.gray4)
+                    
+                    if authorInformation?.nickname != nil {
+                        Image(systemName: "chevron.right")
+                            .shortcutsZipFootnote()
+                            .foregroundColor(.gray4)
+                    }
+                    
+                    Spacer()
+                }
+                .disabled(authorInformation == nil)
+                .padding(.horizontal, 30)
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .frame(height: 48)
+                        .foregroundColor(.gray1)
+                        .padding(.horizontal, 16)
+                )
+                .navigationLinkRouter(data: data)
             }
             .disabled(authorInformation == nil)
             .padding(.horizontal, 30)

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadUserCurationView.swift
@@ -27,12 +27,11 @@ struct ReadUserCurationView: View {
         ScrollView(showsIndicators: false) {
             ZStack(alignment: .bottom) {
                 
-                StickyHeader(height: 371)
+                StickyHeader(height: 100)
                 
-                VStack {
+                VStack(spacing: 16) {
                     userInformation
-                        .padding(.top, 103)
-                        .padding(.bottom, 22)
+                        .padding(EdgeInsets(top: 103, leading: 16, bottom: 0, trailing: 16))
                     
                     UserCurationCell(curation: data.userCuration, navigationParentView: data.navigationParentView)
                 }
@@ -84,35 +83,7 @@ struct ReadUserCurationView: View {
     
     var userInformation: some View {
         ZStack {
-            if let data = NavigationProfile(userInfo: self.authorInformation) {
-                HStack {
-                    shortcutsZipViewModel.fetchShortcutGradeImage(isBig: false, shortcutGrade: shortcutsZipViewModel.checkShortcutGrade(userID: authorInformation?.id ?? "!"))
-                        .font(.system(size: 24, weight: .medium))
-                        .frame(width: 24, height: 24)
-                        .foregroundColor(.gray3)
-                    
-                    Text(authorInformation?.nickname ?? TextLiteral.withdrawnUser)
-                        .shortcutsZipBody2()
-                        .foregroundColor(.gray4)
-                    
-                    if authorInformation?.nickname != nil {
-                        Image(systemName: "chevron.right")
-                            .shortcutsZipFootnote()
-                            .foregroundColor(.gray4)
-                    }
-                    
-                    Spacer()
-                }
-                .disabled(authorInformation == nil)
-                .padding(.horizontal, 30)
-                .background(
-                    RoundedRectangle(cornerRadius: 12)
-                        .frame(height: 48)
-                        .foregroundColor(.gray1)
-                        .padding(.horizontal, 16)
-                )
-                .navigationLinkRouter(data: data)
-            }
+            UserNameCell(userInformation: self.authorInformation, gradeImage: shortcutsZipViewModel.fetchShortcutGradeImage(isBig: false, shortcutGrade: shortcutsZipViewModel.checkShortcutGrade(userID: authorInformation?.id ?? "!")))
         }
         .onAppear {
             shortcutsZipViewModel.fetchUser(userID: self.data.userCuration.author,

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutHeaderView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutHeaderView.swift
@@ -41,7 +41,7 @@ struct ReadShortcutHeaderView: View {
                     .foregroundColor(Color.gray3)
                     .fixedSize(horizontal: false, vertical: true)
             }
-            userInfo
+            UserNameCell(userInformation: userInformation, gradeImage: shortcutsZipViewModel.fetchShortcutGradeImage(isBig: false, shortcutGrade: shortcutsZipViewModel.checkShortcutGrade(userID: userInformation?.id ?? "!")))
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 16)
@@ -84,56 +84,5 @@ struct ReadShortcutHeaderView: View {
                     loginAlerter.isPresented = true
                 }
             }
-    }
-    
-    // MARK: - 유저 정보
-    var userInfo: some View {
-        ZStack {
-            if let data = NavigationProfile(userInfo: self.userInformation) {
-                HStack(spacing: 8) {
-                    
-                    shortcutsZipViewModel.fetchShortcutGradeImage(isBig: false, shortcutGrade: shortcutsZipViewModel.checkShortcutGrade(userID: userInformation?.id ?? "!"))
-                        .font(.system(size: 24, weight: .medium))
-                        .frame(width: 24, height: 24)
-                        .foregroundColor(.gray3)
-                        .padding(.leading, 16)
-                    
-                    Text(userInformation?.nickname ?? TextLiteral.withdrawnUser)
-                        .shortcutsZipBody2()
-                        .foregroundColor(.gray4)
-                    
-                    if userInformation?.nickname != nil {
-                        Image(systemName: "chevron.right")
-                            .shortcutsZipFootnote()
-                            .foregroundColor(.gray4)
-                    }
-                    
-                    Spacer()
-                        .frame(maxWidth: .infinity)
-                    
-                    
-                    // TODO: 신고기능
-                    
-                    /*
-                     Image(systemName: "light.beacon.max.fill")
-                     .Headline()
-                     .foregroundColor(.gray5)
-                     .padding(.trailing, 16)
-                     .onTapGesture {
-                     print("Tapped!")
-                     }
-                     */
-                    
-                }
-                .navigationLinkRouter(data: data)
-                .disabled(userInformation == nil)
-                .padding(.vertical, 10)
-                .frame(maxWidth: .infinity, maxHeight: 44)
-                .background(
-                    RoundedRectangle(cornerRadius: 12)
-                        .foregroundColor(.gray1)
-                )
-            }
-        }
     }
 }

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutHeaderView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutHeaderView.swift
@@ -89,42 +89,50 @@ struct ReadShortcutHeaderView: View {
     // MARK: - 유저 정보
     var userInfo: some View {
         ZStack {
-            HStack(spacing: 8) {
-                
-                shortcutsZipViewModel.fetchShortcutGradeImage(isBig: false, shortcutGrade: shortcutsZipViewModel.checkShortcutGrade(userID: userInformation?.id ?? "!"))
-                    .font(.system(size: 24, weight: .medium))
-                    .frame(width: 24, height: 24)
-                    .foregroundColor(.gray3)
-                    .padding(.leading, 16)
-                
-                Text(userInformation?.nickname ?? TextLiteral.withdrawnUser)
-                    .shortcutsZipBody2()
-                    .foregroundColor(.gray4)
-                
-                Spacer()
-                    .frame(maxWidth: .infinity)
-                
-                
-                // TODO: 신고기능
-                
-                /*
-                 Image(systemName: "light.beacon.max.fill")
-                 .Headline()
-                 .foregroundColor(.gray5)
-                 .padding(.trailing, 16)
-                 .onTapGesture {
-                 print("Tapped!")
-                 }
-                 */
-                
-            }
-            .navigationLinkRouter(data: NavigationProfile(userInfo: self.userInformation))
-            .disabled(userInformation == nil)
-            .padding(.vertical, 10)
-            .frame(maxWidth: .infinity, maxHeight: 44)
-            .overlay {
-                RoundedRectangle(cornerRadius: 12)
-                    .stroke(Color.gray1, lineWidth: 1)
+            if let data = NavigationProfile(userInfo: self.userInformation) {
+                HStack(spacing: 8) {
+                    
+                    shortcutsZipViewModel.fetchShortcutGradeImage(isBig: false, shortcutGrade: shortcutsZipViewModel.checkShortcutGrade(userID: userInformation?.id ?? "!"))
+                        .font(.system(size: 24, weight: .medium))
+                        .frame(width: 24, height: 24)
+                        .foregroundColor(.gray3)
+                        .padding(.leading, 16)
+                    
+                    Text(userInformation?.nickname ?? TextLiteral.withdrawnUser)
+                        .shortcutsZipBody2()
+                        .foregroundColor(.gray4)
+                    
+                    if userInformation?.nickname != nil {
+                        Image(systemName: "chevron.right")
+                            .shortcutsZipFootnote()
+                            .foregroundColor(.gray4)
+                    }
+                    
+                    Spacer()
+                        .frame(maxWidth: .infinity)
+                    
+                    
+                    // TODO: 신고기능
+                    
+                    /*
+                     Image(systemName: "light.beacon.max.fill")
+                     .Headline()
+                     .foregroundColor(.gray5)
+                     .padding(.trailing, 16)
+                     .onTapGesture {
+                     print("Tapped!")
+                     }
+                     */
+                    
+                }
+                .navigationLinkRouter(data: data)
+                .disabled(userInformation == nil)
+                .padding(.vertical, 10)
+                .frame(maxWidth: .infinity, maxHeight: 44)
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .foregroundColor(.gray1)
+                )
             }
         }
     }

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -61,7 +61,7 @@ struct ReadShortcutView: View {
                             
                             ReadShortcutHeaderView(shortcut: $data.shortcut.unwrap()!, isMyLike: $isMyLike)
                                 .frame(minHeight: 160)
-                                .padding(.bottom, 33)
+                                .padding(.bottom, 20)
                                 .background(Color.shortcutsZipWhite)
                             
                             


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #439
- closes #422 

## 구현/변경 사항
- ReadShortcutView와 ReadCurationView의 작성자 셀의 디자인을 통일합니다.
- 셀 오른쪽에 chevron을 추가
- 탈퇴한 사용자일 경우 chevron을 없애서 disabled 표현
- 작성자 셀 컴포넌트화

## 스크린샷

|ReadUserCurationVIew|ReadShortcutView|탈퇴한 사용자|
|:---:|:---:|:---:|
|<img src = "https://github.com/DeveloperAcademy-POSTECH/MacC-Team-HappyAnding/assets/41153398/0ced8eb1-62a4-473e-8017-e8b0e92a810e" width=200>|<img src ="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-HappyAnding/assets/41153398/02440afe-4423-441d-9674-a3509158cc83" width=200>|<img src ="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-HappyAnding/assets/41153398/bc879708-c100-4ed8-96fd-c8d17118fac5" width=200>|



