### PR TITLE
[Feat] Swipe 제스처 삭제 

### DIFF
--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -68,16 +68,12 @@ struct ReadShortcutView: View {
                             // MARK: - 탭뷰 (기본 정보, 버전 정보, 댓글)
                             
                             LazyVStack(pinnedViews: [.sectionHeaders]) {
-                                Section(header: tabBarView
-                                    .background(Color.shortcutsZipWhite)
-                                ) {
+                                Section(header: tabBarView) {
                                     detailInformationView
                                         .padding(.top, 4)
                                         .padding(.horizontal, 16)
                                 }
                             }
-                            
-                            HStack{}.id(bottomID)
                         }
                     }
                 }
@@ -437,7 +433,7 @@ extension ReadShortcutView {
                     EmptyView()
                 }
             }
-//            .animation(.easeInOut, value: currentTab)
+            .animation(.easeInOut, value: currentTab)
         }
     }
     
@@ -450,6 +446,7 @@ extension ReadShortcutView {
         }
         .padding(.horizontal, 16)
         .frame(height: 36)
+        .background(Color.shortcutsZipWhite)
     }
     
     private func tabBarItem(string: String, tab: Int) -> some View {
@@ -457,8 +454,6 @@ extension ReadShortcutView {
             self.currentTab = tab
         } label: {
             VStack {
-                Spacer()
-                
                 if self.currentTab == tab {
                     Text(string)
                         .shortcutsZipHeadline()

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ReadShortcutView/ReadShortcutView.swift
@@ -419,7 +419,7 @@ extension ReadShortcutView {
                     Color.clear.tag(2)
                 }
                 .tabViewStyle(.page(indexDisplayMode: .never))
-                .frame(minHeight: UIScreen.screenHeight / 2 - 50)
+                .frame(minHeight: UIScreen.screenHeight / 2)
                 
                 switch(currentTab) {
                 case 0:
@@ -437,25 +437,7 @@ extension ReadShortcutView {
                     EmptyView()
                 }
             }
-            
-            .animation(.easeInOut, value: currentTab)
-            .gesture(DragGesture(minimumDistance: 20, coordinateSpace: .global)
-                .onEnded { value in
-                    let horizontalAmount = value.translation.width
-                    let verticalAmount = value.translation.height
-                    
-                    if abs(horizontalAmount) > abs(verticalAmount) {
-                        if horizontalAmount < 0 {
-                            if currentTab < 2 {
-                                currentTab += 1
-                            }
-                        } else {
-                            if currentTab > 0 {
-                                currentTab -= 1
-                            }
-                        }
-                    }
-                })
+//            .animation(.easeInOut, value: currentTab)
         }
     }
     

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ShowProfileView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/ShowProfileView.swift
@@ -181,21 +181,6 @@ extension ShowProfileView {
                 }
             }
             .animation(.easeInOut, value: currentTab)
-            .gesture(
-                DragGesture(minimumDistance: 20, coordinateSpace: .global)
-                    .onEnded { value in
-                        let horizontalAmount = value.translation.width
-                        let verticalAmount = value.translation.height
-                        
-                        if abs(horizontalAmount) > abs(verticalAmount) {
-                            if horizontalAmount < 0 {
-                                currentTab += 1
-                            } else {
-                                currentTab -= 1
-                            }
-                        }
-                    }
-            )
         }
     }
 }


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #432

## 구현/변경 사항
- 커스텀 제스처로 인해 swipe back이 간헐적으로 동작하지 않는 문제를 해결했습니다.
  현재 tabbar를 page 형태로 사용하고 있어서 드래그를 커스텀하지 않아도 탭의 변경이 가능한 상황입니다.
  
  그래서 우선 커스텀했던 드래그만 삭제한 상황입니다. 제가 실기기로 테스트 했을 때에는 이전보다 확실히 나아진 것 같아요!
  우선 테스트 해 보시고, 불편하시다면 기본 드래그 제스처도 삭제하도록 하겠습니다!
- 프로필 보기 뷰와 단축어 상세 뷰의 탭 라인 위치를 통일시켰습니다.
   

## 스크린샷

|||
|---|---|
|<img src = "https://github.com/DeveloperAcademy-POSTECH/MacC-Team-HappyAnding/assets/68676844/18d6d9e5-4f06-4454-90a0-b8fff9d157bb" width = 250>|<img src = "https://github.com/DeveloperAcademy-POSTECH/MacC-Team-HappyAnding/assets/68676844/dec20639-d514-4070-a69a-eb59a8e13ce0" width = 250>
|