### PR TITLE
[Feat] TextEditor Keyboard Avoidance

### DIFF
--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView/LovedShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView/LovedShortcutView.swift
@@ -31,10 +31,9 @@ struct LovedShortcutView: View {
                     let data = NavigationReadShortcutType(shortcutID: shortcut.id,
                                                           navigationParentView: .shortcuts)
                     
-
                     ShortcutCell(shortcut: shortcut,
                                  navigationParentView: .shortcuts)
-                    .navigationLinkRouter(data: data)                    
+                    .navigationLinkRouter(data: data)
                 }
             }
         }

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/UpdateShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/UpdateShortcutView.swift
@@ -8,9 +8,14 @@
 import SwiftUI
 
 struct UpdateShortcutView: View {
+    
+    enum FocusableField: Hashable {
+        case updateDescription
+    }
+    
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
     
-    @FocusState var focusedField: String?
+    @FocusState var focusedField: FocusableField?
     
     @Binding var isUpdating: Bool
     @Binding var shortcut: Shortcuts?
@@ -50,7 +55,7 @@ struct UpdateShortcutView: View {
                                      isValid: $isLinkValid
             )
             .onSubmit {
-                focusedField = "updateDescription"
+                focusedField = .updateDescription
             }
             .submitLabel(.next)
             .onAppear(perform : UIApplication.shared.hideKeyboard)
@@ -65,7 +70,7 @@ struct UpdateShortcutView: View {
                                      content: $updateDescription,
                                      isValid: $isDescriptionValid
             )
-            .focused($focusedField, equals: "updateDescription")
+            .focused($focusedField, equals: .updateDescription)
             
             Spacer()
             

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/UpdateShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/UpdateShortcutView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct UpdateShortcutView: View {
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
     
+    @FocusState var focusedField: String?
+    
     @Binding var isUpdating: Bool
     @Binding var shortcut: Shortcuts?
     
@@ -47,6 +49,9 @@ struct UpdateShortcutView: View {
                                      content: $updatedLink,
                                      isValid: $isLinkValid
             )
+            .onSubmit {
+                focusedField = "updateDescription"
+            }
             .onAppear(perform : UIApplication.shared.hideKeyboard)
             .padding(.top, 30)
             
@@ -59,6 +64,7 @@ struct UpdateShortcutView: View {
                                      content: $updateDescription,
                                      isValid: $isDescriptionValid
             )
+            .focused($focusedField, equals: "updateDescription")
             
             Spacer()
             

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/UpdateShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/UpdateShortcutView.swift
@@ -52,6 +52,7 @@ struct UpdateShortcutView: View {
             .onSubmit {
                 focusedField = "updateDescription"
             }
+            .submitLabel(.next)
             .onAppear(perform : UIApplication.shared.hideKeyboard)
             .padding(.top, 30)
             

--- a/HappyAnding/HappyAnding/Views/ShortcutDetailViews/UpdateShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ShortcutDetailViews/UpdateShortcutView.swift
@@ -9,13 +9,9 @@ import SwiftUI
 
 struct UpdateShortcutView: View {
     
-    enum FocusableField: Hashable {
-        case updateDescription
-    }
-    
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
     
-    @FocusState var focusedField: FocusableField?
+    @FocusState var isDescriptionFieldFocused: Bool
     
     @Binding var isUpdating: Bool
     @Binding var shortcut: Shortcuts?
@@ -45,6 +41,7 @@ struct UpdateShortcutView: View {
             }
             .padding(.top, 12)
             .padding(.horizontal, 16)
+            
             ValidationCheckTextField(textType: .mandatory,
                                      isMultipleLines: false,
                                      title: TextLiteral.updateShortcutViewLinkTitle,
@@ -55,7 +52,7 @@ struct UpdateShortcutView: View {
                                      isValid: $isLinkValid
             )
             .onSubmit {
-                focusedField = .updateDescription
+                isDescriptionFieldFocused = true
             }
             .submitLabel(.next)
             .onAppear(perform : UIApplication.shared.hideKeyboard)
@@ -70,7 +67,7 @@ struct UpdateShortcutView: View {
                                      content: $updateDescription,
                                      isValid: $isDescriptionValid
             )
-            .focused($focusedField, equals: .updateDescription)
+            .focused($isDescriptionFieldFocused)
             
             Spacer()
             

--- a/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationInfoView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationInfoView.swift
@@ -12,6 +12,8 @@ struct WriteCurationInfoView: View {
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
     @EnvironmentObject var writeCurationNavigation: WriteCurationNavigation
     
+    @FocusState var focusedField: String?
+    
     @State var data: WriteCurationInfoType
     @Binding var isWriting: Bool
     
@@ -35,6 +37,9 @@ struct WriteCurationInfoView: View {
                                      content: $data.curation.title,
                                      isValid: $isValidTitle)
             .padding(.top, 12)
+            .onSubmit {
+                focusedField = "curationDescription"
+            }
             
             ValidationCheckTextField(textType: .mandatory,
                                      isMultipleLines: true,
@@ -46,6 +51,7 @@ struct WriteCurationInfoView: View {
                                      content: Binding(get: {data.curation.subtitle},
                                                       set: {data.curation.subtitle = $0}),
                                      isValid: $isValidDescription)
+            .focused($focusedField, equals: "curationDescription")
             
             Spacer()
                 .frame(maxHeight: .infinity)

--- a/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationInfoView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationInfoView.swift
@@ -40,6 +40,7 @@ struct WriteCurationInfoView: View {
             .onSubmit {
                 focusedField = "curationDescription"
             }
+            .submitLabel(.next)
             
             ValidationCheckTextField(textType: .mandatory,
                                      isMultipleLines: true,

--- a/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationInfoView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationInfoView.swift
@@ -9,14 +9,10 @@ import SwiftUI
 
 struct WriteCurationInfoView: View {
     
-    enum FocusableField: Hashable {
-        case curationDescription
-    }
-    
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
     @EnvironmentObject var writeCurationNavigation: WriteCurationNavigation
     
-    @FocusState var focusedField: FocusableField?
+    @FocusState var isDescriptionFieldFocused: Bool
     
     @State var data: WriteCurationInfoType
     @Binding var isWriting: Bool
@@ -42,7 +38,7 @@ struct WriteCurationInfoView: View {
                                      isValid: $isValidTitle)
             .padding(.top, 12)
             .onSubmit {
-                focusedField = .curationDescription
+                isDescriptionFieldFocused = true
             }
             .submitLabel(.next)
             
@@ -56,7 +52,7 @@ struct WriteCurationInfoView: View {
                                      content: Binding(get: {data.curation.subtitle},
                                                       set: {data.curation.subtitle = $0}),
                                      isValid: $isValidDescription)
-            .focused($focusedField, equals: .curationDescription)
+            .focused($isDescriptionFieldFocused)
             
             Spacer()
                 .frame(maxHeight: .infinity)

--- a/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationInfoView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationInfoView.swift
@@ -9,10 +9,14 @@ import SwiftUI
 
 struct WriteCurationInfoView: View {
     
+    enum FocusableField: Hashable {
+        case curationDescription
+    }
+    
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
     @EnvironmentObject var writeCurationNavigation: WriteCurationNavigation
     
-    @FocusState var focusedField: String?
+    @FocusState var focusedField: FocusableField?
     
     @State var data: WriteCurationInfoType
     @Binding var isWriting: Bool
@@ -38,7 +42,7 @@ struct WriteCurationInfoView: View {
                                      isValid: $isValidTitle)
             .padding(.top, 12)
             .onSubmit {
-                focusedField = "curationDescription"
+                focusedField = .curationDescription
             }
             .submitLabel(.next)
             
@@ -52,7 +56,7 @@ struct WriteCurationInfoView: View {
                                      content: Binding(get: {data.curation.subtitle},
                                                       set: {data.curation.subtitle = $0}),
                                      isValid: $isValidDescription)
-            .focused($focusedField, equals: "curationDescription")
+            .focused($focusedField, equals: .curationDescription)
             
             Spacer()
                 .frame(maxHeight: .infinity)

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutView.swift
@@ -54,12 +54,21 @@ struct WriteShortcutView: View {
                     shortcutTitleText
                         .id("title")
                         .focused($focusedField, equals: "title")
+                        .onSubmit {
+                            focusedField = "link"
+                        }
                     shortcutLinkText
                         .id("link")
                         .focused($focusedField, equals: "link")
+                        .onSubmit {
+                            focusedField = "subtitle"
+                        }
                     shortcutSubtitleText
                         .id("subtitle")
                         .focused($focusedField, equals: "subtitle")
+                        .onSubmit {
+                            focusedField = "description"
+                        }
                     shortcutDescriptionText
                         .id("description")
                         .focused($focusedField, equals: "description")

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutView.swift
@@ -89,11 +89,12 @@ struct WriteShortcutView: View {
                         .focused($focusedField, equals: .requiredApp)
                 }
             }
-            .ignoresSafeArea(.keyboard)
             .scrollDismissesKeyboard(.interactively)
             .onChange(of: focusedField) { id in
-                withAnimation {
-                    proxy.scrollTo(id, anchor: .center)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    withAnimation {
+                        proxy.scrollTo(id, anchor: .bottom)
+                    }
                 }
             }
             .background(Color.shortcutsZipBackground)

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutView.swift
@@ -9,11 +9,19 @@ import SwiftUI
 
 struct WriteShortcutView: View {
     
+    enum FocusableField: Hashable {
+        case title
+        case link
+        case subtitle
+        case description
+        case requiredApp
+    }
+    
     @Environment(\.presentationMode) var presentationMode
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
     @EnvironmentObject var writeShortcutNavigation: WriteShortcutNavigation
     
-    @FocusState var focusedField: String?
+    @FocusState var focusedField: FocusableField?
     
     @Binding var isWriting: Bool
     
@@ -53,29 +61,32 @@ struct WriteShortcutView: View {
                     iconModalView
                     shortcutTitleText
                         .id("title")
-                        .focused($focusedField, equals: "title")
+                        .focused($focusedField, equals: .title)
                         .onSubmit {
-                            focusedField = "link"
+                            focusedField = .link
                         }
+                        .submitLabel(.next)
                     shortcutLinkText
                         .id("link")
-                        .focused($focusedField, equals: "link")
+                        .focused($focusedField, equals: .link)
                         .onSubmit {
-                            focusedField = "subtitle"
+                            focusedField = .subtitle
                         }
+                        .submitLabel(.next)
                     shortcutSubtitleText
                         .id("subtitle")
-                        .focused($focusedField, equals: "subtitle")
+                        .focused($focusedField, equals: .subtitle)
                         .onSubmit {
-                            focusedField = "description"
+                            focusedField = .description
                         }
+                        .submitLabel(.next)
                     shortcutDescriptionText
                         .id("description")
-                        .focused($focusedField, equals: "description")
+                        .focused($focusedField, equals: .description)
                     shortcutCategory
                     shortcutsRequiredApp
                         .id("requiredapp")
-                        .focused($focusedField, equals: "requiredapp")
+                        .focused($focusedField, equals: .requiredApp)
                 }
             }
             .ignoresSafeArea(.keyboard)

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutView.swift
@@ -13,6 +13,8 @@ struct WriteShortcutView: View {
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
     @EnvironmentObject var writeShortcutNavigation: WriteShortcutNavigation
     
+    @FocusState var isFocused: String?
+    
     @Binding var isWriting: Bool
     
     @State var isInfoButtonTouched = false
@@ -45,66 +47,85 @@ struct WriteShortcutView: View {
     let isEdit: Bool
     
     var body: some View {
-        ScrollView(showsIndicators: false) {
-            VStack(spacing: 32){
-                iconModalView
-                shortcutTitleText
-                shortcutLinkText
-                shortcutSubtitleText
-                shortcutDescriptionText
-                shortcutCategory
-                shortcutsRequiredApp
-            }
-        }
-        .background(Color.shortcutsZipBackground)
-        .navigationTitle(isEdit ? TextLiteral.writeShortcutViewEdit : TextLiteral.writeShortcutViewPost)
-        .navigationBarTitleDisplayMode(.inline)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                Button {
-                    self.presentationMode.wrappedValue.dismiss()
-                } label: {
-                    Text(TextLiteral.cancel)
-                        .shortcutsZipBody1()
-                        .foregroundColor(.gray5)
+        ScrollViewReader { proxy in
+            ScrollView(showsIndicators: false) {
+                VStack(spacing: 32) {
+                    iconModalView
+                    shortcutTitleText
+                        .id("title")
+                        .focused($isFocused, equals: "title")
+                    shortcutLinkText
+                        .id("link")
+                        .focused($isFocused, equals: "link")
+                    shortcutSubtitleText
+                        .id("subtitle")
+                        .focused($isFocused, equals: "subtitle")
+                    shortcutDescriptionText
+                        .id("description")
+                        .focused($isFocused, equals: "description")
+                    shortcutCategory
+                    shortcutsRequiredApp
+                        .id("requiredapp")
+                        .focused($isFocused, equals: "requiredapp")
                 }
             }
-            
-            // MARK: -업로드 버튼
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Button(action: {
-                    if let index = shortcutsZipViewModel.allShortcuts.firstIndex(where: {$0.id == shortcut.id}) {
-                        shortcutsZipViewModel.allShortcuts[index] = shortcut
+            .ignoresSafeArea(.keyboard)
+            .scrollDismissesKeyboard(.interactively)
+            .onChange(of: isFocused) { id in
+                withAnimation {
+                    proxy.scrollTo(id, anchor: .center)
+                }
+            }
+            .background(Color.shortcutsZipBackground)
+            .navigationTitle(isEdit ? TextLiteral.writeShortcutViewEdit : TextLiteral.writeShortcutViewPost)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button {
+                        self.presentationMode.wrappedValue.dismiss()
+                    } label: {
+                        Text(TextLiteral.cancel)
+                            .shortcutsZipBody1()
+                            .foregroundColor(.gray5)
                     }
-                    
-                    shortcut.author = shortcutsZipViewModel.currentUser()
-                    if isEdit {
-                        //단축어 수정
-                        //뷰모델의 카테고리별 단축어 목록에서 정보 수정 및 해당 단축어가 포함된 큐레이션 수정
-                        shortcutsZipViewModel.updateShortcut(existingCategory: existingCategory, newCategory: shortcut.category, shortcut: shortcut)
+                }
+                
+                // MARK: -업로드 버튼
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: {
+                        if let index = shortcutsZipViewModel.allShortcuts.firstIndex(where: {$0.id == shortcut.id}) {
+                            shortcutsZipViewModel.allShortcuts[index] = shortcut
+                        }
                         
-                    } else {
-                        //새로운 단축어 생성 및 저장
-                        // 뷰모델에 추가
-                        shortcutsZipViewModel.shortcutsMadeByUser.insert(shortcut, at: 0)
+                        shortcut.author = shortcutsZipViewModel.currentUser()
+                        if isEdit {
+                            //단축어 수정
+                            //뷰모델의 카테고리별 단축어 목록에서 정보 수정 및 해당 단축어가 포함된 큐레이션 수정
+                            shortcutsZipViewModel.updateShortcut(existingCategory: existingCategory, newCategory: shortcut.category, shortcut: shortcut)
+                            
+                        } else {
+                            //새로운 단축어 생성 및 저장
+                            // 뷰모델에 추가
+                            shortcutsZipViewModel.shortcutsMadeByUser.insert(shortcut, at: 0)
+                            
+                        }
+                        // 서버에 추가 또는 수정
+                        shortcutsZipViewModel.setData(model: shortcut)
                         
-                    }
-                    // 서버에 추가 또는 수정
-                    shortcutsZipViewModel.setData(model: shortcut)
-                    
-                    isWriting.toggle()
-                    
-                    if #available(iOS 16.1, *) {
-                        writeShortcutNavigation.navigationPath = .init()
-                    }
-                    
-                }, label: {
-                    Text(TextLiteral.upload)
-                        .shortcutsZipHeadline()
-                        .foregroundColor(.shortcutsZipPrimary)
-                        .opacity(isUnavailableUploadButton() ? 0.3 : 1)
-                })
-                .disabled(isUnavailableUploadButton())
+                        isWriting.toggle()
+                        
+                        if #available(iOS 16.1, *) {
+                            writeShortcutNavigation.navigationPath = .init()
+                        }
+                        
+                    }, label: {
+                        Text(TextLiteral.upload)
+                            .shortcutsZipHeadline()
+                            .foregroundColor(.shortcutsZipPrimary)
+                            .opacity(isUnavailableUploadButton() ? 0.3 : 1)
+                    })
+                    .disabled(isUnavailableUploadButton())
+                }
             }
         }
     }

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutView.swift
@@ -60,32 +60,32 @@ struct WriteShortcutView: View {
                 VStack(spacing: 32) {
                     iconModalView
                     shortcutTitleText
-                        .id("title")
+                        .id(FocusableField.title)
                         .focused($focusedField, equals: .title)
                         .onSubmit {
                             focusedField = .link
                         }
                         .submitLabel(.next)
                     shortcutLinkText
-                        .id("link")
+                        .id(FocusableField.link)
                         .focused($focusedField, equals: .link)
                         .onSubmit {
                             focusedField = .subtitle
                         }
                         .submitLabel(.next)
                     shortcutSubtitleText
-                        .id("subtitle")
+                        .id(FocusableField.subtitle)
                         .focused($focusedField, equals: .subtitle)
                         .onSubmit {
                             focusedField = .description
                         }
                         .submitLabel(.next)
                     shortcutDescriptionText
-                        .id("description")
+                        .id(FocusableField.description)
                         .focused($focusedField, equals: .description)
                     shortcutCategory
                     shortcutsRequiredApp
-                        .id("requiredapp")
+                        .id(FocusableField.requiredApp)
                         .focused($focusedField, equals: .requiredApp)
                 }
             }

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutView.swift
@@ -13,7 +13,7 @@ struct WriteShortcutView: View {
     @EnvironmentObject var shortcutsZipViewModel: ShortcutsZipViewModel
     @EnvironmentObject var writeShortcutNavigation: WriteShortcutNavigation
     
-    @FocusState var isFocused: String?
+    @FocusState var focusedField: String?
     
     @Binding var isWriting: Bool
     
@@ -53,25 +53,25 @@ struct WriteShortcutView: View {
                     iconModalView
                     shortcutTitleText
                         .id("title")
-                        .focused($isFocused, equals: "title")
+                        .focused($focusedField, equals: "title")
                     shortcutLinkText
                         .id("link")
-                        .focused($isFocused, equals: "link")
+                        .focused($focusedField, equals: "link")
                     shortcutSubtitleText
                         .id("subtitle")
-                        .focused($isFocused, equals: "subtitle")
+                        .focused($focusedField, equals: "subtitle")
                     shortcutDescriptionText
                         .id("description")
-                        .focused($isFocused, equals: "description")
+                        .focused($focusedField, equals: "description")
                     shortcutCategory
                     shortcutsRequiredApp
                         .id("requiredapp")
-                        .focused($isFocused, equals: "requiredapp")
+                        .focused($focusedField, equals: "requiredapp")
                 }
             }
             .ignoresSafeArea(.keyboard)
             .scrollDismissesKeyboard(.interactively)
-            .onChange(of: isFocused) { id in
+            .onChange(of: focusedField) { id in
                 withAnimation {
                     proxy.scrollTo(id, anchor: .center)
                 }


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #387 
- closes #382 

## 구현/변경 사항
- 포커스를 가진 텍스트필드가 키보드에 가려지지 않도록 합니다.
- `@FocusState`를 사용하여 return키로 다음 텍스트필드로 이동할 수 있습니다.
- WriteShortcutView, UpdateShortcutView, WriteCurationInfoView에서 동작 확인해주시면 됩니다.

## 추가
- `@FocusState`가 Sheet 위에서 잘 동작하지 않는 이슈가 있습니다.
  - ShareExtension의 텍스트필드에서는 `@FocusState`를 사용하지 않으셨던데 그래서 그런건가요? 😭
  - ShareExtension은 따로 이슈를 파서 다음 업데이트에 포함해야 할 것 같습니다.

## 스크린
https://github.com/DeveloperAcademy-POSTECH/MacC-Team-HappyAnding/assets/76623853/23efde08-6df6-427b-b400-46606a307da8

