### PR TITLE
[Feat] 단축어 및 댓글에 날짜 표시

### DIFF
--- a/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
+++ b/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
@@ -1407,7 +1407,7 @@
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 9.0.0;
+				minimumVersion = 10.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/HappyAnding/HappyAnding/TextLiteral.swift
+++ b/HappyAnding/HappyAnding/TextLiteral.swift
@@ -136,7 +136,7 @@ enum TextLiteral {
     static let readShortcutContentViewRequirements: String = "단축어 사용을 위한 요구사항"
     
     // MARK: - ReadShortcutVersionView
-    static let readShortcutVersionViewNoUpdates: String = "업데이트된 버전이 없어요"
+    static let readShortcutVersionViewNoUpdates: String = "최신 버전의 단축어에요"
     static let readShortcutVersionViewUpdateContent: String = "업데이트 내용"
     static let readShortcutVersionViewDownloadPreviousVersion: String = "이전 버전 다운로드"
     

--- a/HappyAnding/HappyAnding/TextLiteral.swift
+++ b/HappyAnding/HappyAnding/TextLiteral.swift
@@ -130,6 +130,7 @@ enum TextLiteral {
     
     // MARK: - ReadShortcutContentView
     static let readShortcutContentViewDescription: String = "단축어 설명"
+    static let readShortcutContentViewPostedDate: String = "작성 날짜"
     static let readShortcutContentViewCategory: String = "카테고리"
     static let readShortcutContentViewRequiredApps: String = "단축어 사용에 필요한 앱"
     static let readShortcutContentViewRequirements: String = "단축어 사용을 위한 요구사항"

--- a/HappyAnding/HappyAnding/Views/ReadShortcutViews/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ReadShortcutViews/ReadShortcutView.swift
@@ -555,17 +555,6 @@ extension ReadShortcutView {
                         .lineLimit(nil)
                 }
                 
-                VStack(alignment: .leading) {
-                    Text(TextLiteral.readShortcutContentViewPostedDate)
-                        .shortcutsZipBody2()
-                        .fontWeight(.bold)
-                        .foregroundColor(Color.gray6)
-                    Text(shortcut.date.first?.getVersionUpdateDateFormat() ?? "")
-                        .shortcutsZipBody2()
-                        .foregroundColor(Color.gray5)
-                        .lineLimit(nil)
-                }
-                
                 splitList(title: TextLiteral.readShortcutContentViewCategory, content: shortcut.category)
                 
                 if !shortcut.requiredApp.isEmpty {
@@ -573,7 +562,6 @@ extension ReadShortcutView {
                 }
                 
                 Spacer()
-//                    .frame(maxHeight: .infinity)
             }
             .padding(.top, 16)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -625,10 +613,21 @@ extension ReadShortcutView {
             VStack(alignment: .leading, spacing: 16) {
                 
                 if shortcut.updateDescription.count == 1 {
+                    HStack {
+                        Text("Ver 1.0")
+                            .shortcutsZipBody2()
+                            .foregroundColor(.gray5)
+                        
+                        Spacer()
+                        
+                        Text(shortcut.date.first?.getVersionUpdateDateFormat() ?? "")
+                            .shortcutsZipBody2()
+                            .foregroundColor(.gray3)
+                    }
+
                     Text(TextLiteral.readShortcutVersionViewNoUpdates)
                         .shortcutsZipBody2()
                         .foregroundColor(.gray4)
-                        .padding(.top, 16)
                 } else {
                     Text(TextLiteral.readShortcutVersionViewUpdateContent)
                         .shortcutsZipBody2()

--- a/HappyAnding/HappyAnding/Views/ReadShortcutViews/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ReadShortcutViews/ReadShortcutView.swift
@@ -452,14 +452,9 @@ extension ReadShortcutView {
                 VStack(alignment: .leading) {
                     Text(TextLiteral.readShortcutContentViewDescription)
                         .shortcutsZipBody2()
-<<<<<<< HEAD
                         .fontWeight(.bold)
                         .foregroundColor(Color.gray6)
-                    Text(shortcut.description)
-=======
-                        .foregroundColor(Color.gray4)
                     Text(.init(viewModel.shortcut.description))
->>>>>>> develop
                         .shortcutsZipBody2()
                         .foregroundColor(Color.gray5)
                         .tint(.shortcutsZipPrimary)
@@ -521,8 +516,7 @@ extension ReadShortcutView {
         var body: some View {
             VStack(alignment: .leading, spacing: 16) {
                 
-<<<<<<< HEAD
-                if shortcut.updateDescription.count == 1 {
+                if viewModel.shortcut.updateDescription.count == 1 {
                     HStack {
                         Text("Ver 1.0")
                             .shortcutsZipBody2()
@@ -530,14 +524,10 @@ extension ReadShortcutView {
                         
                         Spacer()
                         
-                        Text(shortcut.date.first?.getVersionUpdateDateFormat() ?? "")
+                        Text(viewModel.shortcut.date.first?.getVersionUpdateDateFormat() ?? "")
                             .shortcutsZipBody2()
                             .foregroundColor(.gray3)
                     }
-
-=======
-                if viewModel.shortcut.updateDescription.count == 1 {
->>>>>>> develop
                     Text(TextLiteral.readShortcutVersionViewNoUpdates)
                         .shortcutsZipBody2()
                         .foregroundColor(.gray4)

--- a/HappyAnding/HappyAnding/Views/ReadShortcutViews/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ReadShortcutViews/ReadShortcutView.swift
@@ -554,6 +554,16 @@ extension ReadShortcutView {
                         .lineLimit(nil)
                 }
                 
+                VStack(alignment: .leading) {
+                    Text(TextLiteral.readShortcutContentViewPostedDate)
+                        .shortcutsZipBody2()
+                        .foregroundColor(Color.gray4)
+                    Text(shortcut.date.first?.getVersionUpdateDateFormat() ?? "")
+                        .shortcutsZipBody2()
+                        .foregroundColor(Color.gray5)
+                        .lineLimit(nil)
+                }
+                
                 splitList(title: TextLiteral.readShortcutContentViewCategory, content: shortcut.category)
                 
                 if !shortcut.requiredApp.isEmpty {

--- a/HappyAnding/HappyAnding/Views/ReadShortcutViews/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ReadShortcutViews/ReadShortcutView.swift
@@ -781,12 +781,12 @@ extension ReadShortcutView {
                         }
                         .padding(.bottom, 4)
                         
-                        
                         /// 댓글 내용
                         Text(comment.contents)
                             .shortcutsZipBody2()
                             .foregroundColor(.gray5)
                             .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.leading, 4)
                         
                         /// 답글, 수정, 삭제 버튼
                         HStack(spacing: 0) {

--- a/HappyAnding/HappyAnding/Views/ReadShortcutViews/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ReadShortcutViews/ReadShortcutView.swift
@@ -542,12 +542,13 @@ extension ReadShortcutView {
         
         
         var body: some View {
-            VStack(alignment: .leading, spacing: 24) {
+            VStack(alignment: .leading, spacing: 32) {
                 
                 VStack(alignment: .leading) {
                     Text(TextLiteral.readShortcutContentViewDescription)
                         .shortcutsZipBody2()
-                        .foregroundColor(Color.gray4)
+                        .fontWeight(.bold)
+                        .foregroundColor(Color.gray6)
                     Text(shortcut.description)
                         .shortcutsZipBody2()
                         .foregroundColor(Color.gray5)
@@ -557,7 +558,8 @@ extension ReadShortcutView {
                 VStack(alignment: .leading) {
                     Text(TextLiteral.readShortcutContentViewPostedDate)
                         .shortcutsZipBody2()
-                        .foregroundColor(Color.gray4)
+                        .fontWeight(.bold)
+                        .foregroundColor(Color.gray6)
                     Text(shortcut.date.first?.getVersionUpdateDateFormat() ?? "")
                         .shortcutsZipBody2()
                         .foregroundColor(Color.gray5)
@@ -571,7 +573,7 @@ extension ReadShortcutView {
                 }
                 
                 Spacer()
-                    .frame(maxHeight: .infinity)
+//                    .frame(maxHeight: .infinity)
             }
             .padding(.top, 16)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -583,7 +585,8 @@ extension ReadShortcutView {
                 
                 Text(title)
                     .shortcutsZipBody2()
-                    .foregroundColor(Color.gray4)
+                    .fontWeight(.bold)
+                    .foregroundColor(Color.gray6)
                 
                 WrappingHStack(content, id: \.self, alignment: .leading, spacing: .constant(8), lineSpacing: 8) { item in
                     if Category.allCases.contains(where: { $0.rawValue == item }) {

--- a/HappyAnding/HappyAnding/Views/ReadShortcutViews/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ReadShortcutViews/ReadShortcutView.swift
@@ -772,6 +772,12 @@ extension ReadShortcutView {
                             Text(comment.user_nickname)
                                 .shortcutsZipBody2()
                                 .foregroundColor(.gray4)
+                            
+                            Spacer()
+                            
+                            Text(comment.date.getVersionUpdateDateFormat())
+                                .shortcutsZipFootnote()
+                                .foregroundColor(.gray4)
                         }
                         .padding(.bottom, 4)
                         


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #447

## 구현/변경 사항
- 단축어 상세 정보 페이지에 단축어 작성 날짜 표시
- 업데이트 시 업데이트 날짜로 표시
- 단축어 댓글 페이지에 댓글 작성 날자 표시

## 논의 사항
- 댓글이 최근에 달렸을 경우 x시간 전, x일 전 등의 레이블을 다는 것에 대해 논의해보면 좋을 것 같습니다!
- 디자인 부분에서 수정 관련 아이디어가 있다면 코멘트 달아주세요.

## 스크린샷

|단축어 상세 정보 날짜|댓글 작성 날짜|
|:---:|:---:|
|![Simulator Screenshot - iPhone 14 Pro - 2023-07-28 at 19 02 47](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-HappyAnding/assets/94854258/dbb55cca-eb68-44fa-b095-b1edf6945488)|![Simulator Screenshot - iPhone 14 Pro - 2023-07-28 at 19 03 49](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-HappyAnding/assets/94854258/5deb87c1-03c3-4d91-8db3-9f49807ff2a8)|
