### PR TITLE
[Fix] #489 - Firebase 버전 문제로 인한 프로젝트 빌드 이슈 해결

### DIFF
--- a/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
+++ b/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
@@ -1497,7 +1497,7 @@
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 9.0.0;
+				minimumVersion = 10.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #489 

## 구현/변경 사항
- 오류가 발생한 원인은 Firebase의 9.x -> 10.x로의 메이저 업데이트와 Xcode 메이저 업데이트가 겹치며 일어난 문제였습니다.
- Xcode와 iOS 버전이 올라가며 생긴 변경사항에 이전 버전의 Firebase 패키지가 대응하지 못했고, Firebase가 업데이트 된 이후에도 Dependency Rule 때문에 10.x 대로 패키지가 업데이트되지 못해 계속해서 오류가 발생했습니다.

- 문제를 해결하기 위해 프로젝트 세팅의 Pakage Dependencies -> Firebase의 Dependency Rule을 9.0.0 < 10.0.0에서 10.0.0<11.0.0으로 변경 후 패키지를 업데이트해 주었습니다.
- 회고 문서 함께 첨부하겠습니다.
https://halogen.notion.site/Firebase-cache-Error-0ece20409ae84ed9b02934106f3c00d9?pvs=4