### PR TITLE
[Fix] IconModalView의 태그 색상 수정 등

### DIFF
--- a/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
+++ b/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
@@ -1497,7 +1497,7 @@
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 9.0.0;
+				minimumVersion = 10.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/IconModalView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/IconModalView.swift
@@ -42,13 +42,9 @@ struct IconModalView: View {
                 
                 ZStack(alignment: .center) {
                     Rectangle()
-                        .fill(Color.gray1)
-                        .aspectRatio(contentMode: .fit)
-                        .cornerRadius(UIScreen.screenHeight > 700 ? 20 : 12.35)
-                        .frame(height: UIScreen.screenHeight > 700 ? 136 : 84)
-                    
-                    Rectangle()
-                        .fill(Color.fetchGradient(color: iconColor))
+                        .foregroundStyle(iconColor.isEmpty
+                                         ? LinearGradient(colors: [Color.gray1, Color.gray2], startPoint: .topLeading, endPoint: .bottomTrailing)
+                                         : Color.fetchGradient(color: iconColor))
                         .aspectRatio(contentMode: .fit)
                         .cornerRadius(UIScreen.screenHeight > 700 ? 20 : 12.35)
                         .frame(height: UIScreen.screenHeight > 700 ? 136 : 84)

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/IconModalView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/IconModalView.swift
@@ -40,27 +40,28 @@ struct IconModalView: View {
                 .padding(.top, 24)
                 .padding(.bottom, 8)
                 
+                ZStack(alignment: .center) {
+                    Rectangle()
+                        .fill(Color.gray1)
+                        .aspectRatio(contentMode: .fit)
+                        .cornerRadius(UIScreen.screenHeight > 700 ? 20 : 12.35)
+                        .frame(height: UIScreen.screenHeight > 700 ? 136 : 84)
+                    
+                    Rectangle()
+                        .fill(Color.fetchGradient(color: iconColor))
+                        .aspectRatio(contentMode: .fit)
+                        .cornerRadius(UIScreen.screenHeight > 700 ? 20 : 12.35)
+                        .frame(height: UIScreen.screenHeight > 700 ? 136 : 84)
+                    
+                    Image(systemName: iconSymbol)
+                        .font(.system(size: UIScreen.screenHeight > 700 ? 48 : 32))
+                        .aspectRatio(contentMode: .fit)
+                        .frame(height: UIScreen.screenHeight > 700 ? 136 : 84)
+                        .foregroundColor(.textIcon)
+                }
+                .padding(.vertical, 24)
+                
                 ScrollView(.vertical) {
-                    ZStack(alignment: .center) {
-                        Rectangle()
-                            .fill(Color.gray1)
-                            .aspectRatio(contentMode: .fit)
-                            .cornerRadius(UIScreen.screenHeight > 700 ? 20 : 12.35)
-                            .frame(height: UIScreen.screenHeight > 700 ? 136 : 84)
-                        
-                        Rectangle()
-                            .fill(Color.fetchGradient(color: iconColor))
-                            .aspectRatio(contentMode: .fit)
-                            .cornerRadius(UIScreen.screenHeight > 700 ? 20 : 12.35)
-                            .frame(height: UIScreen.screenHeight > 700 ? 136 : 84)
-                        
-                        Image(systemName: iconSymbol)
-                            .font(.system(size: UIScreen.screenHeight > 700 ? 48 : 32))
-                            .aspectRatio(contentMode: .fit)
-                            .frame(height: UIScreen.screenHeight > 700 ? 136 : 84)
-                            .foregroundColor(.textIcon)
-                    }
-                    .padding(.vertical, 24)
                     
                     Text(TextLiteral.iconModalViewColor)
                         .shortcutsZipSubtitle()
@@ -114,7 +115,7 @@ struct IconModalView: View {
                                                 .padding(.horizontal, 12)
                                                 .padding(.vertical, 6)
                                                 .foregroundColor(key == viewModel.selectedCategory ? Color.tagText : Color.gray4)
-                                                .background(key == viewModel.selectedCategory ? Color.shortcutsZipBackground : nil)
+                                                .background(key == viewModel.selectedCategory ? Color.tagBackground : nil)
                                                 .clipShape(Capsule())
                                                 .overlay(
                                                     Capsule()


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #484

## 구현/변경 사항
- IconModalView의 아이콘 태그 색상이 다크모드에서 의도된 디자인대로 나오지 않는 뷰 코드 실수를 수정했습니다.
- 동일 뷰 상단의 아이콘을 고정해, 아이콘 수정 시 직관적으로 수정할 수 있게 했습니다. 

## 스크린샷

|다크 모드|라이트 모드|
|:---:|:---:|
|![IMG_0584](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-HappyAnding/assets/94854258/497d9883-fa66-4c8b-8a7b-1d4ce4deaa45)|![IMG_0585](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-HappyAnding/assets/94854258/f65a7855-1759-468f-b1a5-a1352558010d)|
