### PR TITLE
[Feat] 햅틱 피드백 추가

### DIFF
--- a/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
+++ b/HappyAnding/HappyAnding.xcodeproj/project.pbxproj
@@ -99,6 +99,8 @@
 		A365209B29B1F26C00E9B07A /* Image+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9AC2BB92935D34C00165820 /* Image+View.swift */; };
 		A3766B232904330300708F83 /* ReadCurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3766B222904330300708F83 /* ReadCurationView.swift */; };
 		A38115BA292B447D0043E8B8 /* ShortcutCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38115B9292B447D0043E8B8 /* ShortcutCardCell.swift */; };
+		A39504872AD46B9B0019895E /* HapticManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A39504862AD46B9B0019895E /* HapticManager.swift */; };
+		A39504882AD46B9B0019895E /* HapticManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A39504862AD46B9B0019895E /* HapticManager.swift */; };
 		A3A6AD1E292763E2004C49DC /* ShareExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = A3A6AD14292763E2004C49DC /* ShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		A3C404D62A23D0E800C3BA75 /* UpdateInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C404D52A23D0E800C3BA75 /* UpdateInfoView.swift */; };
 		A3C5576C292BE084003907DC /* ShareExtensionWriteShortcutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C5576B292BE084003907DC /* ShareExtensionWriteShortcutView.swift */; };
@@ -279,6 +281,7 @@
 		A35DB3382927E9630011A28B /* CustomShareNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomShareNavigationController.swift; sourceTree = "<group>"; };
 		A3766B222904330300708F83 /* ReadCurationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadCurationView.swift; sourceTree = "<group>"; };
 		A38115B9292B447D0043E8B8 /* ShortcutCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutCardCell.swift; sourceTree = "<group>"; };
+		A39504862AD46B9B0019895E /* HapticManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticManager.swift; sourceTree = "<group>"; };
 		A3A6AD14292763E2004C49DC /* ShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		A3A6AD1B292763E2004C49DC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A3A6AD232927BA06004C49DC /* ShareExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ShareExtension.entitlements; sourceTree = "<group>"; };
@@ -471,6 +474,7 @@
 				87E606AD2910623C00C3DA13 /* HappyAnding.entitlements */,
 				3D41EE06290A458B008BE986 /* Info.plist */,
 				87E99CC22901454D009B691F /* Extensions */,
+				A39504852AD46ACB0019895E /* Support */,
 				87E99C9828FFF1D2009B691F /* Views */,
 				87E99CD729042503009B691F /* Model */,
 				A0F822AA2910B8B900AF4448 /* ViewModel */,
@@ -694,6 +698,14 @@
 				A3C404D52A23D0E800C3BA75 /* UpdateInfoView.swift */,
 			);
 			path = FeatureViews;
+			sourceTree = "<group>";
+		};
+		A39504852AD46ACB0019895E /* Support */ = {
+			isa = PBXGroup;
+			children = (
+				A39504862AD46B9B0019895E /* HapticManager.swift */,
+			);
+			path = Support;
 			sourceTree = "<group>";
 		};
 		A3A6AD15292763E2004C49DC /* ShareExtension */ = {
@@ -981,6 +993,7 @@
 				87E99CBB28FFF298009B691F /* IconModalView.swift in Sources */,
 				87E99C7028F94EA6009B691F /* ShortcutTabView.swift in Sources */,
 				F99569182901DC4D0060AAEF /* UIFont+Extension.swift in Sources */,
+				A39504872AD46B9B0019895E /* HapticManager.swift in Sources */,
 				F91A72C32999160E00CA135A /* Alerter.swift in Sources */,
 				87E99CAD28FFF261009B691F /* ReadShortcutView.swift in Sources */,
 				A33F74AE2908D8C800B8D0D0 /* CheckBoxShortcutCell.swift in Sources */,
@@ -1060,6 +1073,7 @@
 				A3FC475A292A61CC0058BF26 /* Keyword.swift in Sources */,
 				A3439AFC2939B0E80043E273 /* UserDefaults+Extension.swift in Sources */,
 				F9DB8ED3293B4C3200516CE1 /* ShareExtensionTagTextField.swift in Sources */,
+				A39504882AD46B9B0019895E /* HapticManager.swift in Sources */,
 				A3FC474E292A616A0058BF26 /* Color+Extension.swift in Sources */,
 				F9DB8EBD293987BD00516CE1 /* ShareExtensionCustomTextEditor.swift in Sources */,
 				F976E85129395B350088BBA1 /* ShareExtensionViewModel.swift in Sources */,
@@ -1497,7 +1511,7 @@
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 9.0.0;
+				minimumVersion = 10.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/HappyAnding/HappyAnding/Support/HapticManager.swift
+++ b/HappyAnding/HappyAnding/Support/HapticManager.swift
@@ -1,0 +1,23 @@
+//
+//  HapticManager.swift
+//  HappyAnding
+//
+//  Created by HanGyeongjun on 10/10/23.
+//
+
+import SwiftUI
+
+class HapticManager {
+    static let instance = HapticManager()
+    private init() {}
+    
+    func notification(type: UINotificationFeedbackGenerator.FeedbackType) {
+        let generator = UINotificationFeedbackGenerator()
+        generator.notificationOccurred(type)
+    }
+    
+    func impact(style: UIImpactFeedbackGenerator.FeedbackStyle) {
+        let generator = UIImpactFeedbackGenerator(style: style)
+        generator.impactOccurred()
+    }
+}

--- a/HappyAnding/HappyAnding/Views/Components/GradeAlertView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/GradeAlertView.swift
@@ -21,7 +21,8 @@ struct GradeAlertView: View {
     var delayTime = 0.5
     
     let gradeImage = ["level1Super", "level5Super", "level10Super", "level25Super", "level50Super"]
-    
+    private let hapticManager = HapticManager.instance
+
     var body: some View {
         ZStack {
             Color.black
@@ -60,6 +61,7 @@ struct GradeAlertView: View {
             .padding(.top, 66)
         }
         .onAppear() {
+            hapticManager.notification(type: .success)
             index = shortcutsZipViewModel.shortcutGrade - 1
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
                 withAnimation(.spring(response: 0.7, dampingFraction: 0.3, blendDuration: 0)) {

--- a/HappyAnding/HappyAnding/Views/Components/NicknameTextField.swift
+++ b/HappyAnding/HappyAnding/Views/Components/NicknameTextField.swift
@@ -69,6 +69,8 @@ struct NicknameTextField: View {
     
     var initName = ""
     
+    private let hapticManager = HapticManager.instance
+
     var body: some View {
         
         VStack(alignment: .leading, spacing: 8) {
@@ -80,6 +82,9 @@ struct NicknameTextField: View {
                 Text(nicknameError.message)
                     .shortcutsZipFootnote()
                     .foregroundColor(.shortcutsZipError)
+                    .onAppear() {
+                        hapticManager.notification(type: .error)
+                    }
             } else {
                 Text(TextLiteral.nicknameTextFieldSpace)
                     .shortcutsZipFootnote()

--- a/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
@@ -50,7 +50,8 @@ struct ShortcutCell: View {
     var rankNumber: Int = -1
     var sectionType: SectionType?
     let navigationParentView: NavigationParentView
-    
+    private let hapticManager = HapticManager.instance
+
     var body: some View {
         
         ZStack {
@@ -67,6 +68,7 @@ struct ShortcutCell: View {
                                     shortcutsZipViewModel.updateNumberOfDownload(shortcut: shortcut, downloadlinkIndex: 0)
                                 }
                             }
+                            hapticManager.notification(type: .success)
                         } else {
                             loginAlerter.isPresented = true
                         }

--- a/HappyAnding/HappyAnding/Views/Components/ValidationCheckTextField.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ValidationCheckTextField.swift
@@ -77,6 +77,8 @@ struct ValidationCheckTextField: View {
     
     @FocusState private var isFocused: Bool
     
+    private let hapticManager = HapticManager.instance
+
     var body: some View {
         VStack {
             
@@ -117,6 +119,9 @@ struct ValidationCheckTextField: View {
                         .shortcutsZipBody2()
                         .foregroundColor(.shortcutsZipError)
                         .padding(.leading)
+                        .onAppear() {
+                            hapticManager.notification(type: .error)
+                        }
                 }
                 
                 Spacer()

--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView.swift
@@ -16,9 +16,24 @@ struct ExploreShortcutView: View {
     
     let randomCategories: [Category]
     
+    private let hapticManager = HapticManager.instance
+
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView {
+                
+                VStack(spacing: 20) {
+                    Button("SUCCESS") { hapticManager.notification(type: .success) }
+                    Button("WARNING") { hapticManager.notification(type: .warning) }
+                    Button("ERROR") { hapticManager.notification(type: .error) }
+                    Divider()
+                    Button("SOFT") { hapticManager.impact(style: .soft) }
+                    Button("LIGHT") { hapticManager.impact(style: .light) }
+                    Button("MEDIUM") { hapticManager.impact(style: .medium) }
+                    Button("RIGID") { hapticManager.impact(style: .rigid) }
+                    Button("HEAVY") { hapticManager.impact(style: .heavy) }
+                }
+                
                 VStack(spacing: 32) {
                     if isUpdateAnnnouncementShow {
                         Button {

--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView.swift
@@ -21,19 +21,6 @@ struct ExploreShortcutView: View {
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView {
-                
-                VStack(spacing: 20) {
-                    Button("SUCCESS") { hapticManager.notification(type: .success) }
-                    Button("WARNING") { hapticManager.notification(type: .warning) }
-                    Button("ERROR") { hapticManager.notification(type: .error) }
-                    Divider()
-                    Button("SOFT") { hapticManager.impact(style: .soft) }
-                    Button("LIGHT") { hapticManager.impact(style: .light) }
-                    Button("MEDIUM") { hapticManager.impact(style: .medium) }
-                    Button("RIGID") { hapticManager.impact(style: .rigid) }
-                    Button("HEAVY") { hapticManager.impact(style: .heavy) }
-                }
-                
                 VStack(spacing: 32) {
                     if isUpdateAnnnouncementShow {
                         Button {

--- a/HappyAnding/HappyAnding/Views/FeatureViews/AboutShortcutGradeView.swift
+++ b/HappyAnding/HappyAnding/Views/FeatureViews/AboutShortcutGradeView.swift
@@ -15,6 +15,8 @@ struct AboutShortcutGradeView: View {
     
     let shortcutGrade: [ShortcutGrade] = [.level0, .level1, .level2, .level3, .level4, .level5]
     
+    private let hapticManager = HapticManager.instance
+    
     var body: some View {
         ScrollView {
             VStack(alignment: .center, spacing: 32) {
@@ -47,6 +49,7 @@ struct AboutShortcutGradeView: View {
                 .frame(width: UIScreen.screenWidth - 32)
             
             Button {
+                hapticManager.impact(style: .rigid)
                 withAnimation(.interpolatingSpring(stiffness: 10, damping: 3)) {
                     self.animationAmount += 360
                 }

--- a/HappyAnding/HappyAnding/Views/ReadShortcutViews/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ReadShortcutViews/ReadShortcutView.swift
@@ -23,6 +23,7 @@ struct ReadShortcutView: View {
     @Namespace var bottomID
     
     private let tabItems = [TextLiteral.readShortcutViewBasicTabTitle, TextLiteral.readShortcutViewVersionTabTitle, TextLiteral.readShortcutViewCommentTabTitle]
+    private let hapticManager = HapticManager.instance
     
     var body: some View {
         ZStack {
@@ -101,6 +102,7 @@ struct ReadShortcutView: View {
                                         viewModel.isDownloadingShortcut = true
                                         openURL(url)
                                     }
+                                    hapticManager.notification(type: .success)
                                     viewModel.updateNumberOfDownload(index: 0)
                                 } else {
                                     loginAlerter.isPresented = true
@@ -384,6 +386,8 @@ extension ReadShortcutView {
         
         @AppStorage("useWithoutSignIn") var useWithoutSignIn: Bool = false
         
+        private let hapticManager = HapticManager.instance
+        
         var body: some View {
             VStack(alignment: .leading, spacing: 16) {
                 HStack {
@@ -411,6 +415,7 @@ extension ReadShortcutView {
                             if !useWithoutSignIn {
                                 viewModel.isMyLike.toggle()
                                 viewModel.numberOfLike += viewModel.isMyLike ? 1 : -1
+                                hapticManager.impact(style: .rigid)
                             } else {
                                 loginAlerter.isPresented = true
                             }

--- a/HappyAnding/HappyAnding/Views/ReadShortcutViews/ShowProfileView.swift
+++ b/HappyAnding/HappyAnding/Views/ReadShortcutViews/ShowProfileView.swift
@@ -14,6 +14,7 @@ struct ShowProfileView: View {
     @Namespace var namespace
     
     private let tabItems = [TextLiteral.showProfileViewShortcutTabTitle, TextLiteral.showProfileViewCurationTabTitle]
+    private let hapticManager = HapticManager.instance
     
     var body: some View {
         ScrollView {
@@ -23,6 +24,7 @@ struct ShowProfileView: View {
                 //MARK: 프로필이미지 및 닉네임
                 VStack(spacing: 8) {
                     Button {
+                        hapticManager.impact(style: .rigid)
                         withAnimation(.interpolatingSpring(stiffness: 10, damping: 3)) {
                             viewModel.profileDidTap()
                         }

--- a/HappyAnding/HappyAnding/Views/ReadShortcutViews/UpdateShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ReadShortcutViews/UpdateShortcutView.swift
@@ -13,6 +13,8 @@ struct UpdateShortcutView: View {
     
     @FocusState var isDescriptionFieldFocused: Bool
     
+    private let hapticManager = HapticManager.instance
+    
     var body: some View {
         VStack {
             HStack {
@@ -65,6 +67,7 @@ struct UpdateShortcutView: View {
             
             Button {
                 viewModel.updateShortcut()
+                hapticManager.notification(type: .success)
             } label: {
                 ZStack {
                     RoundedRectangle(cornerRadius: 12)

--- a/HappyAnding/HappyAnding/Views/TabView/ShortcutTabView.swift
+++ b/HappyAnding/HappyAnding/Views/TabView/ShortcutTabView.swift
@@ -45,9 +45,12 @@ struct ShortcutTabView: View {
         UITabBar.appearance().clipsToBounds = true
     }
     
+    private let hapticManager = HapticManager.instance
+    
     var handler: Binding<Int> { Binding(
         get: { self.selectedTab },
         set: {
+            hapticManager.impact(style: .light)
             if $0 == self.selectedTab {
                 twiceTappedTab = $0
             }

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutView.swift
@@ -21,6 +21,8 @@ struct WriteShortcutView: View {
     @FocusState var focusedField: FocusableField?
     @StateObject var viewModel: WriteShortcutViewModel
     
+    private let hapticManager = HapticManager.instance
+
     private let gridLayout = [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())]
     
     
@@ -85,6 +87,7 @@ struct WriteShortcutView: View {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button(action: {
                         viewModel.uploadShortcut()
+                        hapticManager.notification(type: .success)
                         self.presentationMode.wrappedValue.dismiss()
                     }, label: {
                         Text(TextLiteral.upload)

--- a/HappyAnding/ShareExtension/CustomShareViewController.swift
+++ b/HappyAnding/ShareExtension/CustomShareViewController.swift
@@ -20,6 +20,8 @@ class CustomShareViewController: UIViewController {
     var itemDone: UIBarButtonItem!
     var itemCancel: UIBarButtonItem!
     
+    private let hapticManager = HapticManager.instance
+    
     ///viewdidload
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -133,6 +135,7 @@ class CustomShareViewController: UIViewController {
     }
     @objc private func doneAction() {
         shareExtensionViewModel.setData()
+        hapticManager.notification(type: .success)
         extensionContext?.completeRequest(returningItems: [], completionHandler: nil)
     }
     func dismissAction() {

--- a/HappyAnding/ShareExtension/ShareExtensionValidationTextField.swift
+++ b/HappyAnding/ShareExtension/ShareExtensionValidationTextField.swift
@@ -79,6 +79,8 @@ struct ShareExtensionValidationCheckTextField: View {
     
     var index: Int
     
+    private let hapticManager = HapticManager.instance
+    
     var body: some View {
         VStack {
             
@@ -119,6 +121,9 @@ struct ShareExtensionValidationCheckTextField: View {
                         .shortcutsZipBody2()
                         .foregroundColor(.shortcutsZipError)
                         .padding(.leading)
+                        .onAppear() {
+                            hapticManager.notification(type: .error)
+                        }
                 }
                 
                 Spacer()


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #492

## 구현/변경 사항
- 앱 곳곳에 Haptic Feedback을 추가해 UX를 개선했습니다.
- Haptic은 싱글톤 형태로 구현했고, Haptic을 위한 HapticManager 파일은 HappyAnding 디렉토리 안 Extension 다음에 `Support` 그룹을 만들어 넣었는데, 더 좋은 방법이 있다면 제안해주세요!
- Haptic을 적용하는 동작/버튼 선정 기준은 다음과 같습니다.
    - 앱의 주요 동작을 수행하는 버튼/동작
    - 사용자가 수행되었음을 분명하게 인지하는 것이 필요한 동작
- Haptic이 적용된 곳은 다음과 같습니다. 화살표 우측은 Haptic의 종류입니다.
1. ShortcutTabView
    1. 3개의 탭바 버튼 → light
2. ShortcutCell
    1. download icon → success
3. ValidationCheckTextField
    1. error 시 → error
4. NicknameTextField
    1. error 시 → error
5. GradeAlertView
    1. 레벨업 시 → success
6. WriteShortcutView
    1. 업로드 탭 시 → success
7. ReadShortcutView
    1. download icon → success 
    2. 하트 탭 시 → rigid
8. UpdateShortcutView
    1. 업로드 탭 시 → success
9. ShowProfileView
    1. icon 탭 시 → rigid
10. AboutShortcutGradeView
    1. icon 탭 시 → rigid
11. ShareExtensionWriteShortcutView
    1. 업로드 탭 시 → success
12. ShareExtensionValidationTextField
    1. error 시 → error

## 리뷰 시 참고해주세요
- Haptic 엔진이 정상적으로 동작하는 실기기에서 확인해 주세요.
- 피드백이 제외/추가되었으면 하는 동작이나 버튼을 알려주세요.