### PR TITLE
[Fix] ShortcutCardCell 두 줄 표시 안 되는 문제 해결

### DIFF
--- a/HappyAnding/HappyAnding/Views/Components/ShortcutCardCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ShortcutCardCell.swift
@@ -14,19 +14,20 @@ struct ShortcutCardCell: View {
     let categoryShortcutColor: String
         
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: 0) {
             Image(systemName: categoryShortcutIcon)
                 .mediumShortcutIcon()
                 .foregroundColor(Color.textIcon)
-            Text(categoryShortcutName)
+                .padding(.bottom, 4)
+            Text(categoryShortcutName.lineBreaking)
                 .multilineTextAlignment(.leading)
                 .lineLimit(2)
                 .shortcutsZipHeadline()
                 .foregroundColor(Color.textIcon)
             Spacer()
         }
-        .padding(12)
-        .frame(width: 168, height: 104, alignment: .leading)
+        .padding(.all, 12)
+        .frame(width: 168, height: 112, alignment: .leading)
         .background(Color.fetchGradient(color: categoryShortcutColor))
         .cornerRadius(12)
     }


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #496

## 구현/변경 사항
- 기존 ShortcutCardCell에서 텍스트가 한 줄만 보이던 문제를 해결했습니다.
- 원인
    - 기존에도 Cell 내부 Text의 Linelimit는 2줄까지로 되어 있었습니다.
    - Cell 내부 공간이 텍스트가 2줄이 배치될 만큼 충분하지 않아서 해당 문제가 발생했습니다.
    - 내부 Padding을 줄여도 같은 문제가 지속되었습니다.
- 해결 및 변경사항
    - Cell의 세로를 104 -> 112로 늘려 해결했습니다.
    - Cell의 크기를 고정하고 텍스트의 크기를 headline(17)에서 subtitle(15)로 줄여도 문제가 해결되지 않아 차선책으로 Cell의 크기를 늘렸습니다.
    - #377 혹시나 나타날 수 있는 해당 문제를 방지하기 위해 .linebreaking extension도 적용했습니다.

## 스크린샷

|수정 전|수정 후|
|:---:|:---:|
|![image](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-HappyAnding/assets/94854258/3744a108-93f7-4564-a9d9-e45ee03f63af)|![Simulator Screenshot - iPhone 15 Pro - 2023-10-13 at 22 48 36](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-HappyAnding/assets/94854258/08e72747-1bbf-439d-ba1c-993997e21641)|

