### PR TITLE
[Fix] 단축어 탭 ShortcutCell의 rankNumber 표시 오류 해결

### DIFF
--- a/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
@@ -110,8 +110,8 @@ struct ShortcutCell: View {
     var shortcutInfo: some View {
         
         VStack(alignment: .leading, spacing: 0) {
-            if (rankNumber != nil) {
-                Text(String(rankNumber! + 1))
+            if let rankNumber {
+                Text(String(rankNumber + 1))
                     .shortcutsZipSubtitle()
                     .foregroundColor(.gray4)
                     .padding(0)

--- a/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
@@ -47,7 +47,7 @@ struct ShortcutCell: View {
     )
     
     var shortcut: Shortcuts?
-    var rankNumber: Int = -1
+    var rankNumber: Int?
     var sectionType: SectionType?
     let navigationParentView: NavigationParentView
     
@@ -110,8 +110,8 @@ struct ShortcutCell: View {
     var shortcutInfo: some View {
         
         VStack(alignment: .leading, spacing: 0) {
-            if rankNumber != -1 {
-                Text("\(rankNumber)")
+            if (rankNumber != nil) {
+                Text(String(rankNumber! + 1))
                     .shortcutsZipSubtitle()
                     .foregroundColor(.gray4)
                     .padding(0)

--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView.swift
@@ -126,16 +126,10 @@ extension ExploreShortcutView {
             
             ForEach(Array(shortcuts.enumerated()), id:\.offset) { index, shortcut in
                 if index < 3 {
-                    if (sectionType == .download) {
-                        ShortcutCell(shortcut: shortcut,
-                                     rankNumber: index + 1,
-                                     navigationParentView: .shortcuts)
-                        .navigationLinkRouter(data: shortcut)
-                    } else {
-                        ShortcutCell(shortcut: shortcut,
-                                     navigationParentView: .shortcuts)
-                        .navigationLinkRouter(data: shortcut)
-                    }
+                    ShortcutCell(shortcut: shortcut,
+                                 rankNumber: (sectionType == .download) ? index : nil,
+                                 navigationParentView: .shortcuts)
+                    .navigationLinkRouter(data: shortcut)
                 }
             }
             .background(Color.shortcutsZipBackground)

--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView.swift
@@ -126,11 +126,16 @@ extension ExploreShortcutView {
             
             ForEach(Array(shortcuts.enumerated()), id:\.offset) { index, shortcut in
                 if index < 3 {
-                    
-                    ShortcutCell(shortcut: shortcut,
-                                 rankNumber: index + 1,
-                                 navigationParentView: .shortcuts)
-                    .navigationLinkRouter(data: shortcut)
+                    if (sectionType == .download) {
+                        ShortcutCell(shortcut: shortcut,
+                                     rankNumber: index + 1,
+                                     navigationParentView: .shortcuts)
+                        .navigationLinkRouter(data: shortcut)
+                    } else {
+                        ShortcutCell(shortcut: shortcut,
+                                     navigationParentView: .shortcuts)
+                        .navigationLinkRouter(data: shortcut)
+                    }
                 }
             }
             .background(Color.shortcutsZipBackground)

--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ListShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ListShortcutView.swift
@@ -48,17 +48,10 @@ struct ListShortcutView: View {
     private func makeShortcutCellList(_ shortcuts: [Shortcuts]) -> some View {
         ForEach(shortcuts.indices, id: \.self) { index in
             let shortcut = shortcuts[index]
-            
-            if (viewModel.sectionType == .download) {
-                ShortcutCell(shortcut: shortcut,
-                             rankNumber: index + 1,
-                             navigationParentView: .shortcuts)
-                .navigationLinkRouter(data: shortcut)
-            } else {
-                ShortcutCell(shortcut: shortcut,
-                             navigationParentView: .shortcuts)
-                .navigationLinkRouter(data: shortcut)
-            }
+            ShortcutCell(shortcut: shortcut,
+                         rankNumber: (viewModel.sectionType == .download) ? index : nil,
+                         navigationParentView: .shortcuts)
+            .navigationLinkRouter(data: shortcut)
         }
     }
 }

--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ListShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ListShortcutView.swift
@@ -49,13 +49,19 @@ struct ListShortcutView: View {
     
     @ViewBuilder
     private func makeShortcutCellList(_ shortcuts: [Shortcuts]) -> some View {
-        ForEach(shortcuts, id: \.self) { shortcut in
+        ForEach(shortcuts.indices, id: \.self) { index in
+            let shortcut = shortcuts[index]
             
-            ShortcutCell(shortcut: shortcut,
-                         sectionType: viewModel.sectionType,
-                         navigationParentView: .shortcuts)
-            .navigationLinkRouter(data: shortcut)
-            
+            if (viewModel.sectionType == .download) {
+                ShortcutCell(shortcut: shortcut,
+                             rankNumber: index + 1,
+                             navigationParentView: .shortcuts)
+                .navigationLinkRouter(data: shortcut)
+            } else {
+                ShortcutCell(shortcut: shortcut,
+                             navigationParentView: .shortcuts)
+                .navigationLinkRouter(data: shortcut)
+            }
         }
     }
 }

--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ListShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ListShortcutView.swift
@@ -30,12 +30,9 @@ struct ListShortcutView: View {
                     //TODO: 무한 스크롤을 위한 업데이트 함수 필요
                     makeShortcutCellList(viewModel.shortcuts)
                     
-                    Rectangle()
-                        .fill(Color.shortcutsZipBackground)
-                        .frame(height: 44)
-                        .listRowInsets(EdgeInsets())
-                        .listRowSeparator(.hidden)
                 }
+                .padding(.top, 16)
+                .padding(.bottom, 44)
             }
             .listRowBackground(Color.shortcutsZipBackground)
             .listStyle(.plain)


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #495

## 구현/변경 사항
- [ExploreShortcutView](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-HappyAnding/pull/461) 코드가 일원화된 이후 rankNumber가 정상적으로 표시되지 않던 오류를 해결했습니다.
- 단축어 탭의 다운로드 순위 섹션에서만 rankNumber가 표시됩니다.
- 다운로드 순위 섹션에서 ListShortcutView에 접근했을 경우에만 rankNumber가 표시됩니다.
- 추가 구현 사항
    - ListShortcutView의 상단 padding이 존재하지 않던 오류를 해결했습니다. 
    - ListShortcutView의 하단 padding 구현 방식을 효율적으로 개선했습니다.

## 스크린샷

| 단축어 탭 | ListChortcutView |상단 Padding|
|:---:|:---:|:---:|
| ![Simulator Screenshot - iPhone 15 Pro - 2023-10-14 at 16 22 11](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-HappyAnding/assets/94854258/2af315d6-5dc0-487a-a08b-1e9b837fc931) | ![Simulator Screenshot - iPhone 15 Pro - 2023-10-14 at 16 22 18](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-HappyAnding/assets/94854258/82f119d6-f215-430f-b89c-1e678243c2ca) | ![Simulator Screenshot - iPhone 15 Pro - 2023-10-14 at 16 24 00](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-HappyAnding/assets/94854258/2d83d73e-c6c3-4c27-855a-2224e02f4d23) |
