### PR TITLE
[Refactor]  foregroundColor(_:) -> foregroundStyle(_:) 로 변경

### DIFF
--- a/HappyAnding/HappyAnding/Extensions/Image+View.swift
+++ b/HappyAnding/HappyAnding/Extensions/Image+View.swift
@@ -12,7 +12,7 @@ extension Image {
     /// Color가 gray4, size: 24, frame size가 32인 Cell을 관리하는 함수입니다.
     func setCellIcon() -> some View {
         self
-            .foregroundColor(.gray4)
+            .foregroundStyle(Color.gray4)
             .mediumShortcutIcon()
             .frame(height: 32)
     }

--- a/HappyAnding/HappyAnding/Views/Components/AdminCurationCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/AdminCurationCell.swift
@@ -41,11 +41,11 @@ struct AdminCurationCell: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text(adminCuration.title)
                     .shortcutsZipTitle1()
-                    .foregroundColor(.textCuration)
+                    .foregroundStyle(Color.textCuration)
                     .lineLimit(1)
                 Text(adminCuration.subtitle.replacingOccurrences(of: "\\n", with: "\n"))
                     .shortcutsZipBody2()
-                    .foregroundColor(.textCuration)
+                    .foregroundStyle(Color.textCuration)
                     .lineLimit(2)
                     .multilineTextAlignment(.leading)
             }
@@ -60,7 +60,7 @@ struct AdminCurationCell: View {
                 .resizable()
                 .aspectRatio(contentMode: .fill)
             Rectangle()
-                .foregroundColor(.white)
+                .foregroundStyle(Color.white)
                 .opacity(0.4)
         }
         .frame(height: 284)

--- a/HappyAnding/HappyAnding/Views/Components/AnnouncementCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/AnnouncementCell.swift
@@ -28,7 +28,7 @@ struct AnnouncementCell: View {
                     Text(tagName)
                         .shortcutsZipFootnote()
                         .fontWeight(.bold)
-                        .foregroundColor(Color.tagText)
+                        .foregroundStyle(Color.tagText)
                         .frame(height: 20)
                         .padding(.horizontal, 8)
                         .padding(.vertical, 2)
@@ -42,7 +42,7 @@ struct AnnouncementCell: View {
                     Text(discription)
                         .shortcutsZipBody2()
                         .fontWeight(.semibold)
-                        .foregroundColor(.gray5)
+                        .foregroundStyle(Color.gray5)
                         .lineLimit(1)
                 }
                 
@@ -53,7 +53,7 @@ struct AnnouncementCell: View {
                 } label: {
                     Image(systemName: "xmark")
                         .shortcutsZipBody1()
-                        .foregroundColor(.gray4)
+                        .foregroundStyle(Color.gray4)
                         .frame(width: 24, height: 24)
                 }
             }

--- a/HappyAnding/HappyAnding/Views/Components/GradeAlertView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/GradeAlertView.swift
@@ -35,7 +35,7 @@ struct GradeAlertView: View {
                     VStack(spacing: 60) {
                         if index < 1 {
                             Rectangle()
-                                .foregroundColor(Color.white)
+                                .fill(Color.white)
                                 .frame(width: 170, height: 198)
                         } else {
                             Image(gradeImage[index - 1])
@@ -53,7 +53,7 @@ struct GradeAlertView: View {
                 
                 Text(isTextShowing ? TextLiteral.gradeAlertMessage : TextLiteral.gradeAlertMessageBlank)
                     .shortcutsZipTitle1()
-                    .foregroundColor(.gray5)
+                    .foregroundStyle(Color.gray5)
                     .padding(.bottom, 60)
                     .disabled(isTextShowing)
             }
@@ -85,7 +85,7 @@ struct GradeAlertView: View {
                         isShowing = false
                     } label: {
                         Image(systemName: "xmark")
-                            .foregroundColor(.gray5)
+                            .foregroundStyle(Color.gray5)
                             .font(.system(size: 24, weight: .medium))
                     }
                 }

--- a/HappyAnding/HappyAnding/Views/Components/MoreCaptionTextView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/MoreCaptionTextView.swift
@@ -14,6 +14,6 @@ struct MoreCaptionTextView: View {
     var body: some View {
         Text(text)
             .shortcutsZipFootnote()
-            .foregroundColor(Color.gray4)
+            .foregroundStyle(Color.gray4)
     }
 }

--- a/HappyAnding/HappyAnding/Views/Components/MyShortcutCardView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/MyShortcutCardView.swift
@@ -17,12 +17,12 @@ struct MyShortcutCardView: View {
         VStack(alignment: .leading, spacing: 4) {
             Image(systemName: myShortcutIcon)
                 .mediumShortcutIcon()
-                .foregroundColor(Color.textIcon)
+                .foregroundStyle(Color.textIcon)
                 .frame(width: 30.0, height: 30.0)
             Text(myShortcutName)
                 .shortcutsZipSubtitle()
                 .multilineTextAlignment(.leading)
-                .foregroundColor(Color.textIcon)
+                .foregroundStyle(Color.textIcon)
                 .lineLimit(3)
             Spacer()
         }
@@ -39,7 +39,7 @@ struct AddMyShortcutCardView: View {
         VStack {
             Image(systemName: "plus")
                 .mediumShortcutIcon()
-                .foregroundColor(Color.gray4)
+                .foregroundStyle(Color.gray4)
         }
         .padding()
         .frame(width: 107, height: 144)

--- a/HappyAnding/HappyAnding/Views/Components/NicknameTextField.swift
+++ b/HappyAnding/HappyAnding/Views/Components/NicknameTextField.swift
@@ -31,11 +31,11 @@ struct NicknameTextField: View {
         var color: Color {
             switch self {
             case .focus:
-                return .shortcutsZipPrimary
+                return Color.shortcutsZipPrimary
             case .focusError:
-                return .shortcutsZipError
+                return Color.shortcutsZipError
             case .notfocus:
-                return .gray2
+                return Color.gray2
             }
         }
         
@@ -79,11 +79,11 @@ struct NicknameTextField: View {
             if nicknameFocus == .focusError {
                 Text(nicknameError.message)
                     .shortcutsZipFootnote()
-                    .foregroundColor(.shortcutsZipError)
+                    .foregroundStyle(Color.shortcutsZipError)
             } else {
                 Text(TextLiteral.nicknameTextFieldSpace)
                     .shortcutsZipFootnote()
-                    .foregroundColor(.gray3)
+                    .foregroundStyle(Color.gray3)
             }
         }
         .onChange(of: nickname) { _ in
@@ -118,7 +118,7 @@ struct NicknameTextField: View {
                     .focused($isFocused)
                     .frame(height: 52)
                     .shortcutsZipBody2()
-                    .foregroundColor(.gray5)
+                    .foregroundStyle(Color.gray5)
                     .padding(.horizontal, 16)
                     .onAppear { UIApplication.shared.hideKeyboard() }
                 
@@ -128,7 +128,7 @@ struct NicknameTextField: View {
             .overlay(
                 RoundedRectangle(cornerRadius: 12)
                     .strokeBorder(lineWidth: 1)
-                    .foregroundColor(nicknameFocus.color)
+                    .foregroundStyle(nicknameFocus.color)
             )
             
             Button {
@@ -147,12 +147,12 @@ struct NicknameTextField: View {
                 
                 ZStack {
                     RoundedRectangle(cornerRadius: 12)
-                        .foregroundColor(nicknameState != .none || nickname.isEmpty || initName == nickname ? .shortcutsZipPrimary.opacity(0.13) : .shortcutsZipPrimary)
+                        .foregroundStyle(nicknameState != .none || nickname.isEmpty || initName == nickname ? Color.shortcutsZipPrimary.opacity(0.13) : Color.shortcutsZipPrimary)
                         .frame(width: 80, height: 52)
                     
                     Text(TextLiteral.nicknameTextFieldDuplicateCheck)
                         .shortcutsZipBody1()
-                        .foregroundColor(nicknameState != .none || nickname.isEmpty || initName == nickname ? .textButtonDisable : .textIcon)
+                        .foregroundStyle(nicknameState != .none || nickname.isEmpty || initName == nickname ? Color.textButtonDisable : Color.textIcon)
                 }
             }
             .disabled(nicknameState != .none || nickname.isEmpty || initName == nickname)
@@ -167,18 +167,18 @@ struct NicknameTextField: View {
                 } label: {
                     Image(systemName: "xmark.circle.fill")
                         .smallIcon()
-                        .foregroundColor(.gray5)
+                        .foregroundStyle(Color.gray5)
                 }
             } else {
                 if nicknameState == .fail {
                     Image(systemName: "exclamationmark.circle.fill")
                         .smallIcon()
-                        .foregroundColor(.shortcutsZipError)
+                        .foregroundStyle(Color.shortcutsZipError)
                         .onTapGesture { }
                 } else if nicknameState == .success {
                     Image(systemName: "checkmark.circle.fill")
                         .smallIcon()
-                        .foregroundColor(.shortcutsZipSuccess)
+                        .foregroundStyle(Color.shortcutsZipSuccess)
                         .onTapGesture { }
                 }
             }

--- a/HappyAnding/HappyAnding/Views/Components/ShortcutCardCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ShortcutCardCell.swift
@@ -17,12 +17,12 @@ struct ShortcutCardCell: View {
         VStack(alignment: .leading, spacing: 4) {
             Image(systemName: categoryShortcutIcon)
                 .mediumShortcutIcon()
-                .foregroundColor(Color.textIcon)
+                .foregroundStyle(Color.textIcon)
             Text(categoryShortcutName)
                 .multilineTextAlignment(.leading)
                 .lineLimit(2)
                 .shortcutsZipHeadline()
-                .foregroundColor(Color.textIcon)
+                .foregroundStyle(Color.textIcon)
             Spacer()
         }
         .padding(12)

--- a/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ShortcutCell.swift
@@ -102,7 +102,7 @@ struct ShortcutCell: View {
             
             Image(systemName: shortcutCell.sfSymbol)
                 .mediumShortcutIcon()
-                .foregroundColor(.textIcon)
+                .foregroundStyle(Color.textIcon)
         }
         .padding(.leading, 20)
     }
@@ -113,16 +113,16 @@ struct ShortcutCell: View {
             if rankNumber != -1 {
                 Text("\(rankNumber)")
                     .shortcutsZipSubtitle()
-                    .foregroundColor(.gray4)
+                    .foregroundStyle(Color.gray4)
                     .padding(0)
             }
             Text(shortcutCell.title)
                 .shortcutsZipHeadline()
-                .foregroundColor(.gray5)
+                .foregroundStyle(Color.gray5)
                 .lineLimit(1)
             Text(shortcutCell.subtitle.lineBreaking)
                 .shortcutsZipFootnote()
-                .foregroundColor(.gray3)
+                .foregroundStyle(Color.gray3)
                 .multilineTextAlignment(.leading)
                 .lineLimit(2)
         }

--- a/HappyAnding/HappyAnding/Views/Components/SubtitleTextView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/SubtitleTextView.swift
@@ -14,7 +14,7 @@ struct SubtitleTextView: View {
     var body: some View {
         Text(text)
             .shortcutsZipTitle2()
-            .foregroundColor(Color.gray5)
+            .foregroundStyle(Color.gray5)
             .frame(maxWidth: .infinity, alignment: .leading)
     }
 }

--- a/HappyAnding/HappyAnding/Views/Components/UserCurationCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/UserCurationCell.swift
@@ -31,7 +31,7 @@ struct UserCurationCell: View {
                                 .cornerRadius(8)
                                 .frame(width: 36, height: 36)
                             Image(systemName: shortcut.sfSymbol)
-                                .foregroundColor(Color.textIcon)
+                                .foregroundStyle(Color.textIcon)
                                 .smallShortcutIcon()
                         }
                     }
@@ -49,7 +49,7 @@ struct UserCurationCell: View {
                                 Text("\(curation.shortcuts.count-4)")
                                     .shortcutsZipFootnote()
                             }
-                            .foregroundColor(.gray5)
+                            .foregroundStyle(Color.gray5)
                         }
                     }
                 }
@@ -60,13 +60,13 @@ struct UserCurationCell: View {
                 
                 Text(curation.title)
                     .shortcutsZipHeadline()
-                    .foregroundColor(Color.gray5)
+                    .foregroundStyle(Color.gray5)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 Text(curation.subtitle.lineBreaking)
                     .shortcutsZipBody2()
                     .multilineTextAlignment(.leading)
                     .lineLimit(lineLimit)
-                    .foregroundColor(Color.gray5)
+                    .foregroundStyle(Color.gray5)
                     .padding(.bottom, 20)
                     .fixedSize(horizontal: false, vertical: true)
             }

--- a/HappyAnding/HappyAnding/Views/Components/UserCurationListView.swift
+++ b/HappyAnding/HappyAnding/Views/Components/UserCurationListView.swift
@@ -47,7 +47,7 @@ struct UserCurationListView: View {
                     Text(TextLiteral.userCurationListViewAdd)
                         .shortcutsZipHeadline()
                 }
-                .foregroundColor(.gray4)
+                .foregroundStyle(Color.gray4)
                 .frame(maxWidth: .infinity)
                 .frame(height: 64)
                 .background(Color.backgroundPlus)

--- a/HappyAnding/HappyAnding/Views/Components/UserNameCell.swift
+++ b/HappyAnding/HappyAnding/Views/Components/UserNameCell.swift
@@ -29,16 +29,16 @@ struct UserNameCell: View {
             gradeImage
                 .font(.system(size: 24, weight: .medium))
                 .frame(width: 24, height: 24)
-                .foregroundColor(.gray3)
+                .foregroundStyle(Color.gray3)
             
             if !userInformation.nickname.isEmpty {
                 Text(userInformation.nickname)
                     .shortcutsZipBody2()
-                    .foregroundColor(.gray4)
+                    .foregroundStyle(Color.gray4)
             } else {
                 Text(TextLiteral.withdrawnUser)
                     .shortcutsZipBody2()
-                    .foregroundColor(.gray4)
+                    .foregroundStyle(Color.gray4)
             }
             
             Spacer()
@@ -46,7 +46,7 @@ struct UserNameCell: View {
             if !userInformation.id.isEmpty {
                 Image(systemName: "chevron.right")
                     .shortcutsZipFootnote()
-                    .foregroundColor(.gray4)
+                    .foregroundStyle(Color.gray4)
             }
             
         }
@@ -54,7 +54,7 @@ struct UserNameCell: View {
         .padding(.vertical, 10)
         .background(
             RoundedRectangle(cornerRadius: 12)
-                .foregroundColor(.gray1)
+                .fill(Color.gray1)
         )
         .navigationLinkRouter(data: self.userInformation)
         .disabled(self.userInformation.id.isEmpty)

--- a/HappyAnding/HappyAnding/Views/Components/ValidationCheckTextField.swift
+++ b/HappyAnding/HappyAnding/Views/Components/ValidationCheckTextField.swift
@@ -89,7 +89,7 @@ struct ValidationCheckTextField: View {
                 if let lengthLimit {
                     Text("\(content.count)/\(lengthLimit)")
                         .shortcutsZipBody2()
-                        .foregroundColor(.gray4)
+                        .foregroundStyle(strokeColor)
                         .padding(.trailing, 16)
                 }
             }
@@ -107,7 +107,7 @@ struct ValidationCheckTextField: View {
             .background(
                 RoundedRectangle(cornerRadius: 12)
                     .strokeBorder(lineWidth: 1)
-                    .foregroundColor(strokeColor)
+                    .foregroundStyle(strokeColor)
             )
             .padding(.horizontal, 16)
             
@@ -115,7 +115,7 @@ struct ValidationCheckTextField: View {
                 if isExceeded {
                     Text(textFieldError.message)
                         .shortcutsZipBody2()
-                        .foregroundColor(.shortcutsZipError)
+                        .foregroundStyle(Color.shortcutsZipError)
                         .padding(.leading)
                 }
                 
@@ -132,13 +132,13 @@ struct ValidationCheckTextField: View {
         HStack {
             Text(title)
                 .shortcutsZipHeadline()
-                .foregroundColor(.gray5)
+                .foregroundStyle(Color.gray5)
                 .padding(.leading, 16)
             
             if textType.isOptional {
                 Text(TextLiteral.validationCheckTextFieldOption)
                     .shortcutsZipFootnote()
-                    .foregroundColor(.gray3)
+                    .foregroundStyle(Color.gray3)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -183,7 +183,7 @@ struct ValidationCheckTextField: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .multilineTextAlignment(.leading)
                     .padding(16)
-                    .foregroundColor(.gray2)
+                    .foregroundStyle(Color.gray2)
                     .onTapGesture {
                         isFocused = true
                     }
@@ -210,19 +210,19 @@ struct ValidationCheckTextField: View {
             case .doneSuccess:
                 Image(systemName: "checkmark.circle.fill")
                     .smallIcon()
-                    .foregroundColor(.shortcutsZipSuccess)
+                    .foregroundStyle(Color.shortcutsZipSuccess)
                     .onTapGesture { }
             case .doneFail:
                 Image(systemName: "exclamationmark.circle.fill")
                     .smallIcon()
-                    .foregroundColor(.shortcutsZipError)
+                    .foregroundStyle(Color.shortcutsZipError)
             case .inProgressSuccess:
                 Button {
                     content.removeAll()
                 } label: {
                     Image(systemName: "xmark.circle.fill")
                         .smallIcon()
-                        .foregroundColor(.gray5)
+                        .foregroundStyle(Color.gray5)
                 }
             case .inProgressFail:
                 Button {
@@ -230,7 +230,7 @@ struct ValidationCheckTextField: View {
                 } label: {
                     Image(systemName: "xmark.circle.fill")
                         .smallIcon()
-                        .foregroundColor(.gray5)
+                        .foregroundStyle(Color.gray5)
                 }
             }
         }

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ListCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ListCurationView.swift
@@ -22,7 +22,7 @@ struct ListCurationView: View {
             if viewModel.curationList.isEmpty {
                 Text(viewModel.getEmptyContentsWording())
                     .shortcutsZipBody2()
-                    .foregroundColor(Color.gray4)
+                    .foregroundStyle(Color.gray4)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                 
             } else {

--- a/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadCurationView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreCurationViews/ReadCurationView.swift
@@ -87,7 +87,7 @@ struct ReadCurationView: View {
                     SubtitleTextView(text: viewModel.curation.title)
                     Text(viewModel.curation.subtitle.replacingOccurrences(of: "\\n", with: "\n"))
                         .shortcutsZipBody2()
-                        .foregroundColor(.gray4)
+                        .foregroundStyle(Color.gray4)
                 }
                 Spacer()
             }
@@ -129,7 +129,7 @@ extension ReadCurationView {
             }
         } label: {
             Image(systemName: "ellipsis")
-                .foregroundColor(.gray4)
+                .foregroundStyle(Color.gray4)
         }
     }
     
@@ -146,7 +146,7 @@ extension ReadCurationView {
             viewModel.shareCuration()
         } label: {
             Label(TextLiteral.share, systemImage: "square.and.arrow.up")
-                .foregroundColor(.gray4)
+                .foregroundStyle(Color.gray4)
                 .fontWeight(.medium)
         }
     }

--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ExploreShortcutView.swift
@@ -90,7 +90,7 @@ struct ExploreShortcutView: View {
             ToolbarItem {
                 Image(systemName: "magnifyingglass")
                     .shortcutsZipHeadline()
-                    .foregroundColor(.gray5)
+                    .foregroundStyle(Color.gray5)
                     .navigationLinkRouter(data: NavigationSearch.first)
             }
         }
@@ -178,7 +178,7 @@ extension ExploreShortcutView {
             .overlay {
                 Text(categoryName)
                     .shortcutsZipBody2()
-                    .foregroundColor(Color.gray5)
+                    .foregroundStyle(Color.gray5)
             }
     }
 }

--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ListCategoryShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ListCategoryShortcutView.swift
@@ -37,13 +37,13 @@ struct ListCategoryShortcutView: View {
     
     var categoryHeader: some View {
         Text(viewModel.category.fetchDescription().lineBreaking)
-        .foregroundColor(.gray5)
+        .foregroundStyle(Color.gray5)
         .shortcutsZipBody2()
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             Rectangle()
-                .foregroundColor(Color.gray1)
+                .fill(Color.gray1)
                 .cornerRadius(12)
         )
         .padding(.vertical, 20)

--- a/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ListShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ExploreShortcutViews/ListShortcutView.swift
@@ -17,7 +17,7 @@ struct ListShortcutView: View {
         if viewModel.shortcuts.count == 0 {
             Text("아직 \(viewModel.sectionType.title)가 없어요")
                 .shortcutsZipBody2()
-                .foregroundColor(Color.gray4)
+                .foregroundStyle(Color.gray4)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             
                 .background(Color.shortcutsZipBackground.ignoresSafeArea(.all, edges: .all))

--- a/HappyAnding/HappyAnding/Views/FeatureViews/AboutShortcutGradeView.swift
+++ b/HappyAnding/HappyAnding/Views/FeatureViews/AboutShortcutGradeView.swift
@@ -43,7 +43,7 @@ struct AboutShortcutGradeView: View {
             Text((shortcutsZipViewModel.userInfo?.nickname ?? TextLiteral.defaultUser) + TextLiteral.shortcutGradeCurrentLevel)
                 .shortcutsZipBody1()
                 .fontWeight(.bold)
-                .foregroundColor(.gray5)
+                .foregroundStyle(Color.gray5)
                 .frame(width: UIScreen.screenWidth - 32)
             
             Button {
@@ -56,7 +56,7 @@ struct AboutShortcutGradeView: View {
                         .resizable()
                         .aspectRatio(contentMode: .fill)
                         .fontWeight(.medium)
-                        .foregroundColor(.gray5)
+                        .foregroundStyle(Color.gray5)
                         .frame(width: 120, height: 120)
                         .rotation3DEffect(
                             .degrees(animationAmount), axis: (x: 0.0, y: 1.0, z: 0.0))
@@ -73,7 +73,7 @@ struct AboutShortcutGradeView: View {
             
             Text("\(shortcutsZipViewModel.checkShortcutGrade(userID: shortcutsZipViewModel.userInfo?.id).fetchTitle())")
                 .shortcutsZipTitle1()
-                .foregroundColor(.tagText)
+                .foregroundStyle(Color.tagText)
                 .padding(.horizontal, 16)
                 .padding(.vertical, 4)
                 .background(
@@ -88,14 +88,14 @@ struct AboutShortcutGradeView: View {
                  TextLiteral.shortcutGradeHighestLevel :
                     TextLiteral.shortcutGradeNumberOfShortcutsToNextLevelStart + "\(shortcutsZipViewModel.countShortcutsToNextGrade(numberOfShortcuts: shortcutsZipViewModel.shortcutsMadeByUser.count))" + TextLiteral.shortcutGradeNumberOfShortcutsToNextLevelEnd)
                 .shortcutsZipBody2()
-                .foregroundColor(.gray5)
+                .foregroundStyle(Color.gray5)
                 .frame(width: UIScreen.screenWidth - 32)
                 .padding(.top, 8)
         }
         .padding(.vertical, 20)
         .background {
             RoundedRectangle(cornerRadius: 12)
-                .foregroundColor(.gray1)
+                .fill(Color.gray1)
         }
         .padding(.horizontal, 16)
     }
@@ -105,7 +105,7 @@ struct AboutShortcutGradeView: View {
         VStack(alignment: .leading, spacing: 12) {
             Text(TextLiteral.shortcutGradeAnnouncementSectionTitle)
                 .shortcutsZipTitle2()
-                .foregroundColor(.gray5)
+                .foregroundStyle(Color.gray5)
             
             ForEach(shortcutGrade.filter{ $0 != .level0 }, id: \.self) { grade in
                 ExplainGradeCell(gradeIcon: grade.fetchIcon(),
@@ -115,7 +115,7 @@ struct AboutShortcutGradeView: View {
             
             Text(TextLiteral.shortcutGradeMaybeDownGrade)
                 .shortcutsZipFootnote()
-                .foregroundColor(.gray3)
+                .foregroundStyle(Color.gray3)
                 .padding(.top, 8)
         }
         .padding(.horizontal, 16)
@@ -132,8 +132,8 @@ struct ExplainGradeCell: View {
         HStack(spacing: 16) {
             ZStack(alignment: .center) {
                 Circle()
+                    .fill(Color.gray1)
                     .frame(width: 72, height: 72)
-                    .foregroundColor(.gray1)
                 Image(gradeIcon)
             }
             
@@ -141,10 +141,10 @@ struct ExplainGradeCell: View {
                 Text(gradeName)
                     .shortcutsZipBody1()
                     .fontWeight(.bold)
-                    .foregroundColor(.gray5)
+                    .foregroundStyle(Color.gray5)
                 Text(gradeDescription)
                     .shortcutsZipBody2()
-                    .foregroundColor(.gray5)
+                    .foregroundStyle(Color.gray5)
             }
             Spacer()
         }

--- a/HappyAnding/HappyAnding/Views/HappyAndingApp.swift
+++ b/HappyAnding/HappyAnding/Views/HappyAndingApp.swift
@@ -36,7 +36,7 @@ struct HappyAndingApp: App {
                 ZStack {
                     Color.shortcutsZipPrimary.ignoresSafeArea()
                     Text("ShortcutsZip")
-                        .foregroundColor(Color.white)
+                        .foregroundStyle(Color.white)
                         .font(.system(size: 26, weight: .bold))
                         .frame(maxHeight: .infinity)
                         .ignoresSafeArea()

--- a/HappyAnding/HappyAnding/Views/MyPageViews/EditNicknameView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/EditNicknameView.swift
@@ -19,7 +19,7 @@ struct EditNicknameView: View {
         VStack(alignment: .leading) {
             Text(TextLiteral.editNicknameViewHeadline)
                 .shortcutsZipTitle1()
-                .foregroundColor(.gray5)
+                .foregroundStyle(Color.gray5)
                 .padding(.top, 40)
             
             NicknameTextField(nickname: $nickname, isValid: $isValid, initName: self.user?.nickname ?? "")
@@ -60,10 +60,10 @@ struct EditNicknameView: View {
         }, label: {
             ZStack {
                 RoundedRectangle(cornerRadius: 12)
-                    .foregroundColor(isValid ? .shortcutsZipPrimary : .shortcutsZipPrimary .opacity(0.13))
+                    .fill(isValid ? Color.shortcutsZipPrimary : Color.shortcutsZipPrimary.opacity(0.13))
                     .frame(height: 52)
                 Text(TextLiteral.done)
-                    .foregroundColor(isValid ? .textIcon : .textButtonDisable)
+                    .foregroundStyle(isValid ? Color.textIcon : Color.textButtonDisable)
                     .shortcutsZipBody1()
             }
         })

--- a/HappyAnding/HappyAnding/Views/MyPageViews/MyPageView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/MyPageView.swift
@@ -29,13 +29,13 @@ struct MyPageView: View {
                         shortcutsZipViewModel.fetchShortcutGradeImage(isBig: true, shortcutGrade: shortcutsZipViewModel.checkShortcutGrade(userID: shortcutsZipViewModel.userInfo?.id ?? "!"))
                             .font(.system(size: 60, weight: .medium))
                             .frame(width: 60, height: 60)
-                            .foregroundColor(.gray3)
+                            .foregroundStyle(Color.gray3)
                             .id(333)
                     }
                     
                     Text(shortcutsZipViewModel.userInfo?.nickname ?? TextLiteral.defaultUser)
                         .shortcutsZipTitle1()
-                        .foregroundColor(.gray5)
+                        .foregroundStyle(Color.gray5)
                     
                     Spacer()
                 }
@@ -70,7 +70,7 @@ struct MyPageView: View {
             ToolbarItem {
                 Image(systemName: "gearshape.fill")
                     .shortcutsZipHeadline()
-                    .foregroundColor(.gray5)
+                    .foregroundStyle(Color.gray5)
                     .navigationLinkRouter(data: NavigationSettingView.first)
             }
         }
@@ -92,11 +92,11 @@ struct MyPageShortcutListCell: View {
         HStack() {
             Text(type == .myLovingShortcut ? TextLiteral.myPageViewLikedShortcuts : TextLiteral.myPageViewDownloadedShortcuts)
                 .shortcutsZipTitle2()
-                .foregroundColor(.gray5)
+                .foregroundStyle(Color.gray5)
                 .padding(.trailing, 9)
             Text("\(shortcuts.count)개")
                 .shortcutsZipBody2()
-                .foregroundColor(Color.tagText)
+                .foregroundStyle(Color.tagText)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 4)
                 .background(
@@ -109,7 +109,7 @@ struct MyPageShortcutListCell: View {
             Spacer()
             Image(systemName: "chevron.forward")
                 .mediumIcon()
-                .foregroundColor(.gray5)
+                .foregroundStyle(Color.gray5)
             
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/HappyAnding/HappyAnding/Views/MyPageViews/SettingView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/SettingView.swift
@@ -206,7 +206,7 @@ struct SettingCell: View {
             Spacer()
         }
         .shortcutsZipBody1()
-        .foregroundColor(.gray4)
+        .foregroundStyle(Color.gray4)
         .padding(.horizontal, 12)
         .padding(.vertical, 16)
     }
@@ -220,12 +220,12 @@ struct FunctionCell: View {
         HStack {
             Text(title)
                 .shortcutsZipBody1()
-                .foregroundColor(.gray4)
+                .foregroundStyle(Color.gray4)
             Spacer()
             if let tag {
                 Text(tag)
                     .shortcutsZipBody2()
-                    .foregroundColor(Color.tagText)
+                    .foregroundStyle(Color.tagText)
                     .frame(height: 20)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 2)

--- a/HappyAnding/HappyAnding/Views/MyPageViews/SettingViews/AboutTeamView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/SettingViews/AboutTeamView.swift
@@ -14,12 +14,12 @@ struct AboutTeamView: View {
             VStack {
                 Text("Team Happy ANDing")
                     .shortcutsZipTitle1()
-                    .foregroundColor(Color.gray5)
+                    .foregroundStyle(Color.gray5)
                     .multilineTextAlignment(.leading)
                     .padding(.horizontal, 16)
                 Text("안녕하세요. ShortcutsZip의 개발팀 Team Happy ANDing입니다. ")
                     .shortcutsZipBody2()
-                    .foregroundColor(Color.gray3)
+                    .foregroundStyle(Color.gray3)
                     .multilineTextAlignment(.leading)
                     .padding(.bottom, 16)
             }
@@ -41,8 +41,8 @@ struct AboutTeamView: View {
     var devCard: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 12)
+                .fill(Color.gray2)
                 .frame(height: 200)
-                .foregroundColor(Color.gray2)
                 .contextMenu{
                     Button {
                         // Add this item to a list of favorites.

--- a/HappyAnding/HappyAnding/Views/MyPageViews/SettingViews/CheckVersionView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/SettingViews/CheckVersionView.swift
@@ -43,11 +43,11 @@ struct CheckVersionView: View {
                 
                 Text("\(currentVersion) / \(latestVersion)")
                     .shortcutsZipFootnote()
-                    .foregroundColor(.gray3)
+                    .foregroundStyle(Color.gray3)
                 
                 Text(versionInformation)
                     .shortcutsZipHeadline()
-                    .foregroundColor(.gray5)
+                    .foregroundStyle(Color.gray5)
             }
             
             Spacer()
@@ -58,12 +58,12 @@ struct CheckVersionView: View {
             } label: {
                 ZStack {
                     RoundedRectangle(cornerRadius: 12)
-                        .foregroundColor(.shortcutsZipPrimary)
+                        .fill(Color.shortcutsZipPrimary)
                         .frame(maxWidth: .infinity, maxHeight: 52)
                     
                     Text(buttonText)
                         .shortcutsZipBody1()
-                        .foregroundColor(.textButton)
+                        .foregroundStyle(Color.textButton)
                 }
                 .padding(.bottom, 44)
             }

--- a/HappyAnding/HappyAnding/Views/MyPageViews/SettingViews/LicenseView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/SettingViews/LicenseView.swift
@@ -31,14 +31,14 @@ struct LicenseCell: View {
         VStack(alignment: .leading) {
             Text(.init(title))
                 .shortcutsZipTitle2()
-                .foregroundColor(Color.gray5)
+                .foregroundStyle(Color.gray5)
                 .multilineTextAlignment(.leading)
                 .padding(.top, 36)
                 .tint(.gray5)
             
             Text(text)
                 .shortcutsZipBody2()
-                .foregroundColor(Color.gray4)
+                .foregroundStyle(Color.gray4)
                 .multilineTextAlignment(.leading)
             Spacer()
         }

--- a/HappyAnding/HappyAnding/Views/MyPageViews/SettingViews/WithdrawalView.swift
+++ b/HappyAnding/HappyAnding/Views/MyPageViews/SettingViews/WithdrawalView.swift
@@ -30,19 +30,19 @@ struct WithdrawalView: View {
             
             Text(TextLiteral.withdrawalViewHeadline)
                 .shortcutsZipTitle2()
-                .foregroundColor(.gray5)
+                .foregroundStyle(Color.gray5)
                 .multilineTextAlignment(.leading)
                 .padding(.vertical, 32)
             
             ForEach(0..<signOutTitle.count, id: \.self) { index in
                 Text(signOutTitle[index])
                     .shortcutsZipBody2()
-                    .foregroundColor(.gray5)
+                    .foregroundStyle(Color.gray5)
                     .padding(.bottom, 8)
                 
                 Text(signOutDescription[index])
                     .shortcutsZipBody2()
-                    .foregroundColor(.gray3)
+                    .foregroundStyle(Color.gray3)
                     .padding(.bottom, 16)
             }
             
@@ -51,13 +51,13 @@ struct WithdrawalView: View {
             HStack(spacing: 8) {
                 Image(systemName: isTappedCheckToggle ? "checkmark.square.fill" : "square")
                     .mediumIcon()
-                    .foregroundColor(isTappedCheckToggle ? .shortcutsZipPrimary : .gray4)
+                    .foregroundStyle(isTappedCheckToggle ? Color.shortcutsZipPrimary : Color.gray4)
                     .onTapGesture {
                         isTappedCheckToggle.toggle()
                     }
                 Text(TextLiteral.withdrawalViewAgree)
                     .shortcutsZipBody2()
-                    .foregroundColor(.gray4)
+                    .foregroundStyle(Color.gray4)
                     .multilineTextAlignment(.leading)
                     .onTapGesture {
                         self.isTappedCheckToggle.toggle()
@@ -72,11 +72,11 @@ struct WithdrawalView: View {
             } label: {
                 ZStack {
                     RoundedRectangle(cornerRadius: 12)
-                        .foregroundColor(isTappedCheckToggle ? .shortcutsZipPrimary : .shortcutsZipPrimary .opacity(0.13))
+                        .foregroundStyle(isTappedCheckToggle ? Color.shortcutsZipPrimary : Color.shortcutsZipPrimary.opacity(0.13))
                         .frame(maxWidth: .infinity, maxHeight: 52)
                     
                     Text(TextLiteral.withdrawalViewButton)
-                        .foregroundColor(isTappedCheckToggle ? .textButton : .textButtonDisable )
+                        .foregroundStyle(isTappedCheckToggle ? Color.textButton : Color.textButtonDisable )
                         .shortcutsZipBody1()
                 }
             }

--- a/HappyAnding/HappyAnding/Views/ReadShortcutViews/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ReadShortcutViews/ReadShortcutView.swift
@@ -108,7 +108,7 @@ struct ReadShortcutView: View {
                             } label: {
                                 Text("다운로드 | \(Image(systemName: "arrow.down.app.fill")) \(viewModel.shortcut.numberOfDownload)")
                                     .shortcutsZipBody1()
-                                    .foregroundColor(Color.textIcon)
+                                    .foregroundStyle(Color.textIcon)
                                     .padding()
                                     .frame(maxWidth: .infinity)
                                     .background(Color.shortcutsZipPrimary)
@@ -214,7 +214,7 @@ extension ReadShortcutView {
                 if viewModel.comment.depth == 1 && !viewModel.isEditingComment {
                     Image(systemName: "arrow.turn.down.right")
                         .smallIcon()
-                        .foregroundColor(.gray4)
+                        .foregroundStyle(Color.gray4)
                 }
                 TextField(useWithoutSignIn ? TextLiteral.readShortcutViewCommentDescriptionBeforeLogin : TextLiteral.readShortcutViewCommentDescription, text: $viewModel.commentText, axis: .vertical)
                     .keyboardType(.twitter)
@@ -234,7 +234,7 @@ extension ReadShortcutView {
                 } label: {
                     Image(systemName: "paperplane.fill")
                         .mediumIcon()
-                        .foregroundColor(viewModel.commentText == "" ? Color.gray2 : Color.gray5)
+                        .foregroundStyle(viewModel.commentText == "" ? Color.gray2 : Color.gray5)
                 }
                 .disabled(viewModel.commentText == "" ? true : false)
             }
@@ -255,7 +255,7 @@ extension ReadShortcutView {
         HStack {
             Text("@ \(viewModel.nestedCommentTarget)")
                 .shortcutsZipFootnote()
-                .foregroundColor(.gray5)
+                .foregroundStyle(Color.gray5)
             
             Spacer()
             
@@ -264,7 +264,7 @@ extension ReadShortcutView {
             } label: {
                 Image(systemName: "xmark")
                     .smallIcon()
-                    .foregroundColor(.gray5)
+                    .foregroundStyle(Color.gray5)
             }
         }
         .padding(.horizontal, 16)
@@ -292,7 +292,7 @@ extension ReadShortcutView {
             } label: {
                 Image(systemName: "ellipsis")
                     .mediumIcon()
-                    .foregroundColor(.gray4)
+                    .foregroundStyle(Color.gray4)
             }
         } else {
             shareButton
@@ -320,7 +320,7 @@ extension ReadShortcutView {
             viewModel.shareShortcut()
         } label: {
             Label(TextLiteral.share, systemImage: "square.and.arrow.up")
-                .foregroundColor(.gray4)
+                .foregroundStyle(Color.gray4)
                 .fontWeight(.medium)
         }
     }
@@ -354,7 +354,7 @@ extension ReadShortcutView {
                 if viewModel.currentTab == tabID {
                     Text(title)
                         .shortcutsZipHeadline()
-                        .foregroundColor(.gray5)
+                        .foregroundStyle(Color.gray5)
                     Color.gray5
                         .frame(height: 2)
                         .matchedGeometryEffect(id: "underline", in: namespace, properties: .frame)
@@ -362,7 +362,7 @@ extension ReadShortcutView {
                 } else {
                     Text(title)
                         .shortcutsZipBody1()
-                        .foregroundColor(.gray3)
+                        .foregroundStyle(Color.gray3)
                     Color.clear.frame(height: 2)
                 }
             }
@@ -392,7 +392,7 @@ extension ReadShortcutView {
                     VStack {
                         Image(systemName: viewModel.shortcut.sfSymbol)
                             .mediumShortcutIcon()
-                            .foregroundColor(Color.textIcon)
+                            .foregroundStyle(Color.textIcon)
                     }
                     .frame(width: 52, height: 52)
                     .background(Color.fetchGradient(color: viewModel.shortcut.color))
@@ -404,7 +404,7 @@ extension ReadShortcutView {
                     Text("\(viewModel.isMyLike ? Image(systemName: "heart.fill") : Image(systemName: "heart")) \(viewModel.numberOfLike)")
                         .shortcutsZipBody2()
                         .padding(10)
-                        .foregroundColor(viewModel.isMyLike ? Color.textIcon : Color.gray4)
+                        .foregroundStyle(viewModel.isMyLike ? Color.textIcon : Color.gray4)
                         .background(viewModel.isMyLike ? Color.shortcutsZipPrimary : Color.gray1)
                         .cornerRadius(12)
                         .onTapGesture {
@@ -421,12 +421,12 @@ extension ReadShortcutView {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("\(viewModel.shortcut.title)")
                         .shortcutsZipTitle1()
-                        .foregroundColor(Color.gray5)
+                        .foregroundStyle(Color.gray5)
                         .fixedSize(horizontal: false, vertical: true)
                     
                     Text("\(viewModel.shortcut.subtitle)")
                         .shortcutsZipBody1()
-                        .foregroundColor(Color.gray3)
+                        .foregroundStyle(Color.gray3)
                         .fixedSize(horizontal: false, vertical: true)
                 }
                 
@@ -453,10 +453,10 @@ extension ReadShortcutView {
                     Text(TextLiteral.readShortcutContentViewDescription)
                         .shortcutsZipBody2()
                         .fontWeight(.bold)
-                        .foregroundColor(Color.gray6)
+                        .foregroundStyle(Color.gray6)
                     Text(.init(viewModel.shortcut.description))
                         .shortcutsZipBody2()
-                        .foregroundColor(Color.gray5)
+                        .foregroundStyle(Color.gray5)
                         .tint(.shortcutsZipPrimary)
                         .lineLimit(nil)
                 }
@@ -479,19 +479,19 @@ extension ReadShortcutView {
                 Text(title)
                     .shortcutsZipBody2()
                     .fontWeight(.bold)
-                    .foregroundColor(Color.gray6)
+                    .foregroundStyle(Color.gray6)
                 
                 WrappingHStack(content, id: \.self, alignment: .leading, spacing: .constant(8), lineSpacing: 8) { item in
                     if Category.allCases.contains(where: { $0.rawValue == item }) {
                         Text(Category(rawValue: item)?.translateName() ?? "")
                             .shortcutsZipBody2()
                             .padding(.trailing, 8)
-                            .foregroundColor(Color.gray5)
+                            .foregroundStyle(Color.gray5)
                     } else {
                         Text(item)
                             .shortcutsZipBody2()
                             .padding(.trailing, 8)
-                            .foregroundColor(Color.gray5)
+                            .foregroundStyle(Color.gray5)
                     }
                     if item != content.last {
                         Divider()
@@ -520,21 +520,21 @@ extension ReadShortcutView {
                     HStack {
                         Text("Ver 1.0")
                             .shortcutsZipBody2()
-                            .foregroundColor(.gray5)
+                            .foregroundStyle(Color.gray5)
                         
                         Spacer()
                         
                         Text(viewModel.shortcut.date.first?.getVersionUpdateDateFormat() ?? "")
                             .shortcutsZipBody2()
-                            .foregroundColor(.gray3)
+                            .foregroundStyle(Color.gray3)
                     }
                     Text(TextLiteral.readShortcutVersionViewNoUpdates)
                         .shortcutsZipBody2()
-                        .foregroundColor(.gray4)
+                        .foregroundStyle(Color.gray4)
                 } else {
                     Text(TextLiteral.readShortcutVersionViewUpdateContent)
                         .shortcutsZipBody2()
-                        .foregroundColor(.gray4)
+                        .foregroundStyle(Color.gray4)
                     
                     versionView
                 }
@@ -552,19 +552,19 @@ extension ReadShortcutView {
                     HStack {
                         Text("Ver \(viewModel.shortcut.updateDescription.count - index).0")
                             .shortcutsZipBody2()
-                            .foregroundColor(.gray5)
+                            .foregroundStyle(Color.gray5)
                         
                         Spacer()
                         
                         Text(viewModel.shortcut.date[index].getVersionUpdateDateFormat())
                             .shortcutsZipBody2()
-                            .foregroundColor(.gray3)
+                            .foregroundStyle(Color.gray3)
                     }
                     
                     if data.trimmingCharacters(in: .whitespacesAndNewlines) != "" {
                         Text(data)
                             .shortcutsZipBody2()
-                            .foregroundColor(.gray5)
+                            .foregroundStyle(Color.gray5)
                     }
                     
                     if index != 0 {
@@ -581,12 +581,12 @@ extension ReadShortcutView {
                         } label: {
                             Text(TextLiteral.readShortcutVersionViewDownloadPreviousVersion)
                                 .shortcutsZipBody2()
-                                .foregroundColor(.shortcutsZipPrimary)
+                                .foregroundStyle(Color.shortcutsZipPrimary)
                         }
                     }
                     
                     Divider()
-                        .foregroundColor(.gray1)
+                        .foregroundStyle(Color.gray1)
                 }
             }
         }
@@ -610,7 +610,7 @@ extension ReadShortcutView {
                 if viewModel.comments.comments.isEmpty {
                     Text(TextLiteral.readShortcutCommentViewNoComments)
                         .shortcutsZipBody2()
-                        .foregroundColor(.gray4)
+                        .foregroundStyle(Color.gray4)
                         .padding(.top, 16)
                 } else {
                     commentView
@@ -645,7 +645,7 @@ extension ReadShortcutView {
                     if comment.depth == 1 {
                         Image(systemName: "arrow.turn.down.right")
                             .smallIcon()
-                            .foregroundColor(.gray4)
+                            .foregroundStyle(Color.gray4)
                     }
                     
                     VStack(alignment: .leading, spacing: 8) {
@@ -656,24 +656,24 @@ extension ReadShortcutView {
                             viewModel.fetchUserGrade(id: comment.user_id)
                                 .font(.system(size: 24, weight: .medium))
                                 .frame(width: 24, height: 24)
-                                .foregroundColor(.gray3)
+                                .foregroundStyle(Color.gray3)
                             
                             Text(comment.user_nickname)
                                 .shortcutsZipBody2()
-                                .foregroundColor(.gray4)
+                                .foregroundStyle(Color.gray4)
                             
                             Spacer()
                             
                             Text(comment.date.getVersionUpdateDateFormat())
                                 .shortcutsZipFootnote()
-                                .foregroundColor(.gray4)
+                                .foregroundStyle(Color.gray4)
                         }
                         .padding(.bottom, 4)
                         
                         /// 댓글 내용
                         Text(comment.contents)
                             .shortcutsZipBody2()
-                            .foregroundColor(.gray5)
+                            .foregroundStyle(Color.gray5)
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(.leading, 4)
                         
@@ -686,7 +686,7 @@ extension ReadShortcutView {
                                 } label: {
                                     Text(TextLiteral.readShortcutCommentViewReply)
                                         .shortcutsZipFootnote()
-                                        .foregroundColor(.gray4)
+                                        .foregroundStyle(Color.gray4)
                                         .frame(width: 32, height: 24)
                                 }
                             }
@@ -701,7 +701,7 @@ extension ReadShortcutView {
                                     } label: {
                                         Text(TextLiteral.readShortcutCommentViewEdit)
                                             .shortcutsZipFootnote()
-                                            .foregroundColor(.gray4)
+                                            .foregroundStyle(Color.gray4)
                                             .frame(width: 32, height: 24)
                                     }
                                     
@@ -711,7 +711,7 @@ extension ReadShortcutView {
                                     } label: {
                                         Text(TextLiteral.delete)
                                             .shortcutsZipFootnote()
-                                            .foregroundColor(.gray4)
+                                            .foregroundStyle(Color.gray4)
                                             .frame(width: 32, height: 24)
                                     }
                                 }

--- a/HappyAnding/HappyAnding/Views/ReadShortcutViews/ShowProfileView.swift
+++ b/HappyAnding/HappyAnding/Views/ReadShortcutViews/ShowProfileView.swift
@@ -31,12 +31,12 @@ struct ShowProfileView: View {
                             viewModel.userGrade
                                 .resizable()
                                 .frame(width: 72, height: 72)
-                                .foregroundColor(.gray3)
+                                .foregroundStyle(Color.gray3)
                         } else {
                             ZStack(alignment: .center) {
                                 Circle()
+                                    .fill(Color.gray1)
                                     .frame(width: 72, height: 72)
-                                    .foregroundColor(.gray1)
                                 viewModel.userGrade
                                     .rotation3DEffect(
                                         .degrees(viewModel.animationAmount), axis: (x: 0.0, y: 1.0, z: 0.0))
@@ -46,7 +46,7 @@ struct ShowProfileView: View {
                     
                     Text(viewModel.user.nickname)
                         .shortcutsZipTitle1()
-                        .foregroundColor(.gray5)
+                        .foregroundStyle(Color.gray5)
                 }
                 .disabled(viewModel.shortcuts.isEmpty)
                 .frame(maxWidth: .infinity)
@@ -92,7 +92,7 @@ struct ShowProfileView: View {
                 if viewModel.currentTab == tabID {
                     Text(title)
                         .shortcutsZipHeadline()
-                        .foregroundColor(.gray5)
+                        .foregroundStyle(Color.gray5)
                     Color.gray5
                         .frame(height: 2)
                         .matchedGeometryEffect(id: "underline", in: namespace, properties: .frame)
@@ -100,7 +100,7 @@ struct ShowProfileView: View {
                 } else {
                     Text(title)
                         .shortcutsZipBody1()
-                        .foregroundColor(.gray3)
+                        .foregroundStyle(Color.gray3)
                     Color.clear
                         .frame(height: 2)
                 }
@@ -128,7 +128,7 @@ struct ShowProfileView: View {
                             Text(TextLiteral.showProfileViewNoShortcuts)
                                 .padding(.top, 16)
                                 .shortcutsZipBody2()
-                                .foregroundColor(.gray4)
+                                .foregroundStyle(Color.gray4)
                             Spacer()
                         }
                     }
@@ -150,7 +150,7 @@ struct ShowProfileView: View {
                             Text(TextLiteral.showProfileViewNoCurations)
                                 .padding(.top, 16)
                                 .shortcutsZipBody2()
-                                .foregroundColor(.gray4)
+                                .foregroundStyle(Color.gray4)
                             Spacer()
                         }
                     }

--- a/HappyAnding/HappyAnding/Views/ReadShortcutViews/UpdateShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ReadShortcutViews/UpdateShortcutView.swift
@@ -20,7 +20,7 @@ struct UpdateShortcutView: View {
                     viewModel.isUpdatingShortcut.toggle()
                 } label: {
                     Text(TextLiteral.cancel)
-                        .foregroundColor(.gray5)
+                        .foregroundStyle(Color.gray5)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 
@@ -68,10 +68,10 @@ struct UpdateShortcutView: View {
             } label: {
                 ZStack {
                     RoundedRectangle(cornerRadius: 12)
-                        .foregroundColor(viewModel.isUpdateValid ? .shortcutsZipPrimary : .shortcutsZipPrimary.opacity(0.13))
+                        .fill(viewModel.isUpdateValid ? Color.shortcutsZipPrimary : Color.shortcutsZipPrimary.opacity(0.13))
                         .frame(maxWidth: .infinity, maxHeight: 52)
                     Text(TextLiteral.update)
-                        .foregroundColor(viewModel.isUpdateValid ? .textButton : .textButtonDisable)
+                        .foregroundStyle(viewModel.isUpdateValid ? Color.textButton : Color.textButtonDisable)
                         .shortcutsZipBody1()
                 }
             }

--- a/HappyAnding/HappyAnding/Views/SearchView.swift
+++ b/HappyAnding/HappyAnding/Views/SearchView.swift
@@ -75,7 +75,7 @@ struct SearchView: View {
         HStack(alignment: .center, spacing: 8) {
             HStack {
                 Image(systemName: "magnifyingglass")
-                    .foregroundColor(.gray5)
+                    .foregroundStyle(Color.gray5)
                 TextField(TextLiteral.searchViewPrompt, text: $searchText)
                     .shortcutsZipBody1()
                     .accentColor(.gray5)
@@ -110,7 +110,7 @@ struct SearchView: View {
                     ForEach(keywords.keyword, id: \.self) { keyword in
                         Text(keyword)
                             .shortcutsZipBody2()
-                            .foregroundColor(Color.gray4)
+                            .foregroundStyle(Color.gray4)
                             .padding(.horizontal, 12)
                             .padding(.vertical, 8)
                             .overlay(
@@ -133,7 +133,7 @@ struct SearchView: View {
         VStack(alignment: .center) {
             Text("\'\(searchText)\'의 결과가 없어요.\n원하는 단축어가 있다면 제안해보세요!").multilineTextAlignment(.center)
                 .shortcutsZipBody1()
-                .foregroundColor(Color.gray4)
+                .foregroundStyle(Color.gray4)
             
             Link(destination: URL(string: TextLiteral.searchViewProposalURL)!) {
                 Text(TextLiteral.searchViewProposal)

--- a/HappyAnding/HappyAnding/Views/SignInViews/PrivacyPolicyView.swift
+++ b/HappyAnding/HappyAnding/Views/SignInViews/PrivacyPolicyView.swift
@@ -31,7 +31,7 @@ struct PrivacyPolicyView: View {
                     self.isTappedPrivacyButton = false
                 } label: {
                     Text(TextLiteral.close)
-                        .foregroundColor(.gray5)
+                        .foregroundStyle(Color.gray5)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.leading, 16)
                 }

--- a/HappyAnding/HappyAnding/Views/SignInViews/SignInWithAppleView.swift
+++ b/HappyAnding/HappyAnding/Views/SignInViews/SignInWithAppleView.swift
@@ -30,11 +30,11 @@ struct SignInWithAppleView: View {
             
             Text(TextLiteral.signInWithAppleViewTitle)
                 .shortcutsZipLargeTitle()
-                .foregroundColor(.shortcutsZipPrimary)
+                .foregroundStyle(Color.shortcutsZipPrimary)
             
             Text(TextLiteral.signInWithAppleViewSubTitle)
                 .shortcutsZipBody2()
-                .foregroundColor(.gray3)
+                .foregroundStyle(Color.gray3)
             
             Spacer()
             
@@ -43,12 +43,12 @@ struct SignInWithAppleView: View {
             }, label: {
                 ZStack {
                     RoundedRectangle(cornerRadius: 12)
+                        .fill(Color.gray5)
                         .padding(.horizontal, 16)
                         .frame(height: 52)
-                        .foregroundColor(.gray5)
                     
                     Label(TextLiteral.signInWithAppleViewSignInWithApple, systemImage: "applelogo")
-                        .foregroundColor(.shortcutsZipWhite)
+                        .foregroundStyle(Color.shortcutsZipWhite)
                 }
                 .padding(.bottom, 8)
             })
@@ -59,7 +59,7 @@ struct SignInWithAppleView: View {
             }, label: {
                 Text(TextLiteral.signInWithAppleViewUseWithoutSignIn)
                     .shortcutsZipBody2()
-                    .foregroundColor(.gray5)
+                    .foregroundStyle(Color.gray5)
             })
             .padding(.bottom, 12)
         }

--- a/HappyAnding/HappyAnding/Views/SignInViews/WriteNicknameView.swift
+++ b/HappyAnding/HappyAnding/Views/SignInViews/WriteNicknameView.swift
@@ -40,7 +40,7 @@ struct WriteNicknameView: View {
             
             Text(TextLiteral.writeNicknameViewHeadline)
                 .shortcutsZipTitle1()
-                .foregroundColor(.gray5)
+                .foregroundStyle(Color.gray5)
                 .padding(.top, 40)
             
             NicknameTextField(nickname: $nickname, isValid: $isValid)
@@ -49,7 +49,7 @@ struct WriteNicknameView: View {
             
             Text(TextLiteral.settingViewPrivacyPolicy)
                 .shortcutsZipBody2()
-                .foregroundColor(Color.gray3)
+                .foregroundStyle(Color.gray3)
                 .padding(.bottom, 12)
                 .frame(maxWidth: .infinity)
                 .onTapGesture {
@@ -87,10 +87,10 @@ struct WriteNicknameView: View {
         }, label: {
             ZStack {
                 RoundedRectangle(cornerRadius: 12)
-                    .foregroundColor(isValid ? .shortcutsZipPrimary : .shortcutsZipPrimary .opacity(0.13))
+                    .fill(isValid ? Color.shortcutsZipPrimary : Color.shortcutsZipPrimary.opacity(0.13))
                     .frame(height: 52)
                 Text(TextLiteral.writeNicknameViewStart)
-                    .foregroundColor(isValid ? .textIcon : .textButtonDisable)
+                    .foregroundStyle(isValid ? Color.textIcon : Color.textButtonDisable)
                     .shortcutsZipBody1()
             }
         })

--- a/HappyAnding/HappyAnding/Views/WriteCurationViews/CheckBoxShortcutCell.swift
+++ b/HappyAnding/HappyAnding/Views/WriteCurationViews/CheckBoxShortcutCell.swift
@@ -54,7 +54,7 @@ struct CheckBoxShortcutCell: View {
     var toggle: some View {
         Image(systemName: isShortcutTapped ? "checkmark.square.fill" : "square")
             .smallIcon()
-            .foregroundColor(isShortcutTapped ? .shortcutsZipPrimary : .gray3)
+            .foregroundStyle(isShortcutTapped ? Color.shortcutsZipPrimary : Color.gray3)
             .padding(.leading, 20)
     }
     
@@ -68,7 +68,7 @@ struct CheckBoxShortcutCell: View {
             
             Image(systemName: shortcutCell.sfSymbol)
                 .mediumShortcutIcon()
-                .foregroundColor(.white)
+                .foregroundStyle(Color.white)
         }
         .padding(.leading, 12)
     }
@@ -78,11 +78,11 @@ struct CheckBoxShortcutCell: View {
         VStack(alignment: .leading, spacing: 4) {
             Text(shortcutCell.title)
                 .shortcutsZipHeadline()
-                .foregroundColor(.gray5)
+                .foregroundStyle(Color.gray5)
                 .lineLimit(1)
             Text(shortcutCell.subtitle)
                 .shortcutsZipFootnote()
-                .foregroundColor(.gray3)
+                .foregroundStyle(Color.gray3)
                 .lineLimit(2)
         }
         .padding(.leading, 12)

--- a/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationInfoView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationInfoView.swift
@@ -70,7 +70,7 @@ struct WriteCurationInfoView: View {
                 } label: {
                     Text(TextLiteral.upload)
                         .shortcutsZipHeadline()
-                        .foregroundColor(isIncomplete ? .shortcutsZipPrimary.opacity(0.3) : .shortcutsZipPrimary)
+                        .foregroundStyle(isIncomplete ? Color.shortcutsZipPrimary.opacity(0.3) : Color.shortcutsZipPrimary)
                 }
                 .disabled(isIncomplete)
             }

--- a/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationSetView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteCurationViews/WriteCurationSetView.swift
@@ -33,7 +33,7 @@ struct WriteCurationSetView: View {
                 Spacer()
                 Text(TextLiteral.writeCurationSetViewNoShortcuts)
                     .shortcutsZipBody2()
-                    .foregroundColor(.gray4)
+                    .foregroundStyle(Color.gray4)
                     .multilineTextAlignment(.center)
                 Spacer()
                 
@@ -57,7 +57,7 @@ struct WriteCurationSetView: View {
                 } label: {
                     Text(TextLiteral.cancel)
                         .shortcutsZipBody1()
-                        .foregroundColor(.gray4)
+                        .foregroundStyle(Color.gray4)
                 }
             }
             
@@ -65,7 +65,7 @@ struct WriteCurationSetView: View {
                 Text(TextLiteral.next)
                     .navigationLinkRouter(data: WriteCurationInfoType(curation: curation, deletedShortcutCells: deletedShortcutCells, isEdit: isEdit), isPresented: $isWriting)
                     .shortcutsZipHeadline()
-                    .foregroundColor(curation.shortcuts.isEmpty ? .shortcutsZipPrimary.opacity(0.3) : .shortcutsZipPrimary)
+                    .foregroundStyle(curation.shortcuts.isEmpty ? Color.shortcutsZipPrimary.opacity(0.3) : Color.shortcutsZipPrimary)
                     .disabled(curation.shortcuts.isEmpty)
             }
         }
@@ -76,14 +76,14 @@ struct WriteCurationSetView: View {
         HStack(alignment: .bottom, spacing: 8) {
             Text(TextLiteral.writeCurationSetViewSelectionTitle)
                 .shortcutsZipSb()
-                .foregroundColor(.gray5)
+                .foregroundStyle(Color.gray5)
             Text(TextLiteral.writeCurationSetViewSelectionDescription)
                 .shortcutsZipFootnote()
-                .foregroundColor(.gray3)
+                .foregroundStyle(Color.gray3)
             Spacer()
             Text("\(curation.shortcuts.count)개")
                 .shortcutsZipBody2()
-                .foregroundColor(.shortcutsZipPrimary)
+                .foregroundStyle(Color.shortcutsZipPrimary)
         }
         .padding(.horizontal, 16)
     }
@@ -108,11 +108,11 @@ struct WriteCurationSetView: View {
         Text(TextLiteral.writeCurationSetViewSelectionInformation)
             .frame(maxWidth: .infinity, alignment: .leading)
             .shortcutsZipBody2()
-            .foregroundColor(.gray5)
+            .foregroundStyle(Color.gray5)
             .padding(.all, 16)
             .background(
                 RoundedRectangle(cornerRadius: 12)
-                    .foregroundColor(.gray1)
+                    .fill(Color.gray1)
             )
             .padding(.horizontal, 16)
             .padding(.bottom, 20)

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/CategoryModalView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/CategoryModalView.swift
@@ -25,7 +25,7 @@ struct CategoryModalView: View {
                         self.isShowingCategoryModal = false
                     } label: {
                         Text(TextLiteral.close)
-                            .foregroundColor(.gray5)
+                            .foregroundStyle(Color.gray5)
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(.leading, 16)
                     }
@@ -56,11 +56,11 @@ struct CategoryModalView: View {
                 }, label: {
                     ZStack {
                         RoundedRectangle(cornerRadius: 12)
-                            .foregroundColor(!selectedCategories.isEmpty ? .shortcutsZipPrimary : .shortcutsZipPrimary.opacity(0.13) )
+                            .fill(!selectedCategories.isEmpty ? Color.shortcutsZipPrimary : Color.shortcutsZipPrimary.opacity(0.13) )
                             .frame(maxWidth: .infinity, maxHeight: 52)
                         
                         Text(TextLiteral.done)
-                            .foregroundColor(!selectedCategories.isEmpty ? .textIcon : .textButtonDisable)
+                            .foregroundStyle(!selectedCategories.isEmpty ? Color.textIcon : Color.textButtonDisable)
                             .shortcutsZipBody1()
                     }
                 })
@@ -87,7 +87,7 @@ struct CategoryModalView: View {
                 Text(item.translateName())
                     .shortcutsZipBody2()
                     .tag(item.category)
-                    .foregroundColor(items.contains(item.category) ? Color.categoryPickText : Color.gray3)
+                    .foregroundStyle(items.contains(item.category) ? Color.categoryPickText : Color.gray3)
                     .frame(maxWidth: .infinity, minHeight: UIScreen.screenHeight * 0.7 * 0.08)
                     .background(
                         RoundedRectangle(cornerRadius: 12)

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/IconModalView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/IconModalView.swift
@@ -25,7 +25,7 @@ struct IconModalView: View {
                         self.isShowingIconModal = false
                     } label: {
                         Text(TextLiteral.close)
-                            .foregroundColor(.gray5)
+                            .foregroundStyle(Color.gray5)
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(.leading, 16)
                     }
@@ -53,7 +53,7 @@ struct IconModalView: View {
                         .font(.system(size: UIScreen.screenHeight > 700 ? 48 : 32))
                         .aspectRatio(contentMode: .fit)
                         .frame(height: UIScreen.screenHeight > 700 ? 136 : 84)
-                        .foregroundColor(.textIcon)
+                        .foregroundStyle(Color.textIcon)
                 }
                 .padding(.vertical, 24)
                 
@@ -62,7 +62,7 @@ struct IconModalView: View {
                     Text(TextLiteral.iconModalViewColor)
                         .shortcutsZipSubtitle()
                         .padding(.horizontal, 16)
-                        .foregroundColor(.gray4)
+                        .foregroundStyle(Color.gray4)
                         .frame(maxWidth: .infinity, alignment: .leading)
                     
                     LazyVGrid(columns: gridLayout, spacing: 12) {
@@ -76,7 +76,7 @@ struct IconModalView: View {
                     Text(TextLiteral.iconModalViewIcon)
                         .shortcutsZipSubtitle()
                         .padding(.horizontal, 16)
-                        .foregroundColor(.gray4)
+                        .foregroundStyle(Color.gray4)
                         .frame(maxWidth: .infinity, alignment: .leading)
                     
                     LazyVStack(pinnedViews: [.sectionHeaders]) {
@@ -84,7 +84,7 @@ struct IconModalView: View {
                             ForEach(viewModel.categories, id: \.self) { key in
                                 Text(key)
                                     .shortcutsZipBody2()
-                                    .foregroundColor(Color.gray4)
+                                    .foregroundStyle(Color.gray4)
                                     .frame(maxWidth: .infinity, alignment: .leading)
                                     .padding(.top, 12)
                                     .id(key)
@@ -110,7 +110,7 @@ struct IconModalView: View {
                                                 .shortcutsZipBody2()
                                                 .padding(.horizontal, 12)
                                                 .padding(.vertical, 6)
-                                                .foregroundColor(key == viewModel.selectedCategory ? Color.tagText : Color.gray4)
+                                                .foregroundStyle(key == viewModel.selectedCategory ? Color.tagText : Color.gray4)
                                                 .background(key == viewModel.selectedCategory ? Color.tagBackground : nil)
                                                 .clipShape(Capsule())
                                                 .overlay(
@@ -136,11 +136,11 @@ struct IconModalView: View {
                 } label: {
                     ZStack {
                         RoundedRectangle(cornerRadius: 12)
-                            .foregroundColor(!iconColor.isEmpty && !iconSymbol.isEmpty ? .shortcutsZipPrimary : .shortcutsZipPrimary.opacity(0.13))
+                            .foregroundStyle(!iconColor.isEmpty && !iconSymbol.isEmpty ? Color.shortcutsZipPrimary : Color.shortcutsZipPrimary.opacity(0.13))
                             .frame(maxWidth: .infinity, maxHeight: 52)
                         
                         Text(TextLiteral.done)
-                            .foregroundColor(!iconColor.isEmpty && !iconSymbol.isEmpty ? .textButton : .textButtonDisable)
+                            .foregroundStyle(!iconColor.isEmpty && !iconSymbol.isEmpty ? Color.textButton : Color.textButtonDisable)
                             .shortcutsZipBody1()
                     }
                 }
@@ -174,7 +174,7 @@ struct IconModalView: View {
                     if paletteColor == iconColor {
                         Image(systemName: "checkmark")
                             .smallIcon()
-                            .foregroundColor(.textIcon)
+                            .foregroundStyle(Color.textIcon)
                     }
                 }
             }
@@ -197,7 +197,7 @@ struct IconModalView: View {
                         .frame(width: 36, height: 36)
                     
                     Image(systemName: paletteSymbol)
-                        .foregroundColor(paletteSymbol == iconSymbol ? Color.gray5 : Color.gray3)
+                        .foregroundStyle(paletteSymbol == iconSymbol ? Color.gray5 : Color.gray3)
                 }
             }
         }

--- a/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/WriteShortcutViews/WriteShortcutView.swift
@@ -77,7 +77,7 @@ struct WriteShortcutView: View {
                     } label: {
                         Text(TextLiteral.cancel)
                             .shortcutsZipBody1()
-                            .foregroundColor(.gray5)
+                            .foregroundStyle(Color.gray5)
                     }
                 }
                 
@@ -89,7 +89,7 @@ struct WriteShortcutView: View {
                     }, label: {
                         Text(TextLiteral.upload)
                             .shortcutsZipHeadline()
-                            .foregroundColor(.shortcutsZipPrimary)
+                            .foregroundStyle(Color.shortcutsZipPrimary)
                             .opacity(viewModel.isUnavailableUploadButton() ? 0.3 : 1)
                     })
                     .disabled(viewModel.isUnavailableUploadButton())
@@ -111,7 +111,7 @@ struct WriteShortcutView: View {
                     .cornerRadius(12.35)
                 Image(systemName: !viewModel.shortcut.sfSymbol.isEmpty ? viewModel.shortcut.sfSymbol : "plus")
                     .mediumIcon()
-                    .foregroundColor(!viewModel.shortcut.sfSymbol.isEmpty ? .textIcon : .gray5)
+                    .foregroundStyle(!viewModel.shortcut.sfSymbol.isEmpty ? Color.textIcon : Color.gray5)
             }
             .frame(width: 84, height: 84)
         })
@@ -187,10 +187,10 @@ struct WriteShortcutView: View {
             HStack(alignment: .bottom) {
                 Text(TextLiteral.writeShortcutViewCategoryTitle)
                     .shortcutsZipHeadline()
-                    .foregroundColor(.gray5)
+                    .foregroundStyle(Color.gray5)
                 Text(TextLiteral.writeShortcutViewCategoryDescription)
                     .shortcutsZipFootnote()
-                    .foregroundColor(.gray3)
+                    .foregroundStyle(Color.gray3)
                 Spacer()
             }
             .padding(.horizontal, 16)
@@ -211,18 +211,18 @@ struct WriteShortcutView: View {
                     HStack {
                         if selectedCategories.isEmpty {
                             Text(TextLiteral.writeShortcutViewCategoryCell)
-                                .foregroundColor(.gray2)
+                                .foregroundStyle(Color.gray2)
                                 .shortcutsZipBody2()
                         } else {
                             Text(selectedCategories.map { Category(rawValue: $0)!.translateName() }.joined(separator: ", "))
-                                .foregroundColor(.gray4)
+                                .foregroundStyle(Color.gray4)
                                 .shortcutsZipBody2()
                                 .multilineTextAlignment(.leading)
                         }
                         Spacer()
                         Image(systemName: "chevron.forward")
                             .smallIcon()
-                            .foregroundColor(selectedCategories.isEmpty ? .gray2 : .gray4)
+                            .foregroundStyle(selectedCategories.isEmpty ? Color.gray2 : Color.gray4)
                     }
                     .padding(.all, 16)
                     .overlay(
@@ -249,14 +249,14 @@ struct WriteShortcutView: View {
             HStack(alignment: .bottom) {
                 Text(TextLiteral.writeShortcutViewRequiredAppsTitle)
                     .shortcutsZipHeadline()
-                    .foregroundColor(.gray5)
+                    .foregroundStyle(Color.gray5)
                 Text(TextLiteral.writeShortcutViewRequiredAppDescription)
                     .shortcutsZipFootnote()
-                    .foregroundColor(.gray3)
+                    .foregroundStyle(Color.gray3)
                 Spacer()
                 Image(systemName: "info.circle.fill")
                     .smallIcon()
-                    .foregroundColor(.gray4)
+                    .foregroundStyle(Color.gray4)
                     .onTapGesture {
                         viewModel.isInfoButtonTouched.toggle()
                     }
@@ -268,18 +268,18 @@ struct WriteShortcutView: View {
                 if viewModel.isInfoButtonTouched {
                     ZStack(alignment: .center) {
                         RoundedRectangle(cornerRadius: 12)
+                            .fill(Color.gray5)
                             .frame(maxWidth: .infinity, maxHeight: 68)
-                            .foregroundColor(.gray5)
                         HStack(alignment: .top) {
                             Text(TextLiteral.writeShortcutViewRequiredAppInformation)
                                 .shortcutsZipFootnote()
-                                .foregroundColor(.gray1)
+                                .foregroundStyle(Color.gray1)
                                 .multilineTextAlignment(.leading)
                             Spacer()
                             Image(systemName: "xmark")
                                 .smallIcon()
                                 .frame(width: 16, height: 16)
-                                .foregroundColor(.gray1)
+                                .foregroundStyle(Color.gray1)
                                 .onTapGesture {
                                     viewModel.isInfoButtonTouched = false
                                 }
@@ -319,7 +319,7 @@ struct WriteShortcutView: View {
                                     viewModel.isTextFieldShowing = false
                                 }
                             }
-                            .modifier(CellModifier(foregroundColor: Color.gray4, strokeColor: Color.shortcutsZipPrimary))
+                            .modifier(CellModifier(foregroundStyle: Color.gray4, strokeColor: Color.shortcutsZipPrimary))
                     }
                     
                     Button(action: {
@@ -332,7 +332,7 @@ struct WriteShortcutView: View {
                             Text(TextLiteral.writeShortcutViewRequiredAppCell)
                         }
                     })
-                    .modifier(CellModifier(foregroundColor: Color.gray2, strokeColor: Color.gray2))
+                    .modifier(CellModifier(foregroundStyle: Color.gray2, strokeColor: Color.gray2))
                 }
                 .padding(.leading, 16)
             }
@@ -355,20 +355,20 @@ struct WriteShortcutView: View {
                         .smallIcon()
                 })
             }
-            .modifier(CellModifier(foregroundColor: Color.gray4,
+            .modifier(CellModifier(foregroundStyle: Color.gray4,
                                    backgroundColor: Color.shortcutsZipBackground,
                                    strokeColor: Color.gray4))
         }
     }
     private struct CellModifier: ViewModifier {
-        @State var foregroundColor: Color
+        @State var foregroundStyle: Color
         @State var backgroundColor = Color.clear
         @State var strokeColor: Color
         
         public func body(content: Content) -> some View {
             content
                 .shortcutsZipBody2()
-                .foregroundColor(foregroundColor)
+                .foregroundStyle(foregroundStyle)
                 .frame(height: 52)
                 .padding(.horizontal)
                 .background(
@@ -391,7 +391,7 @@ struct WriteShortcutView: View {
                 }) {
                     Image(systemName: "xmark.circle.fill")
                         .smallIcon()
-                        .foregroundColor(.gray4)
+                        .foregroundStyle(Color.gray4)
                 }
             }
         }

--- a/HappyAnding/ShareExtension/ShareExtensionValidationTextField.swift
+++ b/HappyAnding/ShareExtension/ShareExtensionValidationTextField.swift
@@ -91,7 +91,7 @@ struct ShareExtensionValidationCheckTextField: View {
                 if let lengthLimit {
                     Text("\(content.count)/\(lengthLimit)")
                         .shortcutsZipBody2()
-                        .foregroundColor(.gray4)
+                        .foregroundStyle(Color.gray4)
                         .padding(.trailing, 16)
                 }
             }
@@ -109,7 +109,7 @@ struct ShareExtensionValidationCheckTextField: View {
             .background(
                 RoundedRectangle(cornerRadius: 12)
                     .strokeBorder(lineWidth: 1)
-                    .foregroundColor(strokeColor)
+                    .foregroundStyle(strokeColor)
             )
             .padding(.horizontal, 16)
             
@@ -117,7 +117,7 @@ struct ShareExtensionValidationCheckTextField: View {
                 if isExceeded {
                     Text(textFieldError.message)
                         .shortcutsZipBody2()
-                        .foregroundColor(.shortcutsZipError)
+                        .foregroundStyle(Color.shortcutsZipError)
                         .padding(.leading)
                 }
                 
@@ -134,13 +134,13 @@ struct ShareExtensionValidationCheckTextField: View {
         HStack {
             Text(title)
                 .shortcutsZipHeadline()
-                .foregroundColor(.gray5)
+                .foregroundStyle(Color.gray5)
                 .padding(.leading, 16)
             
             if textType.isOptional {
                 Text(TextLiteral.validationCheckTextFieldOption)
                     .shortcutsZipFootnote()
-                    .foregroundColor(.gray3)
+                    .foregroundStyle(Color.gray3)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -188,7 +188,7 @@ struct ShareExtensionValidationCheckTextField: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .multilineTextAlignment(.leading)
                     .padding(16)
-                    .foregroundColor(.gray2)
+                    .foregroundStyle(Color.gray2)
                     .allowsHitTesting(false)
             }
         }
@@ -213,19 +213,19 @@ struct ShareExtensionValidationCheckTextField: View {
             case .doneSuccess:
                 Image(systemName: "checkmark.circle.fill")
                     .smallIcon()
-                    .foregroundColor(.shortcutsZipSuccess)
+                    .foregroundStyle(Color.shortcutsZipSuccess)
                     .onTapGesture { }
             case .doneFail:
                 Image(systemName: "exclamationmark.circle.fill")
                     .smallIcon()
-                    .foregroundColor(.shortcutsZipError)
+                    .foregroundStyle(Color.shortcutsZipError)
             case .inProgressSuccess:
                 Button {
                     content.removeAll()
                 } label: {
                     Image(systemName: "xmark.circle.fill")
                         .smallIcon()
-                        .foregroundColor(.gray5)
+                        .foregroundStyle(Color.gray5)
                 }
             case .inProgressFail:
                 Button {
@@ -233,7 +233,7 @@ struct ShareExtensionValidationCheckTextField: View {
                 } label: {
                     Image(systemName: "xmark.circle.fill")
                         .smallIcon()
-                        .foregroundColor(.gray5)
+                        .foregroundStyle(Color.gray5)
                 }
             }
         }

--- a/HappyAnding/ShareExtension/ShareExtensionWriteShortcutView.swift
+++ b/HappyAnding/ShareExtension/ShareExtensionWriteShortcutView.swift
@@ -70,7 +70,7 @@ struct ShareExtensionWriteShortcutView: View {
                     Image(systemName: "plus")
                         .mediumIcon()
                         .frame(width: 84, height: 84)
-                        .foregroundColor(.gray5)
+                        .foregroundStyle(Color.gray5)
                 }
                 
             } else {
@@ -83,7 +83,7 @@ struct ShareExtensionWriteShortcutView: View {
                     Image(systemName: shareExtensionViewModel.shortcut.sfSymbol)
                         .mediumIcon()
                         .frame(width: 84, height: 84)
-                        .foregroundColor(.textIcon)
+                        .foregroundStyle(Color.textIcon)
                 }
             }
         })
@@ -163,10 +163,10 @@ struct ShareExtensionWriteShortcutView: View {
             HStack(alignment: .bottom) {
                 Text(TextLiteral.writeShortcutViewCategoryTitle)
                     .shortcutsZipHeadline()
-                    .foregroundColor(.gray5)
+                    .foregroundStyle(Color.gray5)
                 Text(TextLiteral.writeShortcutViewCategoryDescription)
                     .shortcutsZipFootnote()
-                    .foregroundColor(.gray3)
+                    .foregroundStyle(Color.gray3)
                 Spacer()
             }
             .padding(.horizontal, 16)
@@ -187,18 +187,18 @@ struct ShareExtensionWriteShortcutView: View {
                     HStack {
                         if selectedCategories.isEmpty {
                             Text(TextLiteral.writeShortcutViewCategoryCell)
-                                .foregroundColor(.gray2)
+                                .foregroundStyle(Color.gray2)
                                 .shortcutsZipBody2()
                         } else {
                             Text(selectedCategories.map { String( Category(rawValue: $0)!.translateName()) }.joined(separator: ", "))
-                                .foregroundColor(.gray4)
+                                .foregroundStyle(Color.gray4)
                                 .shortcutsZipBody2()
                                 .multilineTextAlignment(.leading)
                         }
                         Spacer()
                         Image(systemName: "chevron.forward")
                             .smallIcon()
-                            .foregroundColor(selectedCategories.isEmpty ? .gray2 : .gray4)
+                            .foregroundStyle(selectedCategories.isEmpty ? Color.gray2 : Color.gray4)
                     }
                     .padding(.all, 16)
                     .overlay(
@@ -224,15 +224,15 @@ struct ShareExtensionWriteShortcutView: View {
             HStack(alignment: .bottom) {
                 Text(TextLiteral.writeShortcutViewRequiredAppsTitle)
                     .shortcutsZipHeadline()
-                    .foregroundColor(.gray5)
+                    .foregroundStyle(Color.gray5)
                 Text(TextLiteral.writeShortcutViewRequiredAppDescription)
                     .shortcutsZipFootnote()
-                    .foregroundColor(.gray3)
+                    .foregroundStyle(Color.gray3)
                 Spacer()
                 Image(systemName: "info.circle.fill")
                     .smallIcon()
                     .frame(width: 20, height: 20)
-                    .foregroundColor(.gray4)
+                    .foregroundStyle(Color.gray4)
                     .onTapGesture {
                         isInfoButtonTouched.toggle()
                     }
@@ -244,17 +244,17 @@ struct ShareExtensionWriteShortcutView: View {
                 if isInfoButtonTouched {
                     ZStack(alignment: .center) {
                         RoundedRectangle(cornerRadius: 12)
+                            .fill(Color.gray5)
                             .frame(maxWidth: .infinity, maxHeight: 68)
-                            .foregroundColor(.gray5)
                         HStack(alignment: .top) {
                             Text(TextLiteral.writeShortcutViewRequiredAppInformation)
                                 .shortcutsZipFootnote()
-                                .foregroundColor(.gray1)
+                                .foregroundStyle(Color.gray1)
                                 .multilineTextAlignment(.leading)
                             Spacer()
                             Image(systemName: "xmark")
                                 .frame(width: 16, height: 16)
-                                .foregroundColor(.gray1)
+                                .foregroundStyle(Color.gray1)
                                 .onTapGesture {
                                     isInfoButtonTouched = false
                                 }
@@ -297,7 +297,7 @@ struct ShareExtensionWriteShortcutView: View {
                             .onSubmit {
                                 isTextFocused[4] = false
                             }
-                            .modifier(CellModifier(foregroundColor: Color.gray4, strokeColor: Color.shortcutsZipPrimary))
+                            .modifier(CellModifier(foregroundStyle: Color.gray4, strokeColor: Color.shortcutsZipPrimary))
                     }
                     
                     Button(action: {
@@ -310,7 +310,7 @@ struct ShareExtensionWriteShortcutView: View {
                             Text(TextLiteral.writeShortcutViewRequiredAppCell)
                         }
                     })
-                    .modifier(CellModifier(foregroundColor: Color.gray2, strokeColor: Color.gray2))
+                    .modifier(CellModifier(foregroundStyle: Color.gray2, strokeColor: Color.gray2))
                 }
                 .padding(.leading, 16)
             }
@@ -336,20 +336,20 @@ struct ShareExtensionWriteShortcutView: View {
                         .smallIcon()
                 })
             }
-            .modifier(CellModifier(foregroundColor: Color.gray4,
+            .modifier(CellModifier(foregroundStyle: Color.gray4,
                                    backgroundColor: Color.shortcutsZipBackground,
                                    strokeColor: Color.gray4))
         }
     }
     struct CellModifier: ViewModifier {
-        @State var foregroundColor: Color
+        @State var foregroundStyle: Color
         @State var backgroundColor = Color.clear
         @State var strokeColor: Color
         
         public func body(content: Content) -> some View {
             content
                 .shortcutsZipBody2()
-                .foregroundColor(foregroundColor)
+                .foregroundStyle(foregroundStyle)
                 .frame(height: 52)
                 .padding(.horizontal)
                 .background(
@@ -372,7 +372,7 @@ struct ShareExtensionWriteShortcutView: View {
                 }) {
                     Image(systemName: "xmark.circle.fill")
                         .smallIcon()
-                        .foregroundColor(.gray4)
+                        .foregroundStyle(Color.gray4)
                 }
             }
         }


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #494 

## 구현/변경 사항
- 이후 iOS 버전 대비 및 코드 일관성 향상을 위한 작업입니다.
- ShortcutsZip 내 모든 `foregroundColor(_:)` 코드를 `foregroundStyle(_:)` 코드로 변경했습니다.
- Shape에 사용된 `foregroundColor(_:)` 코드는 `fill(style:)` 코드로 변경했습니다.
