### PR TITLE
[Feat] 댓글 Copy 및 hypertext 추가

### DIFF
--- a/HappyAnding/HappyAnding/Views/ReadShortcutViews/ReadShortcutView.swift
+++ b/HappyAnding/HappyAnding/Views/ReadShortcutViews/ReadShortcutView.swift
@@ -217,7 +217,7 @@ extension ReadShortcutView {
                         .foregroundStyle(Color.gray4)
                 }
                 TextField(useWithoutSignIn ? TextLiteral.readShortcutViewCommentDescriptionBeforeLogin : TextLiteral.readShortcutViewCommentDescription, text: $viewModel.commentText, axis: .vertical)
-                    .keyboardType(.twitter)
+                    .keyboardType(.default)
                     .disabled(useWithoutSignIn)
                     .disableAutocorrection(true)
                     .textInputAutocapitalization(.never)
@@ -671,9 +671,11 @@ extension ReadShortcutView {
                         .padding(.bottom, 4)
                         
                         /// 댓글 내용
-                        Text(comment.contents)
+                        Text(.init(comment.contents))
+                            .textSelection(.enabled)
                             .shortcutsZipBody2()
                             .foregroundStyle(Color.gray5)
+                            .tint(.shortcutsZipPrimary)
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(.leading, 4)
                         


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #502 

## 구현/변경 사항
- 댓글에서도 hypertext 를 사용할 수 있게 .init을 추가했습니다.
- 해당 방법만 적용했을 때, 터치가 되지 않는 문제가 있어 .textSelection를 활성화했습니다.
- link의 색상은 .shortcutsZipPrimary로 적용했습니다.

## 스크린샷

|iPhone SE, 다크 모드|iPhone 15 pro, 라이트 모드|
|:---:|:---:|
| ![Simulator Screenshot - iPhone SE (3rd generation) - 2023-10-18 at 12 34 45](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-HappyAnding/assets/94854258/63768be9-0f92-4734-9feb-0ce832db0012) | ![Simulator Screenshot - iPhone 15 Pro - 2023-10-18 at 12 32 50](https://github.com/DeveloperAcademy-POSTECH/MacC-Team-HappyAnding/assets/94854258/eb821e2d-c32f-4fcd-b9ea-10d789f5eb37) |
